### PR TITLE
fix: Resolve hook path errors and missing file references

### DIFF
--- a/hooks/session-start-hook.ts
+++ b/hooks/session-start-hook.ts
@@ -27,7 +27,7 @@ async function sendNotification(title: string, message: string, priority: string
 }
 
 async function testStopHook() {
-  const paiDir = process.env.PAI_DIR || `${process.env.HOME}/PAI/PAI_DIRECTORY`;
+  const paiDir = process.env.PAI_DIR || `${process.env.HOME}/PAI`;
   const stopHookPath = `${paiDir}/hooks/stop-hook.ts`;
 
   console.error('\n🔍 Testing stop-hook configuration...');

--- a/hooks/stop-hook.ts
+++ b/hooks/stop-hook.ts
@@ -147,7 +147,8 @@ interface VoicesConfig {
 // Load voices configuration
 let VOICE_CONFIG: VoicesConfig;
 try {
-  const voicesPath = join(homedir(), 'Library/Mobile Documents/com~apple~CloudDocs/Claude/voice-server/voices.json');
+  const paiDir = process.env.PAI_DIR || join(homedir(), 'PAI');
+  const voicesPath = join(paiDir, 'voice-server/voices.json');
   VOICE_CONFIG = JSON.parse(readFileSync(voicesPath, 'utf-8'));
 } catch (e) {
   // Fallback to hardcoded config if file doesn't exist

--- a/hooks/update-tab-titles.ts
+++ b/hooks/update-tab-titles.ts
@@ -77,19 +77,7 @@ async function main() {
       // Silently fail
     }
 
-    // Launch background process for better Haiku summary
-    try {
-      if (prompt && prompt.length > 3) {
-        const paiDir = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
-        Bun.spawn(['bun', `${paiDir}/hooks/update-tab-title.ts`, prompt], {
-          stdout: 'ignore',
-          stderr: 'ignore',
-          stdin: 'ignore'
-        });
-      }
-    } catch (e) {
-      // Silently fail
-    }
+    // Note: Background process for better summary removed (file was missing)
 
     process.exit(0);
   } catch (error) {


### PR DESCRIPTION
## Summary
Fixed three critical issues causing hook failures on startup:

1. **session-start-hook.ts**: Corrected PAI_DIR fallback path from `${HOME}/PAI/PAI_DIRECTORY` to `${HOME}/PAI`
2. **stop-hook.ts**: Replaced hardcoded iCloud path with dynamic `${PAI_DIR}/voice-server/voices.json` for better portability
3. **update-tab-titles.ts**: Removed reference to non-existent `update-tab-title.ts` file

## Changes
- All hooks now use consistent PAI_DIR environment variable resolution
- Voice server path is now portable across installations  
- Hooks handle missing voice server gracefully with fallback configs

## Testing
Verified all three hooks execute without errors:
- ✅ SessionStart hook sets initial tab title
- ✅ UserPromptSubmit hook updates tab title
- ✅ Stop hook sends notifications and updates final title

## Fixes
Resolves the following errors:
- SessionStart:startup hook error
- UserPromptSubmit hook error
- Stop hook error