### PR TITLE
feat(specfirst): Add SpecFirst skill for spec-driven development

### DIFF
--- a/.claude/commands/openspec-apply.md
+++ b/.claude/commands/openspec-apply.md
@@ -1,0 +1,99 @@
+# /openspec-apply
+
+Implement a change from an approved OpenSpec proposal.
+
+## When Invoked
+
+1. **Identify the change to implement:**
+   > Which change should I implement?
+   >
+   > List active changes with: `ls [openspec-path]/changes/`
+
+2. **Read the proposal and specs:**
+   - Read `proposal.md` for context
+   - Read `specs/*.md` for requirements (SHALL/MUST)
+   - Read `tasks.md` for implementation checklist
+
+3. **Confirm understanding:**
+   > Here's what I'll implement:
+   >
+   > **Requirements:**
+   > - [List each SHALL/MUST requirement]
+   >
+   > **Tasks:**
+   > - [List tasks from tasks.md]
+   >
+   > Ready to proceed?
+
+4. **Consult on test approach:**
+   > Which testing approach would you like to use?
+   >
+   > | Approach | Description | Best For |
+   > |----------|-------------|----------|
+   > | **Automated (TDD)** | pai-tooling pattern with test specs | Complex features, CI/CD, ongoing maintenance |
+   > | **Manual** | ACCEPTANCE_TESTS.md with human verification | Simple changes, quick iteration, exploration |
+   >
+   > Please choose: `automated` or `manual`
+
+5. **Write tests (based on chosen approach):**
+
+   **If Automated (TDD):**
+   - Each spec requirement → test case
+   - Tests SHOULD fail initially (no implementation yet)
+   - Map test IDs to requirements
+
+   ```
+   SPEC: Requirement: --name flag
+   TEST: TEST-CLI-014
+
+   SPEC: Scenario: CLI usage
+   TEST: command: ingest direct --name "X"
+   ```
+
+   **If Manual:**
+   - Create/update ACCEPTANCE_TESTS.md in the skill directory
+   - Each spec requirement → manual test case
+   - Define clear pass/fail criteria
+
+   ```markdown
+   ## Test: [Requirement Name]
+   **Precondition:** [Setup required]
+   **Steps:**
+   1. [Action to take]
+   2. [Action to take]
+   **Expected:** [What should happen]
+   **Pass Criteria:** [How to verify]
+   ```
+
+6. **Implement:**
+   - Follow tasks.md checklist
+   - Update tasks.md as you complete items
+   - Commit frequently
+   - **If Automated:** Run tests after each change
+   - **If Manual:** Verify against acceptance criteria
+
+7. **Validate:**
+   - **If Automated:** All tests pass, no regressions
+   - **If Manual:** Walk through ACCEPTANCE_TESTS.md with user
+   - Implementation matches spec requirements
+
+8. **Report completion:**
+   > Implementation complete for `[change-name]`:
+   >
+   > **Testing approach:** [Automated/Manual]
+   > **Tests:** [X passed / X manual tests verified]
+   > **Tasks:** X/X completed
+   >
+   > Ready to archive with `/openspec-archive`?
+
+## Spec → Test → Code Flow
+
+```
+openspec/changes/[name]/specs/    →    tests/[name].spec.ts    →    src/[impl].ts
+         (requirements)                  (validation)               (code)
+```
+
+## Reference
+
+- SpecFirst workflow: `.claude/skills/SpecFirst/workflows/Develop.md`
+- Test pyramid: `.claude/skills/SpecFirst/docs/TestPyramid.md`

--- a/.claude/commands/openspec-archive.md
+++ b/.claude/commands/openspec-archive.md
@@ -1,0 +1,77 @@
+# /openspec-archive
+
+Archive a completed change, merging spec deltas into current specs.
+
+## When Invoked
+
+1. **Identify the change to archive:**
+   > Which change should I archive?
+   >
+   > List active changes with: `ls [openspec-path]/changes/`
+
+2. **Verify completion:**
+   - [ ] All tasks in tasks.md are checked
+   - [ ] All tests pass
+   - [ ] Implementation matches spec requirements
+
+3. **Merge spec deltas into specs/:**
+
+   For each file in `changes/[name]/specs/`:
+   - **ADDED Requirements** → Append to `specs/[domain].md`
+   - **MODIFIED Requirements** → Replace in `specs/[domain].md`
+   - **REMOVED Requirements** → Delete from `specs/[domain].md`
+
+4. **Update CHANGELOG.md:**
+
+   ```markdown
+   ## [Unreleased]
+
+   ### Added
+   - [Feature name]: [description from proposal.md]
+
+   ### Changed
+   - [If any modifications]
+
+   ### Removed
+   - [If any removals]
+   ```
+
+5. **Move to archive:**
+
+   ```bash
+   # Create dated archive folder
+   mv openspec/changes/[name] openspec/archive/$(date +%Y-%m-%d)-[name]
+   ```
+
+6. **Report completion:**
+   > Archived `[change-name]`:
+   >
+   > **Specs updated:** [list files]
+   > **CHANGELOG:** Updated with [summary]
+   > **Archive location:** `openspec/archive/YYYY-MM-DD-[name]/`
+   >
+   > Ready for release workflow? See `/specfirst-release`
+
+## Archive Structure
+
+```
+openspec/archive/
+└── 2025-12-12-add-name-flag/    # ← Archived change
+    ├── proposal.md               # Preserved for audit
+    ├── tasks.md                  # Preserved for audit
+    └── specs/                    # Preserved for audit
+        └── ingest-direct.md
+```
+
+## What Gets Updated
+
+| Source | Destination |
+|--------|-------------|
+| `changes/[name]/specs/*.md` | `specs/*.md` (merged) |
+| `proposal.md` summary | `CHANGELOG.md` |
+| Entire change folder | `archive/YYYY-MM-DD-[name]/` |
+
+## Reference
+
+- CHANGELOG format: https://keepachangelog.com
+- Release workflow: `.claude/skills/SpecFirst/workflows/Release.md`

--- a/.claude/commands/openspec-proposal.md
+++ b/.claude/commands/openspec-proposal.md
@@ -1,0 +1,105 @@
+# /openspec-proposal
+
+Create an OpenSpec change proposal with proper directory structure.
+
+## When Invoked
+
+1. **Ask for the change name:**
+   > What feature or change are you proposing? (e.g., "add-name-flag")
+
+2. **Determine the scope:**
+   - Is this for a skill? Which one?
+   - Where should the openspec/ directory live?
+   - Default: `.claude/skills/[SkillName]/openspec/`
+
+3. **Create the change directory structure:**
+
+```bash
+mkdir -p [openspec-path]/changes/[change-name]/specs
+```
+
+4. **Create proposal.md:**
+
+```markdown
+# Proposal: [Change Name]
+
+## Summary
+[One sentence: what and why]
+
+## Impact
+- **Scope:** [skill/project affected]
+- **Breaking changes:** Yes/No
+- **Files affected:** [list or TBD]
+
+## Rationale
+[Why this change is needed]
+```
+
+5. **Create tasks.md:**
+
+```markdown
+# Tasks: [Change Name]
+
+## Implementation Checklist
+
+### 1. [Phase Name]
+- [ ] 1.1 [Task description]
+- [ ] 1.2 [Task description]
+
+### 2. Testing
+- [ ] 2.1 Write tests for requirements
+- [ ] 2.2 Verify tests fail initially
+
+### 3. Documentation
+- [ ] 3.1 Update CHANGELOG.md
+- [ ] 3.2 Update relevant docs
+```
+
+6. **Create spec delta file(s) in specs/:**
+
+```markdown
+# Delta for [Domain]
+
+## ADDED Requirements
+
+### Requirement: [Name]
+The system SHALL [behavior].
+
+#### Scenario: [Use case]
+- **GIVEN** [precondition]
+- **WHEN** [action]
+- **THEN** [expected outcome]
+
+## MODIFIED Requirements
+(none)
+
+## REMOVED Requirements
+(none)
+```
+
+7. **Present for review:**
+   > I've created the change proposal at `[path]`. Please review:
+   > - `proposal.md` - Summary and rationale
+   > - `specs/` - Requirements (SHALL/MUST)
+   > - `tasks.md` - Implementation checklist
+   >
+   > Does this match your intent? Ready to proceed with `/openspec-apply`?
+
+## Directory Structure Created
+
+```
+openspec/
+├── specs/                    # Current truth (existing specs)
+├── changes/
+│   └── [change-name]/        # ← Created by this command
+│       ├── proposal.md       # What and why
+│       ├── tasks.md          # Implementation checklist
+│       └── specs/            # Spec deltas
+│           └── [domain].md   # ADDED/MODIFIED/REMOVED
+└── archive/                  # Completed changes
+```
+
+## Reference
+
+- OpenSpec methodology: https://github.com/Fission-AI/OpenSpec
+- SpecFirst workflow: `.claude/skills/SpecFirst/workflows/Develop.md`

--- a/.claude/commands/specfirst-propose.md
+++ b/.claude/commands/specfirst-propose.md
@@ -1,0 +1,50 @@
+# /specfirst-propose
+
+Create a change proposal before implementing significant changes.
+
+## When Invoked
+
+1. **Ask for the change name and description:**
+   > What change are you proposing? (e.g., "Add --name flag to ingest direct")
+
+2. **Draft proposal using this format:**
+
+```markdown
+# Change Proposal: [Feature Name]
+
+## Summary
+[One sentence: what and why]
+
+## Requirements
+
+### Requirement: [Name]
+The system SHALL [behavior].
+
+#### Scenario: [Use case]
+- **GIVEN** [precondition]
+- **WHEN** [action]
+- **THEN** [expected outcome]
+
+## Impact
+- **Files affected:** [list]
+- **Breaking changes:** Yes/No
+
+## Tasks
+- [ ] Task 1
+- [ ] Task 2
+
+## Test Plan
+- [ ] TEST-XXX: [description]
+```
+
+3. **Present for review:**
+   > Here's my proposal. Does this match your intent?
+
+4. **After approval, proceed to implementation** following the spec-first pattern:
+   - Write tests first
+   - Implement to make tests pass
+   - Validate
+
+## Reference
+
+See `.claude/skills/SpecFirst/workflows/ProposeChange.md` for full workflow.

--- a/.claude/commands/specfirst-release.md
+++ b/.claude/commands/specfirst-release.md
@@ -1,0 +1,56 @@
+# /specfirst-release
+
+Prepare a release with strict discipline - file inventory, validation, and sanitization.
+
+## When Invoked
+
+1. **Ask for release details:**
+   > What are you releasing? (skill name, version)
+
+2. **Create RELEASE-vX.Y.Z.md with file inventory:**
+
+```markdown
+# [Skill] Release vX.Y.Z
+
+## Release Info
+| Field | Value |
+|-------|-------|
+| Version | vX.Y.Z |
+| Date | YYYY-MM-DD |
+| Status | In Progress |
+
+## File Inventory
+
+| # | File | Include | Reason |
+|---|------|---------|--------|
+| 1 | path/to/file | Yes/No | Why |
+
+## Pre-Release Checklist
+- [ ] File inventory complete
+- [ ] No PII or secrets
+- [ ] Tests pass
+- [ ] CHANGELOG.md updated
+```
+
+3. **Run pre-release checks:**
+   - Verify files match inventory
+   - Check for secrets/PII patterns
+   - Run test suite
+
+4. **Guide through git workflow:**
+   ```bash
+   # Create contrib branch
+   git checkout -b contrib-[skill]-vX.Y.Z upstream/main
+
+   # Cherry-pick from file inventory
+   git checkout [tag] -- [files from inventory]
+
+   # Verify and commit
+   git diff --name-only --cached
+   ```
+
+5. **Only proceed to push after explicit approval**
+
+## Reference
+
+See `.claude/skills/SpecFirst/workflows/Release.md` for full workflow.

--- a/.claude/commands/specfirst-validate.md
+++ b/.claude/commands/specfirst-validate.md
@@ -1,0 +1,50 @@
+# /specfirst-validate
+
+Run validation checks against specifications.
+
+## When Invoked
+
+1. **Ask what to validate:**
+   > What would you like to validate?
+   > - All tests
+   > - Specific test layer (unit/integration/cli/acceptance)
+   > - Spec compliance for a feature
+
+2. **Run appropriate tests:**
+
+   ```bash
+   # All tests
+   bun test all
+
+   # By layer
+   bun test unit
+   bun test integration
+   bun test cli
+   bun test acceptance
+
+   # Specific test
+   bun test --grep "TEST-CLI-014"
+   ```
+
+3. **Report results in table format:**
+
+   | Layer | Passed | Failed | Skipped |
+   |-------|--------|--------|---------|
+   | Unit | X | 0 | 0 |
+   | Integration | X | 0 | 0 |
+   | CLI | X | 0 | 0 |
+   | Acceptance | X | 0 | 0 |
+
+4. **For failures, show:**
+   - Which tests failed
+   - Error messages
+   - Suggested fixes
+
+5. **Check spec compliance:**
+   - Map requirements to test results
+   - Flag any requirements without tests
+   - Flag any failing tests
+
+## Reference
+
+See `.claude/skills/SpecFirst/workflows/ValidateSpec.md` for full workflow.

--- a/.claude/skills/SpecFirst/ACCEPTANCE_TESTS.md
+++ b/.claude/skills/SpecFirst/ACCEPTANCE_TESTS.md
@@ -1,0 +1,685 @@
+# SpecFirst Skill Acceptance Tests
+
+Manual skill-level tests to verify the SpecFirst skill works correctly before PR submission.
+
+## Prerequisites
+
+1. **Skill loaded:**
+   - Claude Code should have loaded `.claude/skills/SpecFirst/SKILL.md`
+   - Or manually: `read .claude/skills/SpecFirst/SKILL.md`
+
+2. **Slash commands available:**
+   - `/openspec-proposal`, `/openspec-apply`, `/openspec-archive`
+   - `/specfirst-propose`, `/specfirst-release`, `/specfirst-validate`
+
+---
+
+## Test 1: Skill Routing Recognition
+
+**Goal:** Verify Claude recognizes when to use SpecFirst.
+
+**User Query:**
+```
+"I want to develop a JIRA skill"
+```
+
+**Expected Claude Response (similar to):**
+```
+I'll help you develop a JIRA skill. Let me start with a spec proposal
+so we define requirements before implementation.
+
+/openspec-proposal
+
+What feature or change are you proposing?
+> jira-skill
+
+Which skill/project should contain the openspec directory?
+> .claude/skills/Jira
+```
+
+**Success Criteria:**
+- ✅ SpecFirst skill activated
+- ✅ Spec creation offered BEFORE implementation talk
+- ✅ `/openspec-proposal` invoked or offered
+- ✅ Asks clarifying questions about scope
+
+---
+
+## Test 1a: Full JIRA Skill Development (End-to-End Acceptance Test)
+
+**Goal:** Complete end-to-end test of SpecFirst workflow by developing a real skill.
+
+### Context Sources
+
+The spec should be derived from these external requirements:
+
+| Source | Path/URL | What to Extract |
+|--------|----------|-----------------|
+| **mcp-atlassian** | `[local-path]/mcp-atlassian/README.md` | Available Jira tools (`jira_search`, `jira_get_issue`, `jira_create_issue`, etc.) |
+| **PAI Principles** | PAI README or local notes on founding principles | Especially #5 (Spec/Test First), #8 (CLI as Interface), #9 (Goal→Code→CLI→Prompts→Agents) |
+| **OpenSpec Workflow** | OpenSpec documentation or local notes | Spec format, SHALL/MUST language, workflow phases |
+
+### Key PAI Principles to Apply
+
+```
+#5: Spec / Test / Evals First
+   "Define expected behavior before writing implementation.
+    If you can't specify it, you can't test it.
+    If you can't test it, you can't trust it."
+
+#8: CLI as Interface
+   "Every operation should be accessible via command line.
+    If there's no CLI command for it, you can't script it."
+
+#9: Goal → Code → CLI → Prompts → Agents
+   "The proper development pipeline for any new feature.
+    Each layer builds on the previous."
+```
+
+### Design Pattern: Two-Phase Workflow
+
+Reference `.claude/skills/Context/SKILL.md` for the two-phase pattern:
+
+```
+READ OPERATIONS (Search → Load):
+1. SEARCH: User asks query → Show discovery results (table) → WAIT
+2. LOAD: User selects items → Load full details into context
+
+WRITE OPERATIONS (Direct):
+- CREATE: Gather required fields → Execute
+- UPDATE: Identify target → Modify
+- DELETE: Confirm → Execute
+```
+
+The JIRA skill spec SHOULD follow this same pattern:
+- `jira search` returns summary → User selects → `jira load` loads details
+- `jira create` gathers fields → Executes directly
+- `jira update` identifies target → Modifies directly
+
+**Architecture (CLI-First per PAI Principles #4, #8, #9):**
+```
+bin/jira/jira.ts          ← TypeScript CLI (deterministic)
+    ↓
+.claude/skills/Jira/      ← Skill layer (prompts orchestrate CLI)
+    ↓
+CORE routing              ← Triggers skill for "jira", "issues", etc.
+```
+
+### User Query
+
+```
+I want to develop a JIRA skill for PAI following the deterministic-first architecture.
+
+Source Requirements From:
+- mcp-atlassian README — Reference for Jira API capabilities only (NOT as implementation dependency)
+- PAI founding principles documentation — PAI 13 Founding Principles
+
+Follow:
+- OpenSpec workflow documentation — Spec format and workflow phases
+
+Critical Principles (from PAI):
+1. #4 Code Before Prompts — Write TypeScript CLI to handle Jira operations; prompts orchestrate the CLI
+2. #3 Deterministic — CLI produces same output for same input, testable without AI
+3. #8 CLI as Interface — Every Jira operation accessible via `jira <command>`
+4. #9 Goal→Code→CLI→Prompts→Agents — Build layers in order
+5. Stack: Bun + TypeScript — NOT MCP, NOT Python
+
+Architecture Pattern (from Context skill):
+Goal: Jira integration
+    ↓
+Code: bin/jira/jira.ts (TypeScript CLI, direct Jira REST API)
+    ↓
+CLI: jira search|create|update|transition|comment
+    ↓
+Prompts: SKILL.md translates "create issue for this bug" → jira create ...
+    ↓
+Agents: Claude executes workflows
+
+NOT Using:
+- ❌ mcp-atlassian MCP server
+- ❌ Python or pip
+- ❌ External dependencies beyond Jira REST API
+```
+
+### Expected Claude Behavior
+
+**Phase 1: PROPOSAL (Claude MUST invoke `/openspec-proposal`)**
+
+```
+I'll help you develop a JIRA skill using SpecFirst methodology and CLI-first architecture.
+
+First, let me read the source documents to understand the requirements.
+[Reads mcp-atlassian README - for API reference only]
+[Reads PAI principles - especially #3, #4, #8, #9]
+[Reads OpenSpec workflow]
+
+Now I'll create a spec proposal.
+
+/openspec-proposal
+
+Feature name: jira-skill
+Skill/project: .claude/skills/Jira
+
+[Creates directory structure]
+.claude/skills/Jira/openspec/changes/jira-skill/
+├── proposal.md
+├── tasks.md
+└── specs/
+    └── jira-skill.md
+
+[Shows proposal.md content]
+# Proposal: JIRA Skill
+
+## Summary
+Create TypeScript CLI for Jira operations following PAI deterministic-first architecture.
+
+## Impact
+- **Scope:** New skill + CLI at bin/jira/
+- **Breaking changes:** No (new skill)
+- **Files affected:** .claude/skills/Jira/, bin/jira/, CORE routing
+
+## Rationale
+Per PAI Principle #4 (Code Before Prompts), we build a deterministic CLI first.
+Per Principle #9 (Goal→Code→CLI→Prompts→Agents), layers build in order.
+The CLI wraps Jira REST API directly - no MCP, no Python.
+
+[Shows specs/jira-skill.md content]
+# JIRA Skill Specification
+
+## Requirements
+
+### Requirement: Search Issues
+The system SHALL provide issue search via `jira search` CLI command.
+
+#### Scenario: Text Search
+- **GIVEN** user wants to find issues
+- **WHEN** user says "search jira for authentication"
+- **THEN** skill SHALL execute `jira search "authentication" --format index`
+
+### Requirement: Two-Phase Retrieval
+The system SHALL follow SEARCH → LOAD pattern (like Context skill).
+
+#### Scenario: Search then Load
+- **GIVEN** search returns results
+- **WHEN** results displayed
+- **THEN** system SHALL wait for user selection before loading details
+
+### Requirement: CLI Architecture
+The CLI SHALL be implemented as:
+- bin/jira/jira.ts — Main entry point
+- bin/jira/lib/*.ts — Core functions
+- Bun + TypeScript only
+- Direct Jira REST API calls
+...
+
+[Shows tasks.md content]
+# Tasks: JIRA Skill
+
+## 1. CLI Foundation (Code layer)
+- [ ] 1.1 Create bin/jira/jira.ts entry point
+- [ ] 1.2 Implement lib/api.ts for Jira REST
+- [ ] 1.3 Implement lib/config.ts for credentials
+- [ ] 1.4 Add search command
+- [ ] 1.5 Add create command
+
+## 2. Skill Layer (Prompts layer)
+- [ ] 2.1 Create .claude/skills/Jira/SKILL.md
+- [ ] 2.2 Create workflow files
+- [ ] 2.3 Update CORE routing
+
+## 3. Testing
+- [ ] 3.1 CLI unit tests (deterministic)
+- [ ] 3.2 Integration tests
+- [ ] 3.3 Validate against PAI principles
+
+---
+
+Here's my proposal. Please review:
+- Does this match your intent?
+- Any requirements to add or modify?
+- Ready to implement, or need changes?
+```
+
+**CRITICAL: Claude MUST WAIT here for user review. DO NOT auto-implement.**
+
+### Success Criteria
+
+**Fundamental (MUST pass):**
+- ✅ **Claude reads source documents BEFORE creating spec**
+- ✅ **Claude invokes `/openspec-proposal` (not manual file creation)**
+- ✅ **Claude WAITS for review (doesn't auto-implement)**
+- ✅ **Spec references PAI principles by number (#3, #4, #8, #9)**
+- ✅ **Uses SHALL/MUST language in requirements**
+
+**Structural:**
+- ✅ Directory created: `openspec/changes/[name]/`
+- ✅ proposal.md has Summary, Impact, Rationale
+- ✅ specs/*.md has Requirements with Scenarios
+- ✅ tasks.md has checklist format
+
+**Architecture (CLI-First):**
+- ✅ **Spec describes TypeScript CLI at bin/jira/**
+- ✅ **Spec does NOT use MCP server**
+- ✅ **Tasks order: CLI first (Code layer) → Skill second (Prompts layer)**
+- ✅ Tasks include CORE routing update
+- ✅ Tasks include deterministic CLI tests
+
+### Test Execution Notes
+
+**If Claude manually creates files without invoking `/openspec-proposal`:**
+- **TEST FAILS** - Claude should use the slash commands
+- This indicates the skill routing isn't working
+- Check: Is SpecFirst SKILL.md loaded?
+
+**If Claude starts implementing before spec review:**
+- **TEST FAILS** - Violates spec-first methodology
+- Claude should ask "Ready to implement?" and WAIT
+
+**If spec doesn't reference source documents:**
+- **TEST FAILS** - Requirements should be traceable
+- Spec should cite mcp-atlassian features and PAI principles
+
+### Clean State Reset
+
+Before running this test, ensure clean state:
+
+```bash
+# Remove any existing openspec changes
+rm -rf .claude/skills/Jira/openspec/changes/
+
+# Verify clean
+ls .claude/skills/Jira/openspec/ 2>/dev/null || echo "No openspec dir (OK)"
+```
+
+---
+
+## Test 2: /openspec-proposal Command
+
+**Goal:** Verify proposal command creates correct structure and waits for review.
+
+**User Query:**
+```
+/openspec-proposal
+```
+
+**When prompted:**
+```
+> Feature name: add-search
+> Skill/project: .claude/skills/Context
+```
+
+**Expected Claude Response:**
+```
+Created:
+.claude/skills/Context/openspec/changes/add-search/
+├── proposal.md
+├── tasks.md
+└── specs/
+    └── add-search.md
+
+--- proposal.md ---
+# Proposal: Add Search
+
+## Summary
+[Description of what add-search does]
+
+## Impact
+- **Scope:** Context skill
+- **Breaking changes:** No
+- **Files affected:** [list]
+
+## Rationale
+[Why this change is needed]
+
+--- specs/add-search.md ---
+# Add Search Specification
+
+## Requirements
+
+### Requirement: [Name]
+The system SHALL [behavior].
+
+#### Scenario: [Use case]
+- **WHEN** [trigger]
+- **THEN** [outcome]
+
+--- tasks.md ---
+# Tasks: Add Search
+
+- [ ] 1.1 [First task]
+- [ ] 1.2 [Second task]
+
+---
+
+Here's my proposal. Please review:
+- Does this match your intent?
+- Any requirements to add or modify?
+- Ready to implement, or need changes?
+```
+
+**Success Criteria:**
+- ✅ Directory structure created (verify with `ls`)
+- ✅ proposal.md has Summary, Impact, Rationale sections
+- ✅ tasks.md has checklist format `- [ ]`
+- ✅ specs/ has file with SHALL/MUST language
+- ✅ **Claude explicitly asks for review/approval**
+- ✅ **Claude waits (doesn't auto-implement)**
+
+---
+
+## Test 3: Iterative Review (Feedback Loop)
+
+**Goal:** Verify skill handles spec refinement iterations.
+
+**Setup:** Run Test 2 first to create proposal.
+
+**User Query:**
+```
+"Add a requirement for filtering by date"
+```
+
+**Expected Claude Response:**
+```
+I'll add that requirement to the spec.
+
+[Updates specs/add-search.md]
+
+### Requirement: Date Filter
+The system SHALL allow filtering search results by date range.
+
+#### Scenario: Filter by date
+- **WHEN** user provides --from and --to flags
+- **THEN** results SHALL only include items within date range
+
+[Updates tasks.md]
+
+- [ ] 2.1 Implement --from flag
+- [ ] 2.2 Implement --to flag
+- [ ] 2.3 Test date filtering
+
+Updated. Anything else to add, or ready to implement?
+```
+
+**Then User Says:**
+```
+"Also add pagination"
+```
+
+**Expected Claude Response:**
+```
+[Updates specs/add-search.md]
+
+### Requirement: Pagination
+The system SHALL paginate results when exceeding limit.
+
+[Updates tasks.md]
+
+- [ ] 3.1 Implement --limit flag
+- [ ] 3.2 Implement --page flag
+
+Updated. Anything else?
+```
+
+**Success Criteria:**
+- ✅ Claude updates spec (doesn't create new proposal)
+- ✅ Claude updates tasks.md too
+- ✅ Claude asks "anything else?" after each update
+- ✅ **Claude stays in review phase until user says "implement"**
+
+---
+
+## Test 4: /openspec-apply Command
+
+**Goal:** Verify apply command implements from specs with progress tracking.
+
+**Setup:** Run Tests 2-3 first, then user says "implement".
+
+**User Query:**
+```
+"Ready to implement"
+```
+
+**Expected Claude Response:**
+```
+/openspec-apply
+
+I'll implement based on these requirements:
+
+**From specs/add-search.md:**
+1. Search - Allow searching vault content
+2. Date Filter - Filter by date range
+3. Pagination - Paginate results
+
+**From tasks.md:**
+- 1.1 Create search function
+- 1.2 Add CLI command
+- 2.1-2.3 Date filtering
+- 3.1-3.2 Pagination
+
+Proceeding with implementation...
+
+✓ 1.1 Created search function in lib/search.ts
+✓ 1.2 Added `obs search` command
+Working on 2.1...
+✓ 2.1 Implemented --from flag
+✓ 2.2 Implemented --to flag
+✓ 2.3 Added date filter tests (3 tests pass)
+✓ 3.1 Implemented --limit flag
+✓ 3.2 Implemented --page flag
+
+All tasks complete. Running tests...
+All 8 tests pass.
+
+Implementation complete. Ready to archive?
+```
+
+**Success Criteria:**
+- ✅ Lists requirements from specs BEFORE implementing
+- ✅ Shows progress as tasks complete
+- ✅ Updates tasks.md (`- [x]` format)
+- ✅ Runs tests and reports results
+- ✅ **Asks "ready to archive?" when done**
+
+---
+
+## Test 5: /openspec-archive Command
+
+**Goal:** Verify archive command merges specs and updates CHANGELOG.
+
+**Setup:** Run Test 4 first (implementation complete, tests pass).
+
+**User Query:**
+```
+"Yes, archive it"
+```
+
+**Expected Claude Response:**
+```
+/openspec-archive
+
+Archiving add-search...
+
+1. Verifying completion:
+   ✓ All 7 tasks complete in tasks.md
+   ✓ All tests pass
+
+2. Merging specs:
+   ✓ changes/add-search/specs/add-search.md → openspec/specs/add-search.md
+
+3. Updating CHANGELOG.md:
+
+   ## [Unreleased]
+
+   ### Added
+   - Search functionality for vault content
+   - Date range filtering (--from, --to flags)
+   - Pagination support (--limit, --page flags)
+
+4. Moving to archive:
+   ✓ openspec/changes/add-search/ → openspec/archive/2025-12-12-add-search/
+
+Archived successfully!
+- Specs merged to openspec/specs/
+- CHANGELOG.md updated
+- Original proposal preserved in archive/
+
+Ready for next feature? Or proceed to /specfirst-release?
+```
+
+**Verify with:**
+```bash
+ls .claude/skills/Context/openspec/specs/       # Should have add-search.md
+ls .claude/skills/Context/openspec/changes/     # Should be empty
+ls .claude/skills/Context/openspec/archive/     # Should have dated folder
+cat .claude/skills/Context/CHANGELOG.md         # Should have new entry
+```
+
+**Success Criteria:**
+- ✅ Specs merged to `openspec/specs/`
+- ✅ CHANGELOG.md has new entry under [Unreleased]
+- ✅ Change folder moved to `archive/YYYY-MM-DD-name/`
+- ✅ Archive contains original proposal.md and tasks.md
+- ✅ `changes/` folder is now empty
+
+---
+
+## Test 6: /specfirst-release Command
+
+**Goal:** Verify release command creates file inventory.
+
+**User Query:**
+```
+/specfirst-release
+```
+
+**Expected Behavior:**
+- Claude creates RELEASE-vX.Y.Z.md (or uses template)
+- Claude lists files to include
+- Claude lists files to exclude
+- Claude requires human approval gates
+
+**Success Criteria:**
+- ✅ File inventory created
+- ✅ Include list populated
+- ✅ Exclude list populated
+- ✅ Human approval required at each gate
+
+---
+
+## Test 7: Two-Phase Enforcement (Spec Before Code)
+
+**Goal:** Verify skill enforces spec-first, not code-first.
+
+**User Query:**
+```
+"Just implement a quick --verbose flag"
+```
+
+**Expected Behavior:**
+- Claude should redirect to spec creation
+- Claude should NOT jump straight to coding
+- Claude should explain why specs first
+
+**Success Criteria:**
+- ✅ Implementation deferred
+- ✅ Spec creation suggested
+- ✅ Rationale provided ("If you can't specify it...")
+
+---
+
+## Test 8: Universal Applicability
+
+**Goal:** Verify skill works for non-PAI projects.
+
+**User Query:**
+```
+"I'm working on a non-PAI project. How do I use SpecFirst?"
+```
+
+**Expected Behavior:**
+- Claude explains standard development path
+- Claude does NOT require contrib branch
+- Claude offers simplified workflow
+
+**Success Criteria:**
+- ✅ Standard path explained
+- ✅ PAI-specific steps marked optional
+- ✅ Core spec-first flow preserved
+
+---
+
+## Test 9: Cross-Reference Validation
+
+**Goal:** Verify documentation links work.
+
+**Manual Checks:**
+1. SKILL.md references all workflow files - they exist
+2. Examples in SKILL.md use actual commands
+3. Template references in docs point to real files
+
+**Success Criteria:**
+- ✅ All `workflows/*.md` files exist
+- ✅ All `templates/*.md` files exist
+- ✅ All `docs/*.md` files exist
+- ✅ Commands referenced in SKILL.md match actual commands
+
+---
+
+## Test 10: Dogfooding Verification
+
+**Goal:** Verify SpecFirst uses itself.
+
+**Manual Checks:**
+1. `openspec/` directory exists in SpecFirst skill
+2. Specs exist for SpecFirst requirements
+3. CHANGELOG.md documents releases
+
+**Commands:**
+```bash
+ls .claude/skills/SpecFirst/openspec/
+ls .claude/skills/SpecFirst/openspec/changes/
+cat .claude/skills/SpecFirst/CHANGELOG.md
+```
+
+**Success Criteria:**
+- ✅ openspec/ structure exists
+- ✅ Specs define SpecFirst requirements
+- ✅ CHANGELOG tracks changes
+- ✅ Skill follows its own methodology
+
+---
+
+## Quick Test Checklist
+
+Run these 5 essential tests before PR:
+
+- [ ] **Test 1:** Skill routing recognized
+- [ ] **Test 2:** /openspec-proposal creates structure
+- [ ] **Test 5:** /openspec-archive merges correctly
+- [ ] **Test 7:** Spec-before-code enforced
+- [ ] **Test 10:** Dogfooding in place
+
+---
+
+## Automated Validation (Future)
+
+These tests could be automated:
+
+| Test | Automation |
+|------|------------|
+| File existence | `ls` + check exit code |
+| Command availability | Check `.claude/commands/*.md` |
+| Cross-references | Parse markdown links, verify targets |
+| Structure creation | Run command, check directory |
+| CHANGELOG format | Regex validation |
+
+For now, run manually in Claude Code before PR.
+
+---
+
+## Notes
+
+- These are **manual acceptance tests** - run them in Claude Code
+- Focus on **skill behavior** (does Claude understand the methodology)
+- If any test fails, document the issue before PR submission
+- All essential tests should pass before creating PR

--- a/.claude/skills/SpecFirst/CHANGELOG.md
+++ b/.claude/skills/SpecFirst/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to the SpecFirst skill will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v1.0.0] - 2025-12-12
+
+Initial release of SpecFirst - spec-driven development methodology for any software project.
+
+### Added
+
+**Core Skill:**
+- `SKILL.md` - Workflow routing and quick reference
+- Flexible spec tooling guidance with strict release discipline
+
+**Workflows:**
+- `Develop.md` - Branch setup for standard and PAI contribution flows
+- `ProposeChange.md` - Change proposal process
+- `Release.md` - Versioning, tagging, release discipline with human approval gates
+- `ValidateSpec.md` - Test pyramid and validation
+
+**Templates:**
+- `RELEASE-FRAMEWORK.md` - Release methodology template (copy to your skill)
+- `RELEASE-vX.Y.Z.md` - Per-release plan template with file inventory
+- `Requirement.md` - SHALL/MUST requirement format
+
+**Documentation:**
+- `TestPyramid.md` - 4-layer test approach
+- `ToolingArchitecture.md` - Framework vs specs separation
+- `Approaches.md` - OpenSpec vs lightweight comparison
+
+**Slash Commands:**
+- `/specfirst-propose` - Create change proposal
+- `/specfirst-release` - Prepare release with file inventory
+- `/specfirst-validate` - Run validation checks
+
+### Architecture
+
+- Works for any project: PAI skills, CLI tools, web apps, libraries
+- Flexible on spec tooling (OpenSpec, markdown, custom)
+- Strict on release process (file inventory, validation gates, manual review)
+- Complementary with OpenSpec methodology

--- a/.claude/skills/SpecFirst/README.md
+++ b/.claude/skills/SpecFirst/README.md
@@ -1,0 +1,173 @@
+# SpecFirst Skill
+
+Spec-driven development methodology for Claude Code. Works for any software project.
+
+**"If you can't specify it, you can't test it. If you can't test it, you can't trust it."**
+
+## Quick Start
+
+```
+/openspec-proposal     ← Define requirements first
+/openspec-apply        ← Implement from specs
+/openspec-archive      ← Merge specs, update CHANGELOG
+/specfirst-release     ← Prepare for contribution
+```
+
+## Setup
+
+### 1. Install Skill Files
+
+The skill should be at `.claude/skills/SpecFirst/`.
+
+Required files:
+```
+.claude/skills/SpecFirst/
+├── SKILL.md              ← Main skill file
+├── CHANGELOG.md          ← Release history
+├── README.md             ← This file
+├── ACCEPTANCE_TESTS.md   ← Manual test checklist
+├── workflows/
+│   ├── Develop.md
+│   ├── Release.md
+│   ├── ProposeChange.md
+│   └── ValidateSpec.md
+├── templates/
+│   ├── RELEASE-FRAMEWORK.md
+│   ├── RELEASE-vX.Y.Z.md
+│   └── Requirement.md
+├── docs/
+│   ├── TestPyramid.md
+│   ├── ToolingArchitecture.md
+│   └── Approaches.md
+└── openspec/             ← Skill's own specs (dogfooding)
+    ├── specs/
+    ├── changes/
+    └── archive/
+```
+
+### 2. Install Slash Commands
+
+Copy command files to `.claude/commands/`:
+
+```bash
+# These should already be in place:
+ls .claude/commands/openspec-*.md
+ls .claude/commands/specfirst-*.md
+```
+
+Required commands:
+- `openspec-proposal.md`
+- `openspec-apply.md`
+- `openspec-archive.md`
+- `specfirst-propose.md`
+- `specfirst-release.md`
+- `specfirst-validate.md`
+
+### 3. Add CORE Skill Routing (Optional)
+
+To have CORE automatically route to SpecFirst, add to `.claude/skills/CORE/SKILL.md`:
+
+```markdown
+## Workflow Routing
+
+...
+
+**When user mentions specs, testing, release, or development workflow:**
+Examples: "develop a feature", "prepare release", "spec first", "change proposal"
+→ **READ:** .claude/skills/SpecFirst/SKILL.md
+→ **FOLLOW:** Spec-first development workflow
+```
+
+**Note:** This step is optional. You can also invoke SpecFirst directly by reading the skill:
+```
+read .claude/skills/SpecFirst/SKILL.md
+```
+
+### 4. Install OpenSpec CLI (Optional)
+
+For interactive spec management:
+
+```bash
+npm install -g @fission-ai/openspec@latest
+
+# Initialize in your project
+openspec init
+
+# View active changes
+openspec list
+```
+
+## Usage
+
+### Starting a New Feature
+
+```
+User: "I want to add a --verbose flag"
+
+Claude: Let me create a spec proposal first.
+        /openspec-proposal
+
+        [Creates spec files, waits for review]
+
+User: "Looks good, implement it"
+
+Claude: /openspec-apply
+        [Writes tests, implements, runs tests]
+
+User: "Tests pass, archive it"
+
+Claude: /openspec-archive
+        [Merges specs, updates CHANGELOG]
+```
+
+### Preparing a Release
+
+```
+User: "Prepare v1.0.0 for contribution"
+
+Claude: /specfirst-release
+        [Creates file inventory, walks through checklist]
+```
+
+## Testing
+
+Before PR submission, run the acceptance tests:
+
+```
+read .claude/skills/SpecFirst/ACCEPTANCE_TESTS.md
+```
+
+Quick test checklist:
+- [ ] Skill routing recognized (Test 1)
+- [ ] `/openspec-proposal` creates structure (Test 2)
+- [ ] `/openspec-archive` merges correctly (Test 5)
+- [ ] Spec-before-code enforced (Test 7)
+- [ ] Dogfooding in place (Test 10)
+
+## Architecture
+
+```
+SpecFirst (Process Discipline)    +    OpenSpec (Spec Format)
+├── Release workflow                   ├── specs/ directory
+├── File inventory                     ├── changes/ proposals
+├── Pre-release checklist              ├── SHALL/MUST language
+└── Sanitization gates                 └── Archive audit trail
+```
+
+**They're complementary:** OpenSpec for tracking specs, SpecFirst for releasing safely.
+
+## Files Overview
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Entry point, workflow routing, command reference |
+| `workflows/Develop.md` | Branch setup, spec-first development |
+| `workflows/Release.md` | Versioning, tagging, contribution |
+| `templates/RELEASE-vX.Y.Z.md` | Per-release plan template |
+| `ACCEPTANCE_TESTS.md` | Manual test checklist |
+
+## Related
+
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec) - Spec methodology
+- [PAI Discussion #187](https://github.com/danielmiessler/Personal_AI_Infrastructure/discussions/187) - Community input
+- [Keep a Changelog](https://keepachangelog.com) - CHANGELOG format

--- a/.claude/skills/SpecFirst/SKILL.md
+++ b/.claude/skills/SpecFirst/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: SpecFirst
+description: |
+  Spec-driven development methodology for ANY software project.
+  USE WHEN developing features, fixing bugs, creating skills, or preparing releases.
+  USE WHEN user mentions specs, testing, release process, change proposals, or deployment.
+  Provides flexible spec tooling guidance but STRICT release discipline.
+---
+
+# SpecFirst
+
+**"If you can't specify it, you can't test it. If you can't test it, you can't trust it."**
+
+Works for any project: PAI skills, CLI tools, web apps, libraries, or any codebase.
+
+## Core Philosophy
+
+- **Flexible on spec tooling**: Choose OpenSpec, lightweight markdown, or custom
+- **Strict on release process**: File inventory, validation gates, manual review
+
+AI tools make development easy—and make it easy to leak data or create bloated PRs. The release process must be more controlled than development.
+
+### SpecFirst vs OpenSpec
+
+| SpecFirst | OpenSpec |
+|-----------|----------|
+| **Process discipline** | **Spec format** |
+| Release workflow, git ops | Requirement structure |
+| File inventory | Change proposals |
+| Pre-release checklist | Spec deltas, archive |
+
+**They're complementary:** OpenSpec for tracking specs, SpecFirst for releasing safely.
+
+---
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **Develop** | "develop feature", "create skill", "set up branches", "start development" | `workflows/Develop.md` |
+| **ProposeChange** | "propose change", "new feature", "change proposal" | `workflows/ProposeChange.md` |
+| **Release** | "prepare release", "deploy", "create PR", "contribute upstream" | `workflows/Release.md` |
+| **ValidateSpec** | "validate specs", "check compliance", "run tests" | `workflows/ValidateSpec.md` |
+
+---
+
+## Slash Commands
+
+### OpenSpec Commands (Spec Workflow)
+
+| Command | Purpose | When |
+|---------|---------|------|
+| `/openspec-proposal` | Create change folder with specs | Starting new feature |
+| `/openspec-apply` | Implement from approved specs | After spec review |
+| `/openspec-archive` | Merge specs, update CHANGELOG | After tests pass |
+
+### SpecFirst Commands (Release Workflow)
+
+| Command | Purpose | When |
+|---------|---------|------|
+| `/specfirst-propose` | Quick change proposal | Simple changes |
+| `/specfirst-release` | Prepare release with file inventory | Before tagging |
+| `/specfirst-validate` | Run validation checks | Before release |
+
+---
+
+## Command Reference
+
+### /openspec-proposal
+
+**Creates a change proposal with spec structure.**
+
+**Usage:**
+```
+/openspec-proposal
+> What feature or change? add-name-flag
+> Which skill/project? Context
+```
+
+**Creates:**
+```
+openspec/changes/add-name-flag/
+├── proposal.md     ← Summary, impact, rationale
+├── tasks.md        ← Implementation checklist
+└── specs/
+    └── feature.md  ← SHALL/MUST requirements
+```
+
+**Output:** Presents files for human review. Waits for approval before proceeding.
+
+---
+
+### /openspec-apply
+
+**Implements from approved specs.**
+
+**Usage:**
+```
+/openspec-apply
+> Which change? add-name-flag
+```
+
+**Process:**
+1. Reads `proposal.md` and `specs/*.md`
+2. Lists requirements to implement
+3. Writes tests for each requirement (tests fail initially)
+4. Implements code to make tests pass
+5. Updates `tasks.md` as items complete
+
+**Output:** Reports test results and task completion.
+
+---
+
+### /openspec-archive
+
+**Merges completed specs and updates CHANGELOG.**
+
+**Usage:**
+```
+/openspec-archive
+> Which change? add-name-flag
+```
+
+**Process:**
+1. Verifies all tasks complete
+2. Merges spec deltas → `openspec/specs/`
+3. Updates `CHANGELOG.md` (adds entry)
+4. Moves folder → `openspec/archive/YYYY-MM-DD-add-name-flag/`
+
+**Output:** Confirms merge, shows CHANGELOG entry.
+
+---
+
+### /specfirst-release
+
+**Prepares release with file inventory.**
+
+**Usage:**
+```
+/specfirst-release
+> Version? v1.0.0
+> Skill? SpecFirst
+```
+
+**Creates:** `RELEASE-v1.0.0.md` with:
+- File inventory (include list)
+- Exclude list (what NOT to commit)
+- Pre-release checklist
+- Human approval gates
+
+**Output:** Walks through release workflow step by step.
+
+---
+
+### /specfirst-validate
+
+**Runs validation checks.**
+
+**Usage:**
+```
+/specfirst-validate
+> What to validate? specs
+```
+
+**Checks:**
+- Spec format (SHALL/MUST language)
+- File existence (all referenced files exist)
+- Cross-references (links work)
+- Test coverage (specs have tests)
+
+**Output:** Validation report with pass/fail per check.
+
+---
+
+## Quick Reference
+
+### The Spec-First Flow (with Commands)
+
+```
+/openspec-proposal          ← 1. SPECIFY: Define requirements (SHALL/MUST)
+        │
+        ▼  [Human reviews specs]
+        │
+/openspec-apply             ← 2. TEST: Write tests that validate spec
+        │                     3. IMPLEMENT: Code that makes tests pass
+        ▼
+/openspec-archive           ← 4. ARCHIVE: Merge specs, update CHANGELOG
+        │
+        ▼
+/specfirst-release          ← 5. RELEASE: File inventory, validation, PR
+```
+
+### CLI Tool (Optional)
+
+```bash
+# Install OpenSpec CLI globally
+npm install -g @fission-ai/openspec@latest
+
+# Initialize in project
+openspec init
+
+# List active changes
+openspec list
+
+# Interactive dashboard
+openspec view
+
+# Validate spec format
+openspec validate <change-name>
+
+# Archive completed change
+openspec archive <change-name>
+```
+
+### Release Discipline (Strict)
+
+Before any PR:
+- [ ] Explicit file inventory (what's included/excluded)
+- [ ] Change proposal reviewed
+- [ ] Pre-release checklist passed
+- [ ] Sanitization check (no PII, no secrets)
+
+---
+
+## Extended Context
+
+**For detailed workflows, read:**
+- `workflows/Develop.md` - Branch setup, standard & PAI contribution flows
+- `workflows/ProposeChange.md` - Change proposal process
+- `workflows/Release.md` - Versioning, tagging, release discipline
+- `workflows/ValidateSpec.md` - Test pyramid, validation
+
+**Templates:**
+- `templates/RELEASE-FRAMEWORK.md` - Release methodology (copy to your skill)
+- `templates/RELEASE-vX.Y.Z.md` - Release plan template (per release)
+- `templates/Requirement.md` - SHALL/MUST format
+
+**Reference docs:**
+- `docs/WorkedExample.md` - Full walkthrough: developing a JIRA skill
+- `docs/TestPyramid.md` - 4-layer test approach
+- `docs/ToolingArchitecture.md` - Framework vs specs separation
+- `docs/Approaches.md` - OpenSpec vs lightweight comparison
+
+---
+
+## Examples
+
+**Example 1: Starting development (with specs)**
+```
+User: "I want to develop a new feature"
+
+1. /openspec-proposal
+   → Creates openspec/changes/my-feature/
+   → Defines requirements (SHALL/MUST)
+   → Human reviews specs
+
+2. /openspec-apply
+   → Writes tests for requirements
+   → Implements code
+   → Tests pass
+
+3. /openspec-archive
+   → Merges specs to openspec/specs/
+   → Updates CHANGELOG.md
+```
+
+**Example 2: Preparing a PAI contribution**
+```
+User: "Prepare the Context skill for upstream contribution"
+
+1. /specfirst-release
+   → Create RELEASE-v1.0.0.md with file inventory
+   → Run tests with --release v1.0.0
+   → Complete checklist
+   → Tag v1.0.0 (marks tested code)
+   → Cherry-pick from tag to contrib branch
+   → Push to fork for PR
+```
+
+**Example 3: Adding a feature (full flow)**
+```
+User: "Add --name flag to ingest direct"
+
+1. /openspec-proposal
+   → Creates openspec/changes/add-name-flag/
+   → Spec: "The system SHALL allow filename override via --name"
+   → Human approves spec
+
+2. /openspec-apply
+   → Write test: TEST-CLI-014
+   → Implement in process.ts
+   → Tests pass
+
+3. /openspec-archive
+   → Merges spec delta to openspec/specs/ingest-direct.md
+   → Updates CHANGELOG.md
+
+4. /specfirst-release (when ready for contribution)
+```
+
+---
+
+## Related Documents
+
+- **Claude Code Architecture**: Understanding skills vs agents
+- **PAI Principles**: Foundation for spec-first thinking
+- **Discussion #187**: Community input on methodology

--- a/.claude/skills/SpecFirst/docs/Approaches.md
+++ b/.claude/skills/SpecFirst/docs/Approaches.md
@@ -1,0 +1,185 @@
+# Spec-Driven Approaches
+
+**Comparing lightweight vs full spec tooling options.**
+
+---
+
+## Overview
+
+SpecFirst is **process-agnostic** on spec tooling. Choose the approach that fits your needs:
+
+| Approach | Best For | Tooling |
+|----------|----------|---------|
+| **Lightweight** | Solo dev, simple changes | Markdown in conversation |
+| **OpenSpec** | Teams, audit trails | `openspec` CLI |
+| **Custom** | Specific workflows | Your own structure |
+
+---
+
+## Lightweight (Default)
+
+No special tooling—just disciplined markdown.
+
+### How It Works
+
+1. Describe proposal in conversation using SHALL/MUST language
+2. List tasks and test plan
+3. Implement
+4. Validate
+
+### Example
+
+```
+User: "Add --name flag to ingest direct"
+
+AI: Here's my proposal:
+
+### Requirement: Filename Override
+The system SHALL allow filename override via --name flag.
+
+#### Scenario: With --name
+- WHEN user provides `--name "Custom"`
+- THEN filename uses "Custom"
+
+Tasks:
+- [ ] Add name to SourceMetadata
+- [ ] Handle in metadata extraction
+- [ ] Use in generateFilename()
+
+Test: TEST-CLI-014
+
+Does this match your intent?
+```
+
+### Pros/Cons
+
+| Pros | Cons |
+|------|------|
+| No setup | No persistent specs |
+| Fast for small changes | No audit trail |
+| Conversational | Hard to track across sessions |
+
+---
+
+## OpenSpec
+
+Full spec management with CLI tooling.
+
+### Structure
+
+```
+openspec/
+├── specs/                    # Current source of truth
+│   ├── cli.md               # CLI specification
+│   └── api.md               # API specification
+├── changes/                  # Proposed modifications
+│   └── feature-name/
+│       ├── proposal.md      # What and why
+│       ├── tasks.md         # Implementation checklist
+│       └── specs/           # Spec deltas (ADDED/MODIFIED/REMOVED)
+├── archive/                  # Completed changes (audit trail)
+├── project.md               # Project conventions
+└── AGENTS.md                # AI workflow instructions
+```
+
+### Workflow
+
+```bash
+# Initialize
+openspec init
+
+# Create proposal
+mkdir -p openspec/changes/my-feature
+# Create proposal.md, tasks.md, specs/
+
+# Validate
+openspec validate my-feature
+
+# After implementation
+openspec archive my-feature
+```
+
+### Pros/Cons
+
+| Pros | Cons |
+|------|------|
+| Persistent specs | Setup overhead |
+| Audit trail (archive/) | More files to manage |
+| Team collaboration | Overkill for simple changes |
+| Spec deltas track evolution | |
+
+### When to Use
+
+- Team projects
+- Compliance/audit requirements
+- Complex, long-running features
+- Public contributions
+
+---
+
+## Hybrid Approach
+
+Use lightweight for daily work, OpenSpec for releases:
+
+```
+Daily Development          Release Preparation
+─────────────────          ───────────────────
+Conversational specs   →   RELEASE-vX.Y.Z.md
+Quick iteration        →   File inventory
+Informal tracking      →   Pre-release checklist
+                       →   Audit trail
+```
+
+**This is the SpecFirst default:** flexible during development, strict at release.
+
+---
+
+## Choosing an Approach
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    DECISION TREE                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Is this a team project?                                    │
+│  ├── YES → OpenSpec (collaboration, audit trail)            │
+│  └── NO                                                     │
+│      │                                                      │
+│      Is there compliance/audit requirement?                 │
+│      ├── YES → OpenSpec                                     │
+│      └── NO                                                 │
+│          │                                                  │
+│          Is change complex (>5 files, multi-week)?          │
+│          ├── YES → OpenSpec or detailed proposal.md         │
+│          └── NO → Lightweight (conversational)              │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## SpecFirst + OpenSpec
+
+They're **complementary**, not alternatives:
+
+| SpecFirst | OpenSpec |
+|-----------|----------|
+| **Process discipline** | **Spec format** |
+| Branch strategy | Requirement structure |
+| Release workflow | Change proposals |
+| File inventory | Spec deltas |
+| Pre-release checklist | Archive audit trail |
+| Git operations | SHALL/MUST language |
+
+**Use together:**
+- OpenSpec to define and track specifications
+- SpecFirst to release changes safely
+
+---
+
+## Related
+
+- **ProposeChange.md** - Proposal workflow
+- **Release.md** - Release discipline
+- **Requirement.md** - Template for specs
+- **OpenSpec GitHub**: https://github.com/Fission-AI/OpenSpec

--- a/.claude/skills/SpecFirst/docs/TestPyramid.md
+++ b/.claude/skills/SpecFirst/docs/TestPyramid.md
@@ -1,0 +1,239 @@
+# Test Pyramid
+
+**The 4-layer testing approach for PAI skills and tools.**
+
+---
+
+## Overview
+
+```
+                    ┌─────────────────┐
+                    │   ACCEPTANCE    │  Layer 4: User outcomes
+                    │   (E2E tests)   │  Slow, few tests
+                ┌───┴─────────────────┴───┐
+                │         CLI            │  Layer 3: Command contracts
+                │   (Command tests)      │  Medium speed
+            ┌───┴─────────────────────────┴───┐
+            │       INTEGRATION              │  Layer 2: Component interaction
+            │   (Component tests)            │  Medium speed
+        ┌───┴─────────────────────────────────┴───┐
+        │              UNIT                      │  Layer 1: Function behavior
+        │       (Function tests)                 │  Fast, many tests
+        └─────────────────────────────────────────┘
+```
+
+---
+
+## Layer 1: Unit Tests
+
+**What:** Test individual functions in isolation
+**Speed:** Fast (milliseconds)
+**Quantity:** Many (most tests should be here)
+
+### Characteristics
+- No external dependencies (mocked if needed)
+- Test one thing per test
+- Fast feedback during development
+
+### Example
+
+```typescript
+import { describe, it, expect } from "bun:test";
+import { extractMetadata } from "../lib/process";
+
+describe("extractMetadata", () => {
+  it("extracts name from caption", () => {
+    const caption = "[name:Custom] Some content #tag";
+    const result = extractMetadata(caption);
+    expect(result.name).toBe("Custom");
+  });
+
+  it("extracts multiple tags", () => {
+    const caption = "#tag1 #tag2 content";
+    const result = extractMetadata(caption);
+    expect(result.tags).toEqual(["tag1", "tag2"]);
+  });
+});
+```
+
+### When to Write
+- Every function with logic
+- Edge cases and error conditions
+- Before fixing a bug (regression test)
+
+---
+
+## Layer 2: Integration Tests
+
+**What:** Test components working together
+**Speed:** Medium (seconds)
+**Quantity:** Some (key integration points)
+
+### Characteristics
+- Tests real component interaction
+- May use test database/fixtures
+- Verifies data flows correctly between components
+
+### Example
+
+```typescript
+describe("processMessage integration", () => {
+  it("creates vault file from Telegram message", async () => {
+    const message = loadFixture("text-message.json");
+    const result = await processMessage(message, testConfig);
+
+    expect(result.success).toBe(true);
+    expect(result.vaultPath).toContain(".md");
+    expect(await fileExists(result.vaultPath)).toBe(true);
+  });
+});
+```
+
+### When to Write
+- Component boundaries
+- Data transformation pipelines
+- External service interactions (with mocks)
+
+---
+
+## Layer 3: CLI Tests
+
+**What:** Test command-line interface contracts
+**Speed:** Medium (seconds)
+**Quantity:** Some (each command and flag)
+
+### Characteristics
+- Execute actual CLI commands
+- Verify output format and exit codes
+- Test flag combinations
+
+### Example
+
+```typescript
+export const cliTestSpecs: CLITestSpec[] = [
+  {
+    id: "TEST-CLI-014",
+    name: "Direct with --name flag",
+    description: "Verify --name flag adds metadata to caption",
+    command: 'echo "test" | bun run ingest.ts direct --name "Custom" --dry-run',
+    expected: {
+      contains: ["[name:Custom]", "DRY RUN"],
+      exitCode: 0,
+    },
+  },
+  {
+    id: "TEST-CLI-015",
+    name: "Direct with invalid flag",
+    command: 'bun run ingest.ts direct --invalid-flag',
+    expected: {
+      contains: ["Unknown flag"],
+      exitCode: 1,
+    },
+  },
+];
+```
+
+### When to Write
+- Every CLI command
+- Every flag/option
+- Error conditions and help text
+
+---
+
+## Layer 4: Acceptance Tests
+
+**What:** Test end-to-end user outcomes
+**Speed:** Slow (minutes)
+**Quantity:** Few (critical user journeys)
+
+### Characteristics
+- Full system test (may include external services)
+- Tests user-visible outcomes
+- May use LLM-judge for quality evaluation
+
+### Example
+
+```typescript
+describe("Ingest workflow acceptance", () => {
+  it("ingests text and creates searchable note", async () => {
+    // 1. Send content via CLI
+    const ingestResult = await runCommand(
+      'echo "Test content about TypeScript" | bun run ingest.ts direct --tags "test"'
+    );
+    expect(ingestResult.exitCode).toBe(0);
+
+    // 2. Wait for processing
+    await waitForProcessing();
+
+    // 3. Verify searchable
+    const searchResult = await runCommand(
+      'bun run obs.ts search --text "TypeScript"'
+    );
+    expect(searchResult.output).toContain("Test content");
+  });
+});
+```
+
+### When to Write
+- Critical user journeys
+- End-to-end flows
+- Before major releases
+
+---
+
+## Test Naming Convention
+
+```
+TEST-[LAYER]-[NUMBER]: [Description]
+```
+
+| Prefix | Layer | Example |
+|--------|-------|---------|
+| `TEST-UNIT-` | Unit | TEST-UNIT-001: extractMetadata parses tags |
+| `TEST-INT-` | Integration | TEST-INT-005: processMessage creates file |
+| `TEST-CLI-` | CLI | TEST-CLI-014: --name flag works |
+| `TEST-ACC-` | Acceptance | TEST-ACC-001: Full ingest workflow |
+
+---
+
+## Coverage Guidelines
+
+| Layer | Target Coverage |
+|-------|-----------------|
+| Unit | 80%+ of functions with logic |
+| Integration | Key integration points |
+| CLI | Every command and flag |
+| Acceptance | Critical user journeys |
+
+**Note:** 100% coverage is not the goal. Focus on:
+- Business-critical paths
+- Error handling
+- Edge cases that have caused bugs
+
+---
+
+## Running Tests
+
+```bash
+# Run all tests
+bun test all
+
+# Run by layer
+bun test unit
+bun test integration
+bun test cli
+bun test acceptance
+
+# Run specific test
+bun test --grep "TEST-CLI-014"
+
+# Run with coverage
+bun test --coverage
+```
+
+---
+
+## Related Docs
+
+- **ValidateSpec.md** - Workflow for running validation
+- **ToolingArchitecture.md** - Test framework structure

--- a/.claude/skills/SpecFirst/docs/ToolingArchitecture.md
+++ b/.claude/skills/SpecFirst/docs/ToolingArchitecture.md
@@ -1,0 +1,172 @@
+# Tooling Architecture
+
+**Separating methodology from tooling, and tooling from specs.**
+
+---
+
+## The Three Layers
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                 PAI DEVELOPMENT LIFECYCLE                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  LAYER 1: METHODOLOGY (SpecFirst Skill)                         │
+│  └── .claude/skills/SpecFirst/                                  │
+│      ├── workflows/           ← How to develop, release         │
+│      ├── templates/           ← Standard formats                │
+│      └── docs/                ← Test pyramid, architecture      │
+│                                                                 │
+│  LAYER 2: TOOLING (pai-tooling repo)                            │
+│  └── pai-tooling/                                               │
+│      ├── framework/           ← Test runners, validators        │
+│      │   ├── cli-runner.ts                                      │
+│      │   ├── integration-runner.ts                              │
+│      │   └── llm-judge.ts                                       │
+│      └── TEST-FRAMEWORK-SPEC.md                                 │
+│                                                                 │
+│  LAYER 3: SKILL-SPECIFIC (per skill)                            │
+│  └── pai-tooling/[skill]-test/                                  │
+│      ├── specs/               ← Test definitions for THIS skill │
+│      ├── fixtures/            ← Test data (design non-sensitive)│
+│      └── output/              ← Test results                    │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Layer 1: Methodology (SpecFirst Skill)
+
+**What it is:** Process knowledge—how to develop, test, and release.
+
+**Contains:**
+- Workflows (DevelopSkill, ProposeChange, Release, ValidateSpec)
+- Templates (RELEASE-FRAMEWORK, RELEASE-vX.Y.Z)
+- Documentation (TestPyramid, this doc)
+
+**Key insight:** This is **context loaded into Claude's prompt**. It teaches methodology, not execution.
+
+---
+
+## Layer 2: Tooling (Independent)
+
+**What it is:** Reusable test infrastructure that can run tests for ANY skill.
+
+**Contains:**
+```
+pai-tooling/
+├── framework/                 ← Generic runners
+│   ├── cli-runner.ts          ← Executes CLI tests
+│   ├── integration-runner.ts  ← Executes integration tests
+│   ├── acceptance-runner.ts   ← Executes acceptance tests
+│   ├── llm-judge.ts           ← AI-powered evaluation
+│   ├── types.ts               ← Shared type definitions
+│   └── report.ts              ← Generate test reports
+└── TEST-FRAMEWORK-SPEC.md     ← Spec for the framework itself
+```
+
+**Characteristics:**
+- **Independent of any skill** - can test Context, SpecFirst, or any future skill
+- **Reusable** - shared across projects
+- **Public** - could be published as npm package
+
+---
+
+## Layer 3: Skill-Specific Tests
+
+**What it is:** Test definitions and data for a specific skill.
+
+**Contains:**
+```
+pai-tooling/context-test/      ← Tests for Context skill
+├── specs/                     ← Test definitions
+│   ├── cli-direct.spec.ts
+│   ├── cli-context.spec.ts
+│   └── scope.spec.ts
+├── fixtures/                  ← Test data
+│   └── (synthetic data)
+└── output/                    ← Test results
+    └── test-2025-12-12/
+```
+
+**Characteristics:**
+- **Tightly coupled** to the skill being tested
+- **Uses Layer 2 tooling** to execute tests
+- **Fixtures should be non-sensitive** (synthetic data)
+
+---
+
+## Why This Separation?
+
+| Aspect | Layer 1: Methodology | Layer 2: Tooling | Layer 3: Specs |
+|--------|---------------------|------------------|----------------|
+| **Changes when** | Process evolves | Framework improves | Skill changes |
+| **Reusability** | All PAI development | All PAI skills | One skill |
+| **Coupling** | None | None | Tight to skill |
+| **Visibility** | Public (in PAI) | Public (npm pkg) | Public |
+| **Example** | "Use 4-layer tests" | `cli-runner.ts` | `TEST-CLI-014` |
+
+---
+
+## What's Sensitive?
+
+| Component | Sensitive? | Recommendation |
+|-----------|------------|----------------|
+| Methodology (Layer 1) | No | Public skill in PAI |
+| Framework (Layer 2) | No | Public npm package |
+| Specs (Layer 3) | No | Part of skill contribution |
+| Fixtures | **Should be No** | Design with synthetic data |
+| Config | **Yes** | `.env` file, gitignored |
+
+**Best practice:** Design test fixtures to be non-sensitive from the start:
+- Use synthetic test data
+- Use public documents for test content
+- Keep API tokens and paths in `.env`
+
+---
+
+## Integration via Symlinks
+
+For local development, link the test framework to PAI:
+
+```bash
+# Create symlink in PAI pointing to test framework
+ln -s ~/path/to/pai-tooling/context-test ~/path/to/PAI/bin/ingest/test
+
+# Add to .gitignore
+echo "bin/ingest/test" >> .gitignore
+```
+
+This allows:
+- Running tests from PAI directory: `bun run ingest.ts test cli`
+- Keeping test infrastructure versioned separately
+- Not committing sensitive fixtures to PAI repo
+
+---
+
+## Future: npm Package
+
+Layer 2 tooling could become a public npm package:
+
+```bash
+npm install -g @pai/test-framework
+
+# Then in any skill project:
+pai-test init
+pai-test run cli
+pai-test run all
+```
+
+This would:
+- Standardize testing across PAI ecosystem
+- Allow community contributions to framework
+- Keep methodology (Layer 1) in PAI, tooling (Layer 2) as separate package
+
+---
+
+## Related Docs
+
+- **TestPyramid.md** - The 4-layer approach
+- **ValidateSpec.md** - Workflow for running tests
+- **Release.md** - Using tests in release process

--- a/.claude/skills/SpecFirst/docs/WorkedExample.md
+++ b/.claude/skills/SpecFirst/docs/WorkedExample.md
@@ -1,0 +1,440 @@
+# Worked Example: Developing a JIRA Skill
+
+This walkthrough shows exactly what to expect when using SpecFirst to develop a new PAI skill.
+
+**Scenario:** User wants to develop a JIRA integration skill.
+
+---
+
+## The 4-Phase Workflow (Iterative)
+
+```
+┌────────────────────┐
+│ 1. PROPOSE         │  /openspec-proposal
+│ Draft change       │  Create openspec/changes/[feature]/
+└────────┬───────────┘
+         ▼
+┌────────────────────┐
+│ 2. REVIEW & ALIGN  │  Human reviews spec
+│ Edit specs/tasks   │◀──┐ feedback loop
+└────────┬───────────┘   │
+         │               │
+         ▼               │
+┌────────────────────┐   │
+│ 3. IMPLEMENT       │   │  /openspec-apply
+│ AI writes code     │───┘  May reveal spec gaps → back to 2
+└────────┬───────────┘
+         │
+         │  Only when ALL satisfied:
+         ▼
+┌────────────────────┐
+│ 4. ARCHIVE         │  /openspec-archive
+│ Update specs       │  Merge approved changes to specs/
+└────────────────────┘
+```
+
+**Key:** Phases 1-3 are **iterative**. You may cycle through them multiple times before archiving.
+
+---
+
+## How the Skill Guides You
+
+The skill actively guides you through the process:
+
+| Phase | Claude Says | User Action |
+|-------|-------------|-------------|
+| 1. PROPOSE | "Here's my proposal. Does this match your intent?" | Review, request changes |
+| 2. REVIEW | "I've updated the spec. Anything else?" | Approve or request more changes |
+| 3. IMPLEMENT | "Implementation complete. Tests pass. Ready to archive?" | Yes → archive, No → refine |
+| 4. ARCHIVE | "Archived. CHANGELOG updated." | Done (or start new feature) |
+
+**The skill waits for your approval at each phase.** It won't proceed automatically.
+
+---
+
+## Phase 1: PROPOSE
+
+### User Says:
+```
+"I want to develop a JIRA skill that can create issues and sync with my vault"
+```
+
+### Claude Recognizes SpecFirst Trigger:
+```
+I'll help you develop a JIRA skill. Let me start with a spec proposal.
+
+/openspec-proposal
+```
+
+### Claude Asks:
+```
+What feature or change are you proposing?
+> jira-skill
+
+Which skill/project should contain the openspec directory?
+> .claude/skills/Jira
+```
+
+### Claude Creates Structure:
+```
+Created:
+.claude/skills/Jira/openspec/
+├── changes/
+│   └── jira-skill/
+│       ├── proposal.md
+│       ├── tasks.md
+│       └── specs/
+│           └── jira-skill.md
+├── specs/          (empty - first spec)
+└── archive/        (empty)
+```
+
+### Claude Shows proposal.md:
+```markdown
+# Proposal: JIRA Skill
+
+## Summary
+Create a JIRA integration skill that can create issues and sync with Obsidian vault.
+
+## Impact
+- **Scope:** New skill at .claude/skills/Jira/
+- **Breaking changes:** No
+- **Files affected:** SKILL.md, workflows/, CLI tool
+
+## Rationale
+Enable seamless issue tracking from Claude Code sessions, with bidirectional
+sync between JIRA and personal knowledge vault.
+```
+
+### Claude Shows specs/jira-skill.md:
+```markdown
+# JIRA Skill Specification
+
+## Purpose
+Define requirements for the JIRA integration skill.
+
+## Requirements
+
+### Requirement: Create Issue
+The system SHALL allow users to create JIRA issues from Claude Code.
+
+#### Scenario: Create issue from conversation
+- **WHEN** user says "create a JIRA issue for this bug"
+- **THEN** skill SHALL extract issue details from context
+- **AND** skill SHALL create issue via JIRA API
+- **AND** skill SHALL return issue key (e.g., PROJ-123)
+
+### Requirement: Sync to Vault
+The system SHALL sync JIRA issues to Obsidian vault.
+
+#### Scenario: Sync issue to vault
+- **WHEN** user says "sync this issue to my vault"
+- **THEN** skill SHALL fetch issue details from JIRA
+- **AND** skill SHALL create/update note in vault
+- **AND** note SHALL include status, assignee, description
+```
+
+### Claude Shows tasks.md:
+```markdown
+# Tasks: JIRA Skill
+
+## Implementation Checklist
+
+### 1. Skill Structure
+- [ ] 1.1 Create SKILL.md with workflow routing
+- [ ] 1.2 Create workflows/CreateIssue.md
+- [ ] 1.3 Create workflows/SyncVault.md
+
+### 2. CLI Tool
+- [ ] 2.1 Create tools/jira.ts
+- [ ] 2.2 Implement create-issue command
+- [ ] 2.3 Implement sync command
+
+### 3. Configuration
+- [ ] 3.1 Add JIRA_API_TOKEN to .env.example
+- [ ] 3.2 Add JIRA_BASE_URL to .env.example
+
+### 4. Testing
+- [ ] 4.1 Write tests for create-issue
+- [ ] 4.2 Write tests for sync
+```
+
+### Claude Waits:
+```
+Here's my proposal for the JIRA skill. Please review:
+
+- proposal.md - Summary and rationale
+- specs/jira-skill.md - Requirements (SHALL/MUST)
+- tasks.md - Implementation checklist
+
+Does this match your intent? Any requirements to add or modify?
+```
+
+---
+
+## Phase 2: REVIEW & ALIGN
+
+### User Reviews and Requests Changes:
+```
+"Add a requirement for listing issues assigned to me"
+```
+
+### Claude Updates Spec:
+```
+I'll add that requirement to the spec.
+
+[Updates specs/jira-skill.md]
+
+### Requirement: List My Issues
+The system SHALL list JIRA issues assigned to current user.
+
+#### Scenario: List assigned issues
+- **WHEN** user says "show my JIRA issues"
+- **THEN** skill SHALL fetch issues where assignee = current user
+- **AND** skill SHALL display as table (key, summary, status)
+
+[Updates tasks.md]
+
+### 2. CLI Tool
+- [ ] 2.4 Implement list-mine command
+
+Updated. Ready to implement?
+```
+
+### User Approves:
+```
+"Looks good, let's implement"
+```
+
+---
+
+## Iteration Example: Spec Refinement Loop
+
+**What happens when implementation reveals a gap:**
+
+### During Implementation:
+```
+Claude: Working on create-issue command...
+
+I notice the spec doesn't define what happens when JIRA API fails.
+Should I add error handling requirements to the spec?
+```
+
+### User Says:
+```
+"Yes, add error handling requirement"
+```
+
+### Claude Updates Spec (Back to Phase 2):
+```
+I'll update the spec before continuing implementation.
+
+[Updates specs/jira-skill.md]
+
+### Requirement: Error Handling
+The system SHALL handle JIRA API failures gracefully.
+
+#### Scenario: API unavailable
+- **WHEN** JIRA API returns error or timeout
+- **THEN** skill SHALL display clear error message
+- **AND** skill SHALL NOT crash
+- **AND** skill SHALL suggest retry
+
+[Updates tasks.md]
+
+### 5. Error Handling
+- [ ] 5.1 Implement API error handling
+- [ ] 5.2 Add retry logic
+- [ ] 5.3 Test error scenarios
+
+Spec updated. Continuing implementation...
+```
+
+**This iteration is normal and expected.** The skill guides you through it.
+
+---
+
+## Iteration Example: Multiple Review Cycles
+
+**Phase 2 may loop multiple times:**
+
+```
+Cycle 1:
+User: "Add a requirement for listing issues assigned to me"
+Claude: [Updates spec] "Done. Anything else?"
+
+Cycle 2:
+User: "Also add ability to filter by status"
+Claude: [Updates spec] "Done. Anything else?"
+
+Cycle 3:
+User: "That's all, let's implement"
+Claude: "Great, proceeding with /openspec-apply"
+```
+
+**The skill stays in Phase 2 until you say "implement" or "proceed".**
+
+---
+
+## Phase 3: IMPLEMENT
+
+### Claude Invokes:
+```
+/openspec-apply
+```
+
+### Claude Confirms Requirements:
+```
+I'll implement the JIRA skill based on these requirements:
+
+**From specs/jira-skill.md:**
+1. Create Issue - Create JIRA issues from Claude Code
+2. Sync to Vault - Sync issues to Obsidian
+3. List My Issues - Show assigned issues
+
+**From tasks.md:**
+- 1.1 Create SKILL.md
+- 1.2 Create workflows/
+- 2.1-2.4 CLI implementation
+- 3.1-3.2 Configuration
+- 4.1-4.2 Tests
+
+Proceeding with implementation...
+```
+
+### Claude Works Through tasks.md:
+
+```
+✓ 1.1 Created SKILL.md with workflow routing
+✓ 1.2 Created workflows/CreateIssue.md
+✓ 1.3 Created workflows/SyncVault.md
+
+Working on CLI tool...
+✓ 2.1 Created tools/jira.ts
+✓ 2.2 Implemented create-issue command
+✓ 2.3 Implemented sync command
+✓ 2.4 Implemented list-mine command
+
+✓ 3.1 Added JIRA_API_TOKEN to .env.example
+✓ 3.2 Added JIRA_BASE_URL to .env.example
+
+Writing tests...
+✓ 4.1 Tests for create-issue (3 tests)
+✓ 4.2 Tests for sync (2 tests)
+
+Running tests...
+All 5 tests passed.
+
+Implementation complete. All tasks checked off.
+```
+
+### Claude Shows Updated tasks.md:
+```markdown
+### 1. Skill Structure
+- [x] 1.1 Create SKILL.md with workflow routing
+- [x] 1.2 Create workflows/CreateIssue.md
+- [x] 1.3 Create workflows/SyncVault.md
+
+### 2. CLI Tool
+- [x] 2.1 Create tools/jira.ts
+- [x] 2.2 Implement create-issue command
+- [x] 2.3 Implement sync command
+- [x] 2.4 Implement list-mine command
+
+### 3. Configuration
+- [x] 3.1 Add JIRA_API_TOKEN to .env.example
+- [x] 3.2 Add JIRA_BASE_URL to .env.example
+
+### 4. Testing
+- [x] 4.1 Write tests for create-issue
+- [x] 4.2 Write tests for sync
+```
+
+---
+
+## Phase 4: ARCHIVE
+
+### User Says:
+```
+"Great, archive this"
+```
+
+### Claude Invokes:
+```
+/openspec-archive
+```
+
+### Claude Processes:
+```
+Archiving jira-skill...
+
+1. Verifying completion:
+   ✓ All 10 tasks complete
+   ✓ All tests pass
+
+2. Merging specs:
+   ✓ specs/jira-skill.md → openspec/specs/jira-skill.md
+
+3. Updating CHANGELOG.md:
+   Added entry for [Unreleased]:
+
+   ### Added
+   - JIRA skill for creating issues and syncing with vault
+   - Commands: create-issue, sync, list-mine
+   - Vault integration for issue notes
+
+4. Moving to archive:
+   ✓ openspec/changes/jira-skill/ → openspec/archive/2025-12-12-jira-skill/
+
+Done! Spec archived, CHANGELOG updated.
+```
+
+### Final Directory Structure:
+```
+.claude/skills/Jira/
+├── SKILL.md
+├── CHANGELOG.md
+├── workflows/
+│   ├── CreateIssue.md
+│   └── SyncVault.md
+├── tools/
+│   └── jira.ts
+└── openspec/
+    ├── specs/
+    │   └── jira-skill.md     ← Merged from changes
+    ├── changes/              ← Empty (archived)
+    └── archive/
+        └── 2025-12-12-jira-skill/
+            ├── proposal.md   ← Preserved for audit
+            ├── tasks.md
+            └── specs/
+```
+
+---
+
+## What Happens Next?
+
+### If Ready to Release:
+```
+/specfirst-release
+```
+Creates RELEASE-v1.0.0.md with file inventory for PAI contribution.
+
+### If Adding More Features:
+```
+"Add ability to comment on issues"
+
+/openspec-proposal
+→ Creates openspec/changes/add-comments/
+→ Cycle repeats
+```
+
+---
+
+## Key Takeaways
+
+1. **Specs come first** - Requirements defined before any code written
+2. **Human reviews** - Approval required between phases
+3. **Tasks track progress** - Checklist updated as work completes
+4. **Archive preserves audit trail** - Can trace decisions later
+5. **CHANGELOG auto-updated** - From proposal summary

--- a/.claude/skills/SpecFirst/openspec/changes/specfirst-v1.0.0/proposal.md
+++ b/.claude/skills/SpecFirst/openspec/changes/specfirst-v1.0.0/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: SpecFirst Skill v1.0.0
+
+## Summary
+
+Initial release of SpecFirst - a spec-driven development methodology skill for Claude Code that works for any software project, with strict release discipline for PAI contributions.
+
+## Impact
+
+- **Scope:** New skill for `.claude/skills/SpecFirst/`
+- **Breaking changes:** No (new skill)
+- **Files affected:**
+  - `.claude/skills/SpecFirst/` (skill definition)
+  - `.claude/commands/openspec-*.md` (slash commands)
+  - `.claude/commands/specfirst-*.md` (slash commands)
+
+## Rationale
+
+AI tools make development easy—and make it easy to leak data or create bloated PRs. SpecFirst provides:
+
+1. **Spec-driven development:** Define requirements before implementation
+2. **Test-driven validation:** Tests validate spec requirements
+3. **Release discipline:** File inventory, validation gates, manual review
+4. **PAI contribution safety:** Contrib branch pattern prevents data leaks
+
+## Goals
+
+1. Work for ANY software project (not just PAI skills)
+2. Integrate with OpenSpec methodology
+3. Provide strict release discipline for PAI contributions
+4. Enable dogfooding (skill uses itself)
+
+## Non-Goals
+
+- Replace OpenSpec CLI (complementary)
+- Enforce a single spec format (flexible on tooling)
+- Automate release process (requires human approval)

--- a/.claude/skills/SpecFirst/openspec/changes/specfirst-v1.0.0/specs/specfirst-skill.md
+++ b/.claude/skills/SpecFirst/openspec/changes/specfirst-v1.0.0/specs/specfirst-skill.md
@@ -1,0 +1,152 @@
+# SpecFirst Skill Specification
+
+## Purpose
+
+Define requirements for the SpecFirst skill - a spec-driven development methodology for Claude Code.
+
+---
+
+## File Structure Requirements
+
+### Requirement: Core Skill Files
+
+The skill SHALL have the following files at `.claude/skills/SpecFirst/`:
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Entry point with workflow routing |
+| `CHANGELOG.md` | Release history |
+| `workflows/Develop.md` | Development workflow |
+| `workflows/Release.md` | Release workflow |
+| `workflows/ProposeChange.md` | Change proposal workflow |
+| `workflows/ValidateSpec.md` | Validation workflow |
+
+#### Scenario: File existence check
+- **GIVEN** SpecFirst skill is installed
+- **WHEN** checking skill directory
+- **THEN** all core files SHALL exist
+- **AND** each file SHALL have content (not empty)
+
+### Requirement: Slash Command Files
+
+The skill SHALL have slash commands at `.claude/commands/`:
+
+| File | Command |
+|------|---------|
+| `openspec-proposal.md` | `/openspec-proposal` |
+| `openspec-apply.md` | `/openspec-apply` |
+| `openspec-archive.md` | `/openspec-archive` |
+| `specfirst-propose.md` | `/specfirst-propose` |
+| `specfirst-release.md` | `/specfirst-release` |
+| `specfirst-validate.md` | `/specfirst-validate` |
+
+#### Scenario: Command availability
+- **GIVEN** SpecFirst skill is loaded
+- **WHEN** user types `/openspec-`
+- **THEN** proposal, apply, archive commands SHALL appear
+- **AND** each command SHALL have documentation
+
+### Requirement: OpenSpec Directory Structure
+
+When using OpenSpec methodology, the skill SHALL support this structure:
+
+```
+openspec/
+├── specs/          # Current truth
+├── changes/        # Active proposals
+│   └── [name]/
+│       ├── proposal.md
+│       ├── tasks.md
+│       └── specs/
+└── archive/        # Completed changes
+```
+
+#### Scenario: Structure creation
+- **WHEN** user invokes `/openspec-proposal`
+- **THEN** change folder SHALL be created
+- **AND** proposal.md, tasks.md, specs/ SHALL exist
+
+---
+
+## Functional Requirements
+
+### Requirement: Spec-First Flow
+
+The skill SHALL provide a workflow where specifications are defined before implementation.
+
+#### Scenario: New feature development
+- **WHEN** user starts developing a new feature
+- **THEN** the skill SHALL route to spec creation first
+- **AND** implementation SHALL only proceed after spec approval
+
+### Requirement: OpenSpec Integration
+
+The skill SHALL integrate with OpenSpec methodology for spec management.
+
+#### Scenario: Creating a change proposal
+- **WHEN** user invokes `/openspec-proposal`
+- **THEN** the skill SHALL create a change folder structure
+- **AND** the folder SHALL contain proposal.md, tasks.md, and specs/
+
+#### Scenario: Implementing from specs
+- **WHEN** user invokes `/openspec-apply`
+- **THEN** the skill SHALL read specs and implement accordingly
+- **AND** tests SHALL be written to validate spec requirements
+
+#### Scenario: Archiving completed changes
+- **WHEN** user invokes `/openspec-archive`
+- **THEN** the skill SHALL merge spec deltas into specs/
+- **AND** CHANGELOG.md SHALL be updated
+
+### Requirement: Release Discipline
+
+The skill SHALL enforce strict release discipline with human approval gates.
+
+#### Scenario: Preparing a release
+- **WHEN** user invokes `/specfirst-release`
+- **THEN** the skill SHALL create a file inventory (include/exclude)
+- **AND** the skill SHALL require human approval at each gate
+
+#### Scenario: PAI contribution
+- **WHEN** releasing to upstream PAI
+- **THEN** the skill SHALL enforce contrib branch pattern
+- **AND** sanitization checks SHALL be required
+
+### Requirement: Universal Applicability
+
+The skill SHALL work for any software project, not just PAI skills.
+
+#### Scenario: Standard development
+- **WHEN** developing for non-PAI projects
+- **THEN** the skill SHALL provide simplified workflow
+- **AND** contrib branch pattern SHALL be optional
+
+### Requirement: Slash Commands
+
+The skill SHALL provide slash commands for key workflows.
+
+#### Scenario: Command availability
+- **GIVEN** SpecFirst skill is loaded
+- **WHEN** user types `/openspec-` or `/specfirst-`
+- **THEN** relevant commands SHALL be available
+- **AND** commands SHALL have clear documentation
+
+## Non-Functional Requirements
+
+### Requirement: Documentation
+
+The skill SHALL be self-documenting with clear examples.
+
+#### Scenario: Learning the skill
+- **WHEN** user reads SKILL.md
+- **THEN** they SHALL understand the core workflow
+- **AND** examples SHALL show command usage
+
+### Requirement: Dogfooding
+
+The skill SHALL use itself for its own development.
+
+#### Scenario: SpecFirst development
+- **WHEN** developing the SpecFirst skill
+- **THEN** openspec/ structure SHALL be used
+- **AND** specs SHALL be defined before implementation

--- a/.claude/skills/SpecFirst/openspec/changes/specfirst-v1.0.0/tasks.md
+++ b/.claude/skills/SpecFirst/openspec/changes/specfirst-v1.0.0/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: SpecFirst Skill v1.0.0
+
+## Implementation Checklist
+
+### 1. Core Skill Structure
+- [x] 1.1 Create SKILL.md with workflow routing
+- [x] 1.2 Create workflow files (Develop, ProposeChange, Release, ValidateSpec)
+- [x] 1.3 Create template files (RELEASE-FRAMEWORK, RELEASE-vX.Y.Z, Requirement)
+- [x] 1.4 Create docs (TestPyramid, ToolingArchitecture, Approaches)
+
+### 2. Slash Commands
+- [x] 2.1 Create `/openspec-proposal` command
+- [x] 2.2 Create `/openspec-apply` command
+- [x] 2.3 Create `/openspec-archive` command
+- [x] 2.4 Create `/specfirst-propose` command
+- [x] 2.5 Create `/specfirst-release` command
+- [x] 2.6 Create `/specfirst-validate` command
+
+### 3. OpenSpec Integration
+- [x] 3.1 Add spec-first flow to Develop.md
+- [x] 3.2 Add Phase 0 (Spec Setup) to workflow
+- [x] 3.3 Document CLI tool usage (optional)
+- [x] 3.4 Update SKILL.md with command tables
+
+### 4. Dogfooding
+- [x] 4.1 Create openspec/ structure for SpecFirst itself
+- [x] 4.2 Create proposal.md for v1.0.0
+- [x] 4.3 Create tasks.md (this file)
+- [x] 4.4 Create specs for SpecFirst requirements
+- [ ] 4.5 Create CHANGELOG.md
+
+### 5. Documentation
+- [x] 5.1 Update examples in SKILL.md to use commands
+- [ ] 5.2 Verify all cross-references work
+- [ ] 5.3 Review for completeness
+
+### 6. Release Preparation
+- [ ] 6.1 Archive specs (/openspec-archive)
+- [ ] 6.2 Create RELEASE-v1.0.0.md with file inventory
+- [ ] 6.3 Commit all changes
+- [ ] 6.4 Tag v1.0.0

--- a/.claude/skills/SpecFirst/templates/RELEASE-FRAMEWORK.md
+++ b/.claude/skills/SpecFirst/templates/RELEASE-FRAMEWORK.md
@@ -1,0 +1,274 @@
+# RELEASE-FRAMEWORK
+
+**Template for defining release methodology for a PAI skill or project.**
+
+Copy this template and customize for your skill.
+
+---
+
+## Versioning
+
+### Semantic Versioning with `v` Prefix
+
+Use [semantic versioning](https://semver.org/) with a `v` prefix:
+
+| Version | When to Use |
+|---------|-------------|
+| `v1.0.0` | Initial release - feature-complete, tested, ready |
+| `v1.0.1` | Patch - bug fixes, documentation, PR feedback |
+| `v1.1.0` | Minor - new features, backward compatible |
+| `v2.0.0` | Major - breaking changes |
+
+**First release = `v1.0.0`** - Skills should be production-ready before contribution.
+
+### Version Artifacts
+
+| Artifact | Location | Tracked in Git? |
+|----------|----------|-----------------|
+| Git tag | `v1.0.0` | Yes (on origin, NEVER fork) |
+| CHANGELOG.md | `.claude/skills/[Name]/` | Yes |
+| RELEASE-vX.Y.Z.md | `.claude/skills/[Name]/` | **No** (gitignored, instance-specific) |
+| Test run | `output/release-v1.0.0-*` | No (local output) |
+
+**Key:** Test run ID ties to tag: `release-v1.0.0-*` → tag `v1.0.0`
+
+---
+
+## Scope Definition
+
+### Included in Releases
+
+Define what files/directories are part of this skill:
+
+```
+.claude/skills/[SkillName]/
+├── SKILL.md              ✅ Always included
+├── workflows/            ✅ Always included
+├── templates/            ✅ Always included
+├── docs/                 ✅ Always included
+└── CHANGELOG.md          ✅ Always included
+
+bin/[tool-name]/          ✅ If skill has CLI tooling
+└── [tool].ts
+
+shortcuts/                ✅ If skill has shortcuts
+└── [Shortcut].shortcut
+```
+
+### Excluded from Releases (Never Commit)
+
+```
+.env                      ❌ API keys, tokens
+.env.*                    ❌ Environment variants
+config/personal.json      ❌ Personal settings
+test/fixtures/            ❌ If contains real data
+profiles/*.json           ❌ Personal profiles
+*.log                     ❌ Log files
+```
+
+---
+
+## Safety Nets
+
+### .gitignore Requirements
+
+Ensure these patterns are in `.gitignore`:
+
+```gitignore
+# Secrets
+.env
+.env.*
+*.pem
+*.key
+
+# Personal config
+config/personal.json
+profiles/
+
+# Test artifacts (if sensitive)
+test/fixtures/private/
+test/output/
+
+# IDE
+.idea/
+.vscode/
+```
+
+### Sanitization Check
+
+Before any public release, verify:
+
+```bash
+# No secrets in code
+grep -r "API_KEY\|TOKEN\|PASSWORD" --include="*.ts" --include="*.md"
+
+# No personal paths
+grep -r "/Users/\|/home/" --include="*.ts" --include="*.md"
+
+# No hardcoded IDs
+grep -r "TELEGRAM_\|CHANNEL_ID" --include="*.ts"
+```
+
+---
+
+## Propagation Process
+
+### Repository & Branch Overview
+
+| Remote | Repo | Branch | Visibility | Purpose |
+|--------|------|--------|------------|---------|
+| `origin` | your-private-repo | `feature/*` | **PRIVATE** | Daily development |
+| `origin` | your-private-repo | `contrib-*` | **PRIVATE** | Squash staging for PRs |
+| `fork` | your-public-fork | `contrib-*` | **PUBLIC** | PR source branch |
+| `upstream` | upstream-owner/repo | `main` | PUBLIC | PR target (read-only) |
+
+### Complete Release Workflow (PAI Contribution)
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│                         PRE-RELEASE PHASE                               │
+├────────────────────────────────────────────────────────────────────────┤
+│  1. CREATE RELEASE-vX.Y.Z.md with file inventory                       │
+│  2. RUN TESTS with --release flag                                      │
+│     └── Creates: output/release-v1.0.0-YYYY-MM-DD-HH-MM-SS/            │
+│  3. COMPLETE PRE-RELEASE CHECKLIST                                     │
+│  4. UPDATE CHANGELOG.md                                                │
+│     └── Move [Unreleased] → [vX.Y.Z] - DATE                            │
+├────────────────────────────────────────────────────────────────────────┤
+│                     TAG PHASE (after checklist approved)                │
+├────────────────────────────────────────────────────────────────────────┤
+│  5. CREATE TAG ON FEATURE BRANCH                                       │
+│     └── git tag -a v1.0.0 -m "Release v1.0.0"                          │
+│     └── git push origin v1.0.0                                         │
+│     └── Tag marks EXACT code that was tested                           │
+├────────────────────────────────────────────────────────────────────────┤
+│                      CONTRIBUTION PHASE                                 │
+├────────────────────────────────────────────────────────────────────────┤
+│  6. CREATE CONTRIB BRANCH FROM UPSTREAM                                │
+│     └── git checkout -b contrib-[name]-v1.0.0 upstream/main            │
+│  7. CHERRY-PICK FROM TAG (not feature branch!)                         │
+│     └── git checkout v1.0.0 -- [file-list from inventory]              │
+│  8. SANITIZE AND PUSH TO FORK                                          │
+│     └── ./scripts/sanitize-for-contrib.sh                              │
+│     └── git push fork contrib-[name]-v1.0.0                            │
+│  9. CREATE PR                                                          │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### When to Tag
+
+**Tag BEFORE creating PR:**
+- Tag on `origin` (private) after checklist approved
+- Tag marks the exact code that was tested
+- Cherry-pick FROM TAG ensures PR matches tested code
+- If PR needs changes → increment version (`v1.0.1`)
+
+**Where to tag:** Always on `origin` (private), NEVER on `fork` (public)
+
+### If PR Needs Changes
+
+```
+→ Fix on feature branch
+→ Run tests: --release v1.0.1
+→ Tag v1.0.1
+→ Cherry-pick from v1.0.1 to contrib branch
+→ Push updated contrib branch
+```
+
+### Standard Development (Non-Fork)
+
+```
+feature/[name]  →  PR  →  main
+     │               │
+  (develop)    (squash merge)
+```
+
+---
+
+## CHANGELOG Management
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+```markdown
+# Changelog
+
+All notable changes to [Skill Name] will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v1.1.0] - 2025-12-12
+
+### Added
+- New workflow: DevelopSkill.md
+- Template: RELEASE-vX.Y.Z.md
+
+### Changed
+- Updated SKILL.md routing table
+
+### Fixed
+- Typo in Release.md
+
+## [v1.0.0] - 2025-12-10
+
+Initial release of [Skill Name].
+
+### Added
+- SKILL.md with core workflows
+- CLI implementation
+
+### Architecture
+- CLI-First design following PAI principles
+- Deterministic code with AI as capability layer
+```
+
+### When to Update CHANGELOG
+
+| Event | Action |
+|-------|--------|
+| New feature merged | Add to `[Unreleased]` |
+| Bug fix | Add to `[Unreleased]` |
+| Preparing release | Move `[Unreleased]` → `[vX.Y.Z] - DATE` |
+| After tagging | Create new `[Unreleased]` section |
+
+---
+
+## Checklist Templates
+
+### Pre-Release Checklist
+
+```markdown
+## Pre-Release Checklist for v[X.Y.Z]
+
+### Scope
+- [ ] File inventory complete
+- [ ] No unintended files included
+- [ ] Excluded files verified
+
+### Sanitization
+- [ ] No PII
+- [ ] No secrets
+- [ ] No personal paths
+- [ ] Config externalized
+
+### Quality
+- [ ] Tests pass (all layers)
+- [ ] Documentation current
+- [ ] CHANGELOG updated
+- [ ] Version bumped
+
+### Final
+- [ ] Squash merge complete
+- [ ] PR description ready
+```
+
+---
+
+## Using This Framework
+
+1. **Copy to your skill:** `cp templates/RELEASE-FRAMEWORK.md .claude/skills/MySkill/`
+2. **Customize:** Update include/exclude lists for your skill
+3. **Create release plans:** Use `templates/RELEASE-vX.Y.Z.md` for each release
+4. **Follow the checklist:** Every. Single. Time.

--- a/.claude/skills/SpecFirst/templates/RELEASE-vX.Y.Z.md
+++ b/.claude/skills/SpecFirst/templates/RELEASE-vX.Y.Z.md
@@ -1,0 +1,230 @@
+# RELEASE-vX.Y.Z
+
+**Template for release plans. Copy and fill in for each release.**
+
+---
+
+# [Skill Name] Release v[VERSION]
+
+## Release Info
+
+| Field | Value |
+|-------|-------|
+| **Version** | vX.Y.Z |
+| **Target Date** | YYYY-MM-DD |
+| **Test Run ID** | `release-vX.Y.Z-YYYY-MM-DD-HH-MM-SS` |
+| **Status** | In Progress / Ready for PR / Merged |
+| **Contrib Branch** | `contrib-[skill]-vX.Y.Z` |
+
+## Summary
+
+[One sentence: What does this release deliver?]
+
+---
+
+## File Inventory (Include)
+
+**This inventory guides all git operations. Only files listed here get cherry-picked.**
+
+| # | File | Reason |
+|---|------|--------|
+| | **Config** | |
+| 1 | `.claude/.env.example` | Template for required env vars |
+| | **Skill Definition** | |
+| 2 | `.claude/skills/[Name]/SKILL.md` | Claude Code skill triggers |
+| 3 | `.claude/skills/[Name]/CHANGELOG.md` | Release changelog |
+| 4 | `.claude/skills/[Name]/workflows/*.md` | Workflow docs |
+| 5 | `.claude/skills/[Name]/docs/*.md` | Additional docs |
+| | **CLI** | |
+| 6 | `bin/[cli]/[cli].ts` | Main CLI entry point |
+| 7 | `bin/[cli]/lib/*.ts` | Library modules |
+| 8 | `bin/[cli]/package.json` | Dependencies |
+| 9 | `bin/[cli]/bun.lock` | Lock file |
+
+**Total Include: X files**
+
+---
+
+## Exclude (Not Part of This Release)
+
+**These paths must NOT be in the PR. Remove if accidentally cherry-picked.**
+
+| Path | Reason | Action |
+|------|--------|--------|
+| `.env`, `.env.*` | Contains API keys, tokens | Never commit |
+| `config/personal.json` | Personal settings | Never commit |
+| `bin/[cli]/test/` | Test fixtures (may contain personal data) | Remove if present |
+| `RELEASE-vX.Y.Z.md` | Instance-specific release plan | Remove if present |
+| `.claude/skills/*/RELEASE-*.md` | Release plans are gitignored | Remove if present |
+| `.claude/hooks/` | Personal automation | Not part of skill |
+| `.claude/settings.json` | Personal preferences | Not part of skill |
+| `docs/` (personal) | Internal documentation | Not part of skill |
+| Other skills (e.g., `CORE/`, `Jira/`) | Separate contributions | Not part of this PR |
+
+---
+
+## Summary
+
+| Status | Count | Description |
+|--------|-------|-------------|
+| ✅ Include | X | Core skill files to cherry-pick |
+| ❌ Exclude | Y | Personal/sensitive files to remove |
+
+---
+
+## File Inventory → Git Operations
+
+**The file inventory drives the cherry-pick step:**
+
+```bash
+# Cherry-pick ONLY files from the Include list:
+git checkout [tag-or-branch] -- \
+    .claude/skills/[Name]/ \
+    .claude/.env.example \
+    bin/[cli]/
+
+# Remove any excluded files that were accidentally included:
+rm -rf bin/[cli]/test/ \
+       .claude/skills/[Name]/RELEASE-vX.Y.Z.md
+
+# Verify staged files match inventory:
+git diff --name-only --cached | sort
+# Compare against Include list above
+```
+
+---
+
+## Decisions
+
+| Item | Decision | Rationale |
+|------|----------|-----------|
+| [Decision 1] | [Option chosen] | [Why] |
+| [Decision 2] | [Option chosen] | [Why] |
+
+---
+
+## Pre-Release Checklist
+
+### 1. Code Ready
+- [ ] All features complete
+- [ ] No TODO/FIXME in release files
+- [ ] .env.example up to date
+
+### 2. Tests Pass
+- [ ] Unit tests: `[test command] --release vX.Y.Z`
+- [ ] Integration tests pass
+- [ ] CLI tests pass
+- [ ] Acceptance tests pass (or documented why skipped)
+
+### 3. Documentation
+- [ ] SKILL.md accurate
+- [ ] CLI --help output correct
+- [ ] CHANGELOG.md updated
+
+### 4. Sanitization
+- [ ] `./scripts/sanitize-for-contrib.sh` passes
+- [ ] No personal data in diff
+- [ ] Scope validated against file inventory
+
+---
+
+## Test Results
+
+| Layer | Passed | Failed | Skipped | Notes |
+|-------|--------|--------|---------|-------|
+| Unit | X | 0 | 0 | |
+| Integration | X | 0 | 0 | |
+| CLI | X | 0 | 0 | |
+| Acceptance | X | 0 | 0 | |
+
+**Test run:** `release-vX.Y.Z-YYYY-MM-DD-HH-MM-SS`
+
+---
+
+## Propagation Process
+
+```
+origin/feature/[name]         (PRIVATE - development)
+        │
+        │  1. Complete checklist above
+        │  2. Update CHANGELOG.md
+        │
+        ├── TAG: vX.Y.Z (after checklist approved)
+        │   └── Marks exact code that was tested
+        │
+        │  3. Create contrib branch from upstream/main
+        │  4. Cherry-pick from TAG using file inventory
+        ▼
+origin/contrib-[name]-vX.Y.Z  (PRIVATE - staging)
+        │
+        │  5. Run sanitization
+        │  6. Verify diff matches file inventory
+        ▼
+fork/contrib-[name]-vX.Y.Z    (PUBLIC - PR source)
+        │
+        │  7. Create PR
+        ▼
+upstream/main                 (PUBLIC - target)
+```
+
+---
+
+## PR Description
+
+```markdown
+## Summary
+
+[TL;DR: One sentence value proposition]
+
+### How It Works
+
+[Brief architecture explanation or ASCII diagram]
+
+### CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `cmd1` | Description |
+| `cmd2` | Description |
+
+---
+
+## What This Adds
+
+- [File/component 1]
+- [File/component 2]
+
+## Required Configuration
+
+```bash
+# Add to ~/.claude/.env
+VAR_NAME=description
+```
+
+## Test Plan
+
+- [x] Unit tests pass
+- [x] Integration tests pass
+- [x] Manual testing completed
+
+## What's NOT Included (Yet)
+
+[Honest about gaps - builds trust with reviewers]
+```
+
+---
+
+## Post-Checklist Steps
+
+**After checklist approved:**
+- [ ] Tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z: [description]"`
+- [ ] Push tag: `git push origin vX.Y.Z`
+- [ ] Create contrib branch from upstream
+- [ ] Cherry-pick from tag (using file inventory)
+- [ ] Run sanitization
+- [ ] Push to fork
+- [ ] Create PR
+
+**After PR merged:**
+- [ ] Update dependent documentation
+- [ ] Archive this release plan (optional)

--- a/.claude/skills/SpecFirst/templates/Requirement.md
+++ b/.claude/skills/SpecFirst/templates/Requirement.md
@@ -1,0 +1,96 @@
+# Requirement Template
+
+**Use this format for testable requirements.**
+
+---
+
+## Format
+
+```markdown
+### Requirement: [Descriptive Name]
+
+[Description using SHALL/MUST language]
+
+#### Scenario: [Use Case Name]
+- **GIVEN** [precondition/context]
+- **WHEN** [action/trigger]
+- **THEN** [expected outcome]
+- **AND** [additional outcomes if any]
+```
+
+---
+
+## Language Reference
+
+| Word | Meaning | Testability |
+|------|---------|-------------|
+| **SHALL** | Mandatory requirement | Must have test |
+| **MUST** | Absolute constraint | Must have test |
+| **SHOULD** | Recommended | Optional test |
+| **MAY** | Optional behavior | No test required |
+
+---
+
+## Examples
+
+### Good Requirements
+
+```markdown
+### Requirement: Filename Override
+
+The system SHALL allow users to override generated filenames via --name flag.
+
+#### Scenario: CLI with --name flag
+- **GIVEN** user is running ingest direct
+- **WHEN** user provides `--name "Custom-Name"`
+- **THEN** output filename SHALL contain "Custom-Name"
+- **AND** caption SHALL include `[name:Custom-Name]` metadata
+
+#### Scenario: Missing --name flag
+- **GIVEN** user is running ingest direct
+- **WHEN** --name flag is not provided
+- **THEN** filename SHALL be auto-generated from content
+```
+
+### Bad Requirements (Avoid)
+
+```markdown
+### Requirement: Good UX
+The system should work correctly and be user-friendly.
+```
+*Why bad: Not testable, no scenarios, vague language*
+
+---
+
+## Mapping to Tests
+
+Each scenario maps to a test:
+
+```
+Requirement          →    Scenario           →    Test ID
+──────────────────────────────────────────────────────────
+Filename Override    →    CLI with --name    →    TEST-CLI-014
+                     →    Missing --name     →    TEST-CLI-015
+```
+
+---
+
+## Delta Format (for changes)
+
+When modifying existing requirements:
+
+```markdown
+## ADDED Requirements
+### Requirement: [New Feature]
+The system SHALL [behavior].
+
+## MODIFIED Requirements
+### Requirement: [Existing Feature]
+The system SHALL [updated behavior].
+<!-- Changed from: [original behavior] -->
+<!-- Rationale: [why changed] -->
+
+## REMOVED Requirements
+### Requirement: [Deprecated Feature]
+<!-- Removal rationale: [why removed] -->
+```

--- a/.claude/skills/SpecFirst/workflows/Develop.md
+++ b/.claude/skills/SpecFirst/workflows/Develop.md
@@ -1,0 +1,473 @@
+# Develop Workflow
+
+**Purpose:** Spec-first development for any project - from simple features to PAI skill contributions.
+
+**Core Principle:** Specs drive everything. Tests validate specs. Code makes tests pass.
+
+---
+
+## The Spec-First Flow
+
+```
+SPEC → TEST → IMPLEMENT → RELEASE
+  │       │        │          │
+  │       │        │          └── Release.md workflow
+  │       │        └── Code that makes tests pass
+  │       └── Tests that validate spec requirements
+  └── Define requirements (SHALL/MUST)
+```
+
+---
+
+## Development Paths
+
+| Path | When to Use | Flow |
+|------|-------------|------|
+| **Standard** | Most projects, internal tools | `spec → test → feature/x → PR → main` |
+| **PAI Contribution** | Contributing to upstream PAI | `spec → test → feature/x → TAG → contrib/x → fork → upstream` |
+
+Both use **squash commits** for clean history. The difference is whether you need the contrib branch sanitization gate.
+
+---
+
+## Branch & Remote Reference
+
+### Standard Development
+
+| Name | Example | Visibility | Purpose |
+|------|---------|------------|---------|
+| **main** | `main` | Depends | Production branch |
+| **feature** | `feature/add-name-flag` | Private | Development work |
+
+### PAI Contribution
+
+| Name | Remote | Branch | Visibility | Purpose |
+|------|--------|--------|------------|---------|
+| **upstream** | `upstream` | `main` | PUBLIC | Target repo (read-only) |
+| **origin** | `origin` | `main` | PRIVATE | Your private copy |
+| **feature** | `origin` | `feature/my-skill` | PRIVATE | Development (messy OK) |
+| **tag** | `origin` | `v1.0.0` | PRIVATE | Marks tested code |
+| **contrib** | `origin` | `contrib-my-skill-v1.0.0` | PRIVATE | Clean staging |
+| **fork** | `fork` | `contrib-my-skill-v1.0.0` | PUBLIC | PR source |
+
+**Flow:**
+```
+upstream/main ← fork/contrib ← origin/contrib ← TAG ← origin/feature
+   (target)      (PR source)     (staging)     (tested)  (development)
+```
+
+---
+
+## Why PAI Needs Extra Care
+
+Your Personal AI is entangled with personal data:
+- `.env` with API keys and tokens
+- Personal vault paths and Telegram IDs
+- Real test fixtures with captured data
+- Config files with your preferences
+
+**The contrib branch pattern untangles contribution-worthy code from personal data.** Without it, you risk:
+- Leaking API keys to public repos
+- Exposing personal paths and usernames
+- Bloated PRs with debug/personal files
+
+---
+
+## Prerequisites (PAI Contribution)
+
+Before starting development on a PAI contribution:
+
+```bash
+# 1. Sync with upstream (required for PAI contributions)
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+---
+
+## Phase 0: Spec Setup
+
+**Before writing code, define what you're building.**
+
+### For New Skills/Features
+
+```bash
+# Initialize OpenSpec structure (if not exists)
+openspec init
+
+# Or create manually:
+mkdir -p openspec/specs openspec/changes openspec/archive
+```
+
+### Create Change Proposal
+
+```bash
+# Use slash command to create proposal
+/openspec-proposal
+
+# Creates: openspec/changes/[feature-name]/
+#   ├── proposal.md    ← What and why
+#   ├── tasks.md       ← Implementation checklist
+#   └── specs/         ← Spec deltas (SHALL/MUST requirements)
+```
+
+### Define Requirements First
+
+```markdown
+# In openspec/changes/my-feature/specs/feature.md
+
+## ADDED Requirements
+
+### Requirement: [Feature Name]
+The system SHALL [behavior using SHALL/MUST language].
+
+#### Scenario: [Use case]
+- **GIVEN** [precondition]
+- **WHEN** [trigger]
+- **THEN** [expected outcome]
+```
+
+**Human review required:** Get spec approval before proceeding to implementation.
+
+---
+
+## Phase 1: Test Setup
+
+**Write tests that validate your specs before implementing.**
+
+```bash
+# Tests SHOULD fail initially - you haven't implemented yet!
+# Each spec requirement maps to a test:
+
+# SPEC (spec.md)              → TEST (*.spec.ts)
+# Requirement: --name flag    → TEST-CLI-014
+# Scenario: CLI usage         → command: ingest direct --name "X"
+# THEN filename SHALL use     → expected.contains: ["[name:X]"]
+```
+
+---
+
+## Standard Development
+
+For typical projects: feature branch → PR → main.
+
+### Setup
+
+```bash
+# Create feature branch
+git checkout -b feature/my-feature main
+```
+
+### Implement (Make Tests Pass)
+
+```bash
+# Develop against specs - tests guide implementation
+git add .
+git commit -m "wip: initial implementation"
+git commit -m "feat: add core functionality"
+git commit -m "fix: handle edge case"
+# ... many commits OK during development
+
+# Run tests frequently
+bun test
+```
+
+### Release
+
+```bash
+# Push feature branch
+git push origin feature/my-feature
+
+# Create PR (squash merge recommended)
+gh pr create --base main --title "feat: Add my feature"
+
+# After approval, squash merge
+gh pr merge --squash
+```
+
+**Squash is key:** Collapses "wip", "fix typo", "debug" into one clean commit.
+
+---
+
+## PAI Contribution Development
+
+For contributing skills/features to upstream PAI repository.
+
+### Branch Strategy (with Specs)
+
+```
+openspec/specs/               ← Current truth (WHAT the skill does)
+    │
+    └── openspec/changes/     ← Proposed changes (spec deltas)
+            │
+            │  /openspec-proposal (define requirements)
+            │  Human reviews specs
+            │  /openspec-apply (implement)
+            ▼
+main (or upstream/main)
+    │
+    └── feature/[name]           ← Development (PRIVATE, messy commits OK)
+            │
+            │  /openspec-archive (merge specs, update CHANGELOG)
+            │
+            ├── TAG: v1.0.0      ← Marks tested code (after checklist)
+            │
+            └── contrib-[name]   ← Clean commit for PR (cherry-picked from TAG)
+                    │
+                    └── fork/contrib-[name]  ← PUBLIC PR source
+```
+
+### Versioning
+
+| Version | When to Use |
+|---------|-------------|
+| `v1.0.0` | Initial release - feature-complete, tested |
+| `v1.0.1` | Patch - bug fixes, PR feedback |
+| `v1.1.0` | Minor - new features, backward compatible |
+| `v2.0.0` | Major - breaking changes |
+
+**First release = `v1.0.0`** - PAI skills should be production-ready before contribution.
+
+### Version Artifacts
+
+| Artifact | Location | Tracked in Git? |
+|----------|----------|-----------------|
+| Git tag | `v1.0.0` | Yes (on origin, NEVER fork) |
+| CHANGELOG.md | `.claude/skills/[Name]/` | Yes |
+| RELEASE-vX.Y.Z.md | `.claude/skills/[Name]/` | **No** (gitignored) |
+| Test run | `output/release-v1.0.0-*` | No (local output) |
+
+### Setup
+
+```bash
+# 1. Sync with upstream (see Prerequisites above)
+git fetch upstream && git checkout main && git merge upstream/main
+
+# 2. Initialize specs (Phase 0)
+openspec init  # or mkdir -p openspec/specs openspec/changes
+
+# 3. Create change proposal
+/openspec-proposal
+# Define requirements in openspec/changes/my-skill/specs/
+
+# 4. Get spec approval from human review
+
+# 5. Create feature branch for development
+git checkout -b feature/my-skill main
+
+# 6. Implement (tests guide you)
+/openspec-apply
+git add .
+git commit -m "wip: initial skill structure"
+git commit -m "feat: add core workflow"
+# ... many commits OK during development
+```
+
+### Pre-Release
+
+```bash
+# 7. Archive specs (merge deltas to specs/, update CHANGELOG)
+/openspec-archive
+
+# 8. Create RELEASE-v1.0.0.md with file inventory
+# See templates/RELEASE-vX.Y.Z.md
+
+# 9. Run tests with release flag
+bun test all --release v1.0.0
+# Creates: output/release-v1.0.0-2025-12-12-14-30-00/
+
+# 10. Complete pre-release checklist
+# All boxes checked in RELEASE-v1.0.0.md
+
+# 11. Verify CHANGELOG.md is updated (done by /openspec-archive)
+```
+
+### Tag (After Checklist Approved)
+
+```bash
+# 7. Create annotated tag on feature branch
+git tag -a v1.0.0 -m "Release v1.0.0: My Skill
+
+- Feature 1
+- Feature 2
+
+Test run: release-v1.0.0-2025-12-12-14-30-00"
+
+# 8. Push tag to private repo (NEVER to fork)
+git push origin v1.0.0
+```
+
+### Contribution
+
+```bash
+# 9. Sync with upstream
+git fetch upstream
+
+# 10. Create fresh contrib branch from upstream
+git checkout -b contrib-my-skill-v1.0.0 upstream/main
+
+# 11. Cherry-pick FROM TAG (not feature branch!)
+git checkout v1.0.0 -- \
+    .claude/skills/MySkill/ \
+    bin/my-cli/ \
+    .claude/.env.example
+
+# 12. Remove excluded files
+rm -rf bin/my-cli/test/ \
+       .claude/skills/MySkill/RELEASE-v1.0.0.md
+
+# 13. Run sanitization
+./scripts/sanitize-for-contrib.sh
+
+# 14. Review diff
+git diff --name-only upstream/main
+
+# 15. Commit with clean message
+git add -A
+git commit -m "feat(my-skill): Add MySkill for [purpose]
+
+- Feature 1
+- Feature 2
+
+Implements CLI-First architecture."
+
+# 16. Push to origin for verification
+git push origin contrib-my-skill-v1.0.0
+
+# 17. After verification, push to fork (EXPLICIT APPROVAL REQUIRED)
+git push fork contrib-my-skill-v1.0.0
+
+# 18. Create PR
+gh pr create \
+  --repo danielmiessler/Personal_AI_Infrastructure \
+  --head your-username:contrib-my-skill-v1.0.0 \
+  --base main \
+  --title "feat(my-skill): Add MySkill" \
+  --body-file PR_DESCRIPTION.md
+```
+
+### If PR Needs Changes
+
+```bash
+# Fix on feature branch
+git checkout feature/my-skill
+# Make fixes...
+
+# Run tests with incremented version
+bun test all --release v1.0.1
+
+# Tag new version
+git tag -a v1.0.1 -m "Release v1.0.1: Address PR feedback"
+git push origin v1.0.1
+
+# Update contrib branch from new tag
+git checkout contrib-my-skill-v1.0.0
+git checkout v1.0.1 -- .claude/skills/MySkill/ bin/my-cli/
+git commit -m "fix: Address PR feedback"
+git push fork contrib-my-skill-v1.0.0
+```
+
+---
+
+## Development Checklist
+
+### Phase 0: Spec Setup
+
+- [ ] Sync with upstream: `git fetch upstream && git merge upstream/main`
+- [ ] Initialize OpenSpec: `openspec init`
+- [ ] Create proposal: `/openspec-proposal`
+- [ ] Define requirements (SHALL/MUST language)
+- [ ] Get spec approval from human review
+
+### Phase 1: Test Setup
+
+- [ ] Write tests that validate spec requirements
+- [ ] Verify tests fail (no implementation yet)
+
+### Phase 2: Implementation
+
+- [ ] Create feature branch: `git checkout -b feature/[name]`
+- [ ] Implement: `/openspec-apply`
+- [ ] Run tests frequently
+- [ ] Commit freely (feature branch can be messy)
+
+### Phase 3: Pre-Release
+
+- [ ] Archive specs: `/openspec-archive`
+- [ ] Verify CHANGELOG.md updated
+- [ ] Ensure all tests pass
+
+### Before Release (Standard)
+
+- [ ] Push feature branch
+- [ ] Create PR with description
+- [ ] Squash merge after approval
+
+### Before Release (PAI Contribution)
+
+- [ ] Create RELEASE-vX.Y.Z.md with file inventory
+- [ ] Run tests with `--release` flag
+- [ ] Complete pre-release checklist
+- [ ] Create tag after checklist approved
+- [ ] Cherry-pick from tag to contrib branch
+- [ ] Run sanitization
+- [ ] Push to fork (explicit approval)
+- [ ] Create PR
+
+---
+
+## Common Patterns
+
+### Pattern: Syncing with Upstream
+
+```bash
+# Keep your fork updated
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+
+# Rebase feature branch if needed
+git checkout feature/my-skill
+git rebase main
+```
+
+### Pattern: Multiple Features in Parallel
+
+```bash
+# Each feature gets its own branch
+git checkout -b feature/feature-a main
+git checkout -b feature/feature-b main
+
+# Each release gets its own tag and contrib branch
+# feature-a → v1.0.0 → contrib-feature-a-v1.0.0
+# feature-b → v1.1.0 → contrib-feature-b-v1.1.0
+```
+
+### Pattern: Hotfix After Release
+
+```bash
+# Fix on feature branch
+git checkout feature/my-skill
+# Apply fix...
+
+# Increment patch version
+git tag -a v1.0.1 -m "Hotfix: Critical bug"
+git push origin v1.0.1
+
+# Cherry-pick fix to contrib branch
+git checkout contrib-my-skill-v1.0.0
+git checkout v1.0.1 -- path/to/fixed/file.ts
+git commit -m "fix: Critical bug"
+git push fork contrib-my-skill-v1.0.0
+```
+
+---
+
+## Related Workflows
+
+- **ProposeChange.md** - For significant changes, create proposal first
+- **Release.md** - Detailed release checklist and workflows
+- **ValidateSpec.md** - Verify implementation meets spec

--- a/.claude/skills/SpecFirst/workflows/ProposeChange.md
+++ b/.claude/skills/SpecFirst/workflows/ProposeChange.md
@@ -1,0 +1,186 @@
+# ProposeChange Workflow
+
+**Purpose:** Create a change proposal before implementing significant changes. Aligns intent between human and AI before code is written.
+
+---
+
+## When to Use
+
+- Adding new features
+- Modifying existing behavior
+- Fixing bugs with multiple affected areas
+- Any change touching more than 2-3 files
+
+**Skip for:** Typo fixes, single-line changes, documentation updates
+
+---
+
+## The Core Pattern
+
+```
+1. SPECIFY  →  Define what the system SHALL do
+2. TEST     →  Write tests that validate the spec
+3. IMPLEMENT →  Code that makes tests pass
+4. VALIDATE  →  Confirm tests pass, update docs
+```
+
+---
+
+## Proposal Format
+
+Create a proposal document (can be temporary or in `changes/` directory):
+
+```markdown
+# Change Proposal: [Feature Name]
+
+## Summary
+One sentence: what are we changing and why?
+
+## Requirements
+
+### Requirement: [Descriptive Name]
+The system SHALL [behavior].
+
+#### Scenario: [Use case]
+- **WHEN** [trigger/condition]
+- **THEN** [expected outcome]
+- **AND** [additional outcomes]
+
+## Impact
+- **Files affected:** [list]
+- **Breaking changes:** Yes/No
+- **Dependencies:** [any new deps]
+
+## Tasks
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+## Test Plan
+- [ ] TEST-XXX: [description]
+- [ ] TEST-YYY: [description]
+```
+
+---
+
+## Example: --name Flag
+
+**Proposal:**
+```markdown
+# Change Proposal: Filename Override Flag
+
+## Summary
+Implement --name flag for `ingest direct` to allow custom filenames.
+
+## Requirements
+
+### Requirement: Filename Override
+The system SHALL allow users to override generated filenames via --name flag.
+
+#### Scenario: CLI with --name flag
+- **WHEN** user provides `--name "Custom-Name"`
+- **THEN** output filename SHALL use "Custom-Name"
+- **AND** `[name:Custom-Name]` SHALL appear in caption metadata
+
+## Impact
+- **Files affected:** process.ts (3 locations)
+- **Breaking changes:** No (additive)
+- **Dependencies:** None
+
+## Tasks
+- [ ] Add `name?: string` to SourceMetadata interface
+- [ ] Add `case "name":` in metadata extraction switch
+- [ ] Use `sourceMetadata.name` in generateFilename() calls
+
+## Test Plan
+- [ ] TEST-CLI-014: --name flag
+- [ ] TEST-CLI-014a: -n short flag
+- [ ] TEST-CLI-022: all flags combined
+```
+
+---
+
+## Workflow Steps
+
+### 1. Draft Proposal
+
+```bash
+# Create proposal (can be in changes/ or temporary)
+# For OpenSpec users:
+openspec/changes/[feature-name]/proposal.md
+
+# For lightweight approach:
+# Just describe in conversation or create temp file
+```
+
+### 2. Review Requirements
+
+Before implementing, verify:
+- [ ] Requirements are testable (has WHEN/THEN)
+- [ ] Scope is clear (files affected listed)
+- [ ] No ambiguity in expected behavior
+
+### 3. Align with Human
+
+**AI asks:**
+> "Here's my understanding of the change. Does this match your intent?"
+> [Shows proposal summary]
+
+**Human confirms or adjusts**
+
+### 4. Proceed to Implementation
+
+Once aligned:
+- Write tests first (they define the spec)
+- Implement to make tests pass
+- Validate all tests pass
+
+---
+
+## SHALL/MUST Language
+
+Use precise language for testable requirements:
+
+| Word | Meaning |
+|------|---------|
+| **SHALL** | Mandatory requirement |
+| **SHOULD** | Recommended but not required |
+| **MAY** | Optional |
+| **MUST** | Absolute requirement (stronger than SHALL) |
+
+**Good:** "The system SHALL return exit code 0 on success"
+**Bad:** "The system should work correctly"
+
+---
+
+## Lightweight vs Full OpenSpec
+
+### Lightweight (Default)
+- Describe proposal in conversation
+- Use SHALL/MUST language
+- List tasks and tests
+- No special directory structure
+
+### Full OpenSpec
+```
+openspec/
+├── specs/           # Current truth
+└── changes/
+    └── [feature]/
+        ├── proposal.md
+        ├── tasks.md
+        └── specs/   # Delta
+```
+
+**Choose based on:**
+- Team size (solo = lightweight, team = full)
+- Change complexity (simple = lightweight, complex = full)
+- Audit needs (compliance = full, personal = lightweight)
+
+---
+
+## Related Workflows
+
+- **DevelopSkill.md** - Set up branches first
+- **Release.md** - After implementation, prepare release
+- **ValidateSpec.md** - Run validation checks

--- a/.claude/skills/SpecFirst/workflows/Release.md
+++ b/.claude/skills/SpecFirst/workflows/Release.md
@@ -1,0 +1,573 @@
+# Release Workflow
+
+**Purpose:** Strict, controlled release process for deploying skills and changes. More manual than development to prevent data leakage, bloated PRs, and scope creep.
+
+---
+
+## Why Stricter Releases?
+
+AI tools make development easy—and make it easy to:
+- **Leak data:** Personal config, API keys, sensitive fixtures
+- **Bloat deployments:** Debug files, verbose output, tangential changes
+- **Creep scope:** PRs touching far more than intended
+
+**The release process must be more controlled than development.**
+
+Move fast during implementation (tests provide confidence), but **slow down at the release gate**.
+
+---
+
+## Branch & Remote Reference
+
+### Standard Development
+
+| Name | Example | Visibility | Purpose |
+|------|---------|------------|---------|
+| **main** | `main` | Depends | Production branch |
+| **feature** | `feature/add-name-flag` | Private | Your development work |
+
+### PAI Contribution (Fork Pattern)
+
+| Name | Remote | Branch | Visibility | Purpose |
+|------|--------|--------|------------|---------|
+| **upstream** | `upstream` | `main` | PUBLIC | Target repo (read-only) |
+| **origin** | `origin` | `main` | PRIVATE | Your private copy |
+| **feature** | `origin` | `feature/my-skill` | PRIVATE | Development (messy OK) |
+| **contrib** | `origin` | `contrib-my-skill-v1.0.0` | PRIVATE | Clean staging |
+| **fork** | `fork` | `contrib-my-skill-v1.0.0` | PUBLIC | PR source |
+
+**Flow:**
+```
+upstream/main ← fork/contrib ← origin/contrib ← origin/feature
+   (target)      (PR source)     (staging)       (development)
+```
+
+---
+
+## Human Approval Gates
+
+**This process is intentionally manual.** Each gate requires human review before proceeding.
+
+| Gate | What to Review | Approval |
+|------|----------------|----------|
+| **1. File Inventory** | Is scope correct? Any missing/extra files? | ☐ Approved |
+| **2. Test Results** | All tests pass? Any skipped tests justified? | ☐ Approved |
+| **3. Pre-Release Checklist** | All boxes checked? | ☐ Approved |
+| **4. Tag Creation** | Ready to mark this as tested release? | ☐ Approved |
+| **5. Cherry-Pick Review** | Staged files match inventory exactly? | ☐ Approved |
+| **6. Sanitization** | No secrets, PII, or personal data? | ☐ Approved |
+| **7. Push to Fork** | Ready to make this public? | ☐ Approved |
+| **8. Create PR** | Description accurate? Ready for upstream? | ☐ Approved |
+
+**Never skip gates.** AI can assist with each step, but human approves before moving to next.
+
+---
+
+## Versioning & Test Run Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    VERSION LIFECYCLE                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  1. RELEASE-v1.0.0.md        ← Define scope, file inventory     │
+│         │                                                        │
+│         ▼                                                        │
+│  2. Test run --release v1.0.0                                   │
+│     └── output/release-v1.0.0-2025-12-12-14-30-00/              │
+│         │                                                        │
+│         ▼                                                        │
+│  3. CHANGELOG.md             ← Move [Unreleased] → [v1.0.0]     │
+│         │                                                        │
+│         ▼                                                        │
+│  4. git tag v1.0.0           ← Marks EXACT code that was tested │
+│         │                                                        │
+│         ▼                                                        │
+│  5. Cherry-pick FROM TAG     ← Ensures PR = tested code         │
+│         │                                                        │
+│         ▼                                                        │
+│  6. PR created                                                   │
+│                                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│  IF PR NEEDS CHANGES:                                           │
+│     → Fix on feature branch                                     │
+│     → Test run --release v1.0.1                                 │
+│     → Tag v1.0.1                                                │
+│     → Cherry-pick from v1.0.1                                   │
+│     → Push to contrib branch                                    │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Principle: Tag = Tested Code
+
+- **Tag AFTER** tests pass, checklist complete
+- **Tag BEFORE** creating PR
+- **Cherry-pick FROM TAG** (not feature branch)
+- Test run ID matches tag: `release-v1.0.0-*` → `v1.0.0`
+
+This ensures the PR contains EXACTLY what was tested—no more, no less.
+
+---
+
+## Pre-Release Checklist
+
+Before ANY release, complete this checklist:
+
+### 1. File Inventory
+- [ ] **Explicit include list:** What files are part of this release?
+- [ ] **Explicit exclude list:** What files must NOT be released?
+- [ ] **No new untracked files** that shouldn't be included
+
+### 2. Sanitization
+- [ ] **No PII:** Personal paths, usernames, email addresses
+- [ ] **No secrets:** API keys, tokens, passwords
+- [ ] **No sensitive fixtures:** Real user data, captured messages
+- [ ] **Config externalized:** Paths/tokens in `.env`, not hardcoded
+
+### 3. Scope Check
+- [ ] **PR matches proposal:** Only changes from the original proposal
+- [ ] **No drive-by fixes:** Unrelated changes go in separate PRs
+- [ ] **Commit history clean:** Squash if needed
+
+### 4. Validation
+- [ ] **Tests pass:** All layers (unit, integration, CLI, acceptance)
+- [ ] **Spec compliance:** Implementation matches requirements
+- [ ] **Documentation updated:** README, CHANGELOG, help text
+
+---
+
+## Release Plan Template
+
+For each release, create a RELEASE-vX.Y.Z.md file:
+
+```markdown
+# RELEASE-v1.0.0
+
+## Summary
+One sentence describing what this release delivers.
+
+## File Inventory
+
+### Included
+- `.claude/skills/MySkill/SKILL.md`
+- `.claude/skills/MySkill/workflows/DoSomething.md`
+- `bin/my-cli/my-cli.ts`
+
+### Excluded (never release)
+- `.env`
+- `config/personal.json`
+- `test/fixtures/` (if contains real data)
+
+## Pre-Release Checklist
+- [ ] Files match inventory
+- [ ] No PII in any file
+- [ ] No hardcoded secrets
+- [ ] Tests pass
+- [ ] Documentation current
+
+## Test Results
+| Layer | Status | Notes |
+|-------|--------|-------|
+| Unit | PASS | 12/12 |
+| Integration | PASS | 8/8 |
+| CLI | PASS | 43/43 |
+| Acceptance | PASS | 5/5 |
+
+## PR Description
+[Draft PR description for GitHub]
+```
+
+---
+
+## File Inventory as Release Guide
+
+**The RELEASE-vX.Y.Z.md file inventory is the source of truth for what goes into a release.**
+
+```
+RELEASE-v1.0.0.md                    Git Operations
+─────────────────────────────────────────────────────────────
+### Included                    →    These files get staged
+  - .claude/skills/MySkill/         git add .claude/skills/MySkill/
+  - bin/my-cli/                     git add bin/my-cli/
+  - CHANGELOG.md                    git add CHANGELOG.md
+
+### Excluded                    →    These files are NOT staged
+  - .env                            (in .gitignore)
+  - config/personal.json            git reset config/personal.json
+  - test/fixtures/                  (in .gitignore or reset)
+```
+
+### Why This Matters
+
+1. **Prevents scope creep:** Only files in the inventory get released
+2. **Prevents data leakage:** Excluded files are explicitly blocked
+3. **Creates audit trail:** The release plan documents exactly what was shipped
+4. **Enables selective commits:** You can cherry-pick specific files instead of everything
+
+### Verification Commands
+
+```bash
+# Before committing, verify ONLY inventory files are staged:
+git diff --name-only main | sort > /tmp/actual-files.txt
+
+# Compare against your RELEASE-vX.Y.Z.md include list
+# Any file NOT in the inventory should be reset or gitignored
+
+# If unwanted files appear:
+git reset path/to/unwanted-file.ts
+git checkout -- path/to/unwanted-file.ts
+```
+
+---
+
+## Release Workflows
+
+Choose the workflow that fits your situation:
+
+| Workflow | When to Use |
+|----------|-------------|
+| **Standard Feature Branch** | Most projects - simple PR to main |
+| **Fork Contribution** | Contributing to someone else's repo (e.g., PAI upstream) |
+
+The **pre-release checklist and file inventory apply to ALL workflows**.
+
+---
+
+### Standard Feature Branch (Most Common)
+
+For typical development: feature branch → PR → main.
+
+```bash
+# 1. Create release plan with file inventory
+# Create RELEASE-vX.Y.Z.md (can be brief for small changes)
+
+# 2. Ensure feature branch is ready
+git checkout feature/my-feature
+git status  # Verify clean state
+
+# 3. Run pre-release checklist
+# - Tests pass
+# - No secrets/PII
+# - Scope matches proposal
+
+# 4. Push feature branch
+git push origin feature/my-feature
+
+# 5. Create PR
+gh pr create \
+  --base main \
+  --title "feat: Add my feature" \
+  --body "## Summary
+[Description]
+
+## Test Plan
+- [x] Unit tests pass
+- [x] Integration tests pass"
+
+# 6. After review, merge (squash recommended for clean history)
+gh pr merge --squash
+```
+
+**Key points:**
+- Feature branch from `main`, PR back to `main`
+- Squash merge keeps history clean
+- File inventory still guides what's in the PR
+
+---
+
+### Fork Contribution (Open Source / PAI)
+
+For contributing to upstream repos where you have a fork.
+
+**Especially important for PAI:** Your personal AI is entangled with personal data, config, and paths. The contrib branch is a **sanitization gate** that forces you to explicitly select what gets contributed via the file inventory.
+
+```
+feature-branch  →  TAG  →  contrib-branch  →  fork  →  upstream/main
+ (private dev)    (marks    (cherry-pick      (public)   (target)
+  with personal    tested    from TAG)
+  config mixed)    code)
+```
+
+**Why contrib branch matters for PAI:**
+- Your working copy has `.env`, personal paths, real API keys
+- Feature branch may have dozens of commits, debug changes, personal config
+- Contrib branch: fresh from upstream, only file-inventory items cherry-picked FROM TAG
+- Forces you to untangle contribution from personal data
+
+---
+
+#### Step-by-Step with Approval Gates
+
+Each step requires **human approval** before proceeding to the next.
+
+**PHASE 1: PRE-RELEASE (on feature branch)**
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 1: Create release plan with file inventory
+# ══════════════════════════════════════════════════════════════
+# Create RELEASE-v1.0.0.md listing every file to include/exclude
+```
+☐ **GATE 1: File inventory approved?** Review scope before proceeding.
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 2: Run tests with release flag
+# ══════════════════════════════════════════════════════════════
+git checkout feature/my-feature
+bun test all --release v1.0.0
+# Creates: output/release-v1.0.0-YYYY-MM-DD-HH-MM-SS/
+```
+☐ **GATE 2: Tests pass?** All tests must pass before proceeding.
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 3: Complete pre-release checklist
+# ══════════════════════════════════════════════════════════════
+# Go through RELEASE-v1.0.0.md checklist manually
+# Update CHANGELOG.md: Move [Unreleased] → [v1.0.0] - DATE
+```
+☐ **GATE 3: Checklist complete?** All boxes checked before proceeding.
+
+**PHASE 2: TAG (marks tested code)**
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 4: Create tag on feature branch
+# ══════════════════════════════════════════════════════════════
+git tag -a v1.0.0 -m "Release v1.0.0: [description]
+
+Test run: release-v1.0.0-YYYY-MM-DD-HH-MM-SS"
+
+git push origin v1.0.0  # Push to PRIVATE repo only!
+```
+☐ **GATE 4: Tag created?** This marks the exact code that was tested.
+
+**PHASE 3: CONTRIBUTION (cherry-pick from tag)**
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 5: Create contrib branch from upstream
+# ══════════════════════════════════════════════════════════════
+git fetch upstream
+git checkout -b contrib-my-feature-v1.0.0 upstream/main
+```
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 6: Cherry-pick FROM TAG (not feature branch!)
+# ══════════════════════════════════════════════════════════════
+# The RELEASE-v1.0.0.md file inventory IS your cherry-pick specification.
+#
+# Example from RELEASE-v1.0.0.md:
+# | # | File                              | Include | Reason              |
+# |---|-----------------------------------|---------|---------------------|
+# | 1 | .claude/skills/MySkill/SKILL.md   | ✅      | Skill definition    |
+# | 2 | .claude/skills/MySkill/workflows/ | ✅      | Workflows           |
+# | 3 | bin/my-cli/                       | ✅      | CLI implementation  |
+# | - | bin/my-cli/test/                  | ❌      | Contains fixtures   |
+# | - | .env                              | ❌      | Contains secrets    |
+#
+# Cherry-pick ONLY the ✅ Include files:
+git checkout v1.0.0 -- \
+    .claude/skills/MySkill/ \
+    bin/my-cli/ \
+    .claude/.env.example
+
+# Remove any ❌ Exclude files that got pulled in:
+rm -rf bin/my-cli/test/ \
+       .claude/skills/MySkill/RELEASE-v1.0.0.md
+```
+
+**The file inventory is the release specification.** Every ✅ becomes a cherry-pick path. Every ❌ gets removed if accidentally included.
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 7: Verify staged files match inventory EXACTLY
+# ══════════════════════════════════════════════════════════════
+git diff --name-only upstream/main | sort
+
+# Compare this output against your RELEASE-v1.0.0.md include list
+# If ANY file is not in inventory: git checkout upstream/main -- path/to/file
+```
+☐ **GATE 5: Staged files match inventory?** No extra files, no missing files.
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 8: Run sanitization check
+# ══════════════════════════════════════════════════════════════
+./scripts/sanitize-for-contrib.sh
+
+# Or manually:
+grep -r "API_KEY\|TOKEN\|PASSWORD" --include="*.ts"
+grep -r "/Users/\|/home/" --include="*.ts" --include="*.md"
+```
+☐ **GATE 6: Sanitization passes?** No secrets, no personal paths.
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 9: Commit with clean message
+# ══════════════════════════════════════════════════════════════
+git add -A
+git commit -m "feat(my-skill): Add MySkill for [purpose]
+
+- Feature 1
+- Feature 2
+
+Implements CLI-First architecture."
+```
+
+**PHASE 4: PUBLISH (make public)**
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 10: Push to fork (THIS MAKES IT PUBLIC!)
+# ══════════════════════════════════════════════════════════════
+git push fork contrib-my-feature-v1.0.0
+```
+☐ **GATE 7: Ready to make public?** Once pushed to fork, it's visible.
+
+```bash
+# ══════════════════════════════════════════════════════════════
+# STEP 11: Create PR to upstream
+# ══════════════════════════════════════════════════════════════
+gh pr create \
+  --repo upstream-owner/repo \
+  --head your-username:contrib-my-feature-v1.0.0 \
+  --base main \
+  --title "feat(my-skill): Add MySkill" \
+  --body-file PR_DESCRIPTION.md
+```
+☐ **GATE 8: PR created?** Review PR description before submitting.
+
+---
+
+#### If PR Needs Changes
+
+```bash
+# Fix on feature branch (NOT contrib branch)
+git checkout feature/my-feature
+# Make fixes...
+
+# Increment version and re-test
+bun test all --release v1.0.1
+git tag -a v1.0.1 -m "Release v1.0.1: Address PR feedback"
+git push origin v1.0.1
+
+# Update contrib branch from NEW tag
+git checkout contrib-my-feature-v1.0.0
+git checkout v1.0.1 -- .claude/skills/MySkill/ bin/my-cli/
+git commit -m "fix: Address PR feedback"
+git push fork contrib-my-feature-v1.0.0
+```
+
+---
+
+#### Why This Flow?
+
+| Step | Why It Matters |
+|------|----------------|
+| **Tag before contrib** | Marks exact tested code; PR matches test run |
+| **Cherry-pick from TAG** | Not from feature branch (may have new commits) |
+| **Contrib branch** | Fresh from upstream, clean diff |
+| **Single commit = squash** | 50 messy commits become 1 clean commit |
+| **File inventory** | Explicit control over what's included |
+| **Human gates** | Prevents accidental data leaks |
+
+#### Where's the Squash?
+
+The squash happens **implicitly** through the file inventory:
+
+```
+RELEASE-v1.0.0.md (specification):
+  | File                    | Include |
+  |-------------------------|---------|
+  | .claude/skills/MySkill/ | ✅      |
+  | bin/my-cli/             | ✅      |
+  | bin/my-cli/test/        | ❌      |
+  | .env                    | ❌      |
+            │
+            ▼
+Feature branch:              Contrib branch:
+  50 commits                   ↓
+  "wip", "debug"               ↓  git checkout v1.0.0 -- [✅ files only]
+  "fix typo", "revert"         ↓  git commit -m "feat: Add feature"
+  TAG: v1.0.0          ────────→  ONE CLEAN COMMIT
+```
+
+- **File inventory** = what gets cherry-picked (✅ Include only)
+- **Feature branch** = 50 messy commits
+- **Contrib branch** = 1 clean commit with only inventory files
+
+**The release specification drives everything:** what to test, what to tag, what to cherry-pick, what ends up in the PR.
+
+---
+
+## Sanitization Checks
+
+### Manual Checks
+
+```bash
+# Search for common secrets patterns
+grep -r "API_KEY\|api_key\|TOKEN\|token\|PASSWORD" --include="*.ts" --include="*.md"
+
+# Search for personal paths
+grep -r "/Users/\|/home/" --include="*.ts" --include="*.md"
+
+# List all files that would be committed
+git diff --name-only main
+
+# Check for large files (might be fixtures)
+find . -type f -size +100k
+```
+
+### Automated Script (Example)
+
+```bash
+#!/bin/bash
+# sanitize-for-contrib.sh
+
+echo "Checking for secrets..."
+if grep -rq "API_KEY\|TELEGRAM_BOT_TOKEN" --include="*.ts"; then
+  echo "ERROR: Found potential secrets"
+  exit 1
+fi
+
+echo "Checking for personal paths..."
+if grep -rq "/Users/[a-z]" --include="*.ts" --include="*.md"; then
+  echo "ERROR: Found personal paths"
+  exit 1
+fi
+
+echo "Sanitization check passed"
+```
+
+---
+
+## Common Release Mistakes
+
+| Mistake | Prevention |
+|---------|------------|
+| Committing `.env` | Add to `.gitignore`, check `git status` |
+| Personal paths in code | Use environment variables |
+| Real test fixtures | Design fixtures to be synthetic |
+| Scope creep in PR | Stick to file inventory |
+| Skipping tests | Require passing tests before release |
+
+---
+
+## Real Example
+
+See the Context Skill PR #183 for a complete example:
+- **RELEASE-FRAMEWORK.md**: `.claude/skills/Context/RELEASE-FRAMEWORK.md`
+- **RELEASE-v1.0.0.md**: `.claude/skills/Context/RELEASE-v1.0.0.md`
+- **CHANGELOG.md**: `.claude/skills/Context/CHANGELOG.md`
+
+---
+
+## Related Workflows
+
+- **DevelopSkill.md** - Branch setup before development
+- **ProposeChange.md** - Define scope before implementing
+- **ValidateSpec.md** - Run validation before release

--- a/.claude/skills/SpecFirst/workflows/ValidateSpec.md
+++ b/.claude/skills/SpecFirst/workflows/ValidateSpec.md
@@ -1,0 +1,220 @@
+# ValidateSpec Workflow
+
+**Purpose:** Validate that implementation matches specifications. Run tests, check compliance, ensure quality gates pass.
+
+---
+
+## The 4-Layer Test Pyramid
+
+```
+                    ┌─────────────────┐
+                    │   ACCEPTANCE    │  ← User outcomes (slow, few)
+                    │    (Layer 4)    │
+                ┌───┴─────────────────┴───┐
+                │         CLI            │  ← Command contracts (medium)
+                │       (Layer 3)        │
+            ┌───┴─────────────────────────┴───┐
+            │         INTEGRATION            │  ← Component interaction
+            │           (Layer 2)            │
+        ┌───┴─────────────────────────────────┴───┐
+        │              UNIT                      │  ← Function behavior (fast, many)
+        │            (Layer 1)                   │
+        └─────────────────────────────────────────┘
+```
+
+| Layer | What It Tests | Speed | Quantity |
+|-------|---------------|-------|----------|
+| **Unit** | Individual functions | Fast | Many |
+| **Integration** | Components working together | Medium | Some |
+| **CLI** | Command-line contracts | Medium | Some |
+| **Acceptance** | End-to-end user outcomes | Slow | Few |
+
+---
+
+## Running Validation
+
+### Quick Validation (Development)
+
+```bash
+# Run unit tests only (fast feedback)
+bun test unit
+
+# Run specific test
+bun test --grep "TEST-CLI-014"
+```
+
+### Full Validation (Pre-Release)
+
+```bash
+# Run all test layers
+bun test all
+
+# Or layer by layer
+bun test unit        # ~seconds
+bun test integration # ~minutes
+bun test cli         # ~minutes
+bun test acceptance  # ~minutes
+```
+
+---
+
+## Spec → Test Traceability
+
+Every requirement should map to a test:
+
+```
+SPECIFICATION                         TEST
+────────────────────────────────────────────────────────────────
+### Requirement: --name flag    →    TEST-CLI-014
+  #### Scenario: CLI usage      →    command: ingest direct --name "X"
+  - THEN filename SHALL use     →    expected.contains: ["[name:X]"]
+```
+
+### Test Naming Convention
+
+```
+TEST-[LAYER]-[NUMBER]: [Description]
+
+Examples:
+- TEST-UNIT-001: extractMetadata parses tags
+- TEST-INT-005: processMessage creates vault file
+- TEST-CLI-014: --name flag overrides filename
+- TEST-ACC-001: Full ingest workflow creates note
+```
+
+---
+
+## Validation Checklist
+
+### Before Marking Complete
+
+- [ ] All tests pass
+- [ ] New features have tests
+- [ ] Test coverage adequate for the change
+- [ ] No skipped tests without reason
+
+### Spec Compliance
+
+For each requirement in the proposal:
+
+| Requirement | Test | Status |
+|-------------|------|--------|
+| Filename override | TEST-CLI-014 | PASS |
+| Short flag -n | TEST-CLI-014a | PASS |
+| Combined flags | TEST-CLI-022 | PASS |
+
+---
+
+## Test File Structure
+
+### Separating Framework from Specs
+
+```
+pai-tooling/                      ← Test infrastructure repo
+├── framework/                    ← PUBLIC: Reusable runners
+│   ├── cli-runner.ts
+│   ├── integration-runner.ts
+│   └── types.ts
+├── [skill]-test/
+│   ├── specs/                    ← PUBLIC: Test definitions
+│   │   ├── cli-direct.spec.ts
+│   │   └── scope.spec.ts
+│   ├── fixtures/                 ← PRIVATE: Test data (gitignored)
+│   └── output/                   ← Test results
+└── config/                       ← PRIVATE: Personal config (gitignored)
+```
+
+### What's Sensitive?
+
+| Component | Sensitive? | Recommendation |
+|-----------|------------|----------------|
+| `framework/` | No | Public npm package |
+| `specs/` | No | Part of contribution |
+| `fixtures/` | Should be No | Use synthetic data |
+| `config/` | Yes | `.env` file only |
+
+---
+
+## Writing Test Specs
+
+### CLI Test Example
+
+```typescript
+// specs/cli-direct.spec.ts
+export const directCLITestSpecs: CLITestSpec[] = [
+  {
+    id: "TEST-CLI-014",
+    name: "Direct with --name flag",
+    description: "Verify --name flag adds [name:...] metadata",
+    command: 'echo "test" | bun run ingest.ts direct --name "Custom" --dry-run',
+    expected: {
+      contains: ["[name:Custom]", "DRY RUN"],
+      exitCode: 0,
+    },
+  },
+];
+```
+
+### Unit Test Example
+
+```typescript
+// unit/extractMetadata.test.ts
+import { describe, it, expect } from "bun:test";
+import { extractMetadata } from "../lib/process";
+
+describe("extractMetadata", () => {
+  it("extracts name from caption", () => {
+    const result = extractMetadata("[name:Custom] Some content");
+    expect(result.name).toBe("Custom");
+  });
+});
+```
+
+---
+
+## Handling Test Failures
+
+### Failure During Development
+
+1. Read the failure message
+2. Check if spec changed (update test) or bug (fix code)
+3. Fix and re-run
+
+### Failure Pre-Release
+
+**DO NOT release with failing tests.**
+
+Options:
+- Fix the issue
+- Remove the feature (and its test)
+- Document known issue and skip test (last resort)
+
+---
+
+## LLM-Judge Evaluation (Advanced)
+
+For subjective quality checks, use LLM evaluation:
+
+```typescript
+// framework/llm-judge.ts
+export async function evaluateOutput(
+  output: string,
+  criteria: string[]
+): Promise<JudgeResult> {
+  // Use Claude to evaluate output against criteria
+  // Returns: pass/fail with reasoning
+}
+```
+
+**Use cases:**
+- "Does this note have good formatting?"
+- "Is the title descriptive?"
+- "Does the content match the intent?"
+
+---
+
+## Related Workflows
+
+- **ProposeChange.md** - Define specs before testing
+- **Release.md** - Run validation before release
+- **DevelopSkill.md** - Set up test infrastructure


### PR DESCRIPTION
## Summary

**TL;DR:** Spec-driven development methodology for Claude Code - define requirements before implementation.

### Why This Matters

From PAI's founding principles:
- **#5 Spec/Test/Evals First**: "If you can't specify it, you can't test it. If you can't test it, you can't trust it."
- **CLI-First**: Slash commands provide the interface (`/openspec-proposal`, `/openspec-apply`, `/openspec-archive`)
- **Skills as Containers**: Self-contained with workflows, templates, and documentation

### How You Use It

```
You: "I want to develop a JIRA skill"

Claude: I'll help you develop a JIRA skill using spec-first methodology.

/openspec-proposal

[Creates proposal.md, tasks.md, specs/jira-skill.md]

Here's my proposal. Please review:
- Does this match your intent?
- Ready to implement, or need changes?
```

### How It Works

```
┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
│  /openspec-     │ ──► │  /openspec-     │ ──► │  /openspec-     │
│   proposal      │     │    apply        │     │   archive       │
│                 │     │                 │     │                 │
│ Define specs    │     │ Implement from  │     │ Merge specs,    │
│ Wait for review │     │ specs + tests   │     │ update CHANGELOG│
└─────────────────┘     └─────────────────┘     └─────────────────┘
```

### Validation

**Dogfooding:** The Jira skill (PR #190) was built entirely using this methodology, demonstrating the complete workflow works.

---

## What This Adds

### Slash Commands (`.claude/commands/`)
| Command | Purpose |
|---------|---------|
| `/openspec-proposal` | Create change proposal with specs |
| `/openspec-apply` | Implement from approved specs |
| `/openspec-archive` | Archive completed changes |

### Skill Definition (`.claude/skills/SpecFirst/`)
- `SKILL.md` - Entry point and routing
- `workflows/` - Develop, Release, ProposeChange, ValidateSpec
- `docs/` - Approaches, TestPyramid, ToolingArchitecture, WorkedExample
- `templates/` - Reusable templates for releases and specs

---

## Test Plan

- [x] Skill routing recognized
- [x] /openspec-proposal creates correct structure
- [x] /openspec-apply implements from specs
- [x] /openspec-archive merges correctly
- [x] Dogfooded via Jira skill development (PR #190)

---

## Related

- **Jira Skill:** PR #190 - Built using SpecFirst methodology (validates this works end-to-end)