### PR TITLE
Moved environment reload to its own snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,11 @@ export PAI_HOME="$HOME"  # Your home directory
 # export PAI_DIR="$HOME/Projects/PAI/PAI_DIRECTORY"
 # export PAI_DIR="$HOME/Documents/PAI/PAI_DIRECTORY"
 # export PAI_DIR="/Users/yourname/PAI/PAI_DIRECTORY"
+```
 
+Now you must reload your shell configuration for the changes to take effect.
+
+```bash
 # Reload your shell configuration
 source ~/.zshrc  # or source ~/.bashrc
 ```


### PR DESCRIPTION
Before if you just cut and pasted the text in the snippet block into your ~/.zshrc or ~/.bashrc file the environment reload would cause the shell to keep reloading its environment. This way you can copy the two snippets separately.