### PR TITLE
feat(jira): Add Jira skill with Filters API, Quick Filters, and Ordering

### DIFF
--- a/.claude/skills/Jira/ACCEPTANCE_TESTS.md
+++ b/.claude/skills/Jira/ACCEPTANCE_TESTS.md
@@ -1,0 +1,301 @@
+# Jira Skill Acceptance Tests
+
+Manual acceptance tests to verify the Jira skill works correctly.
+
+## Prerequisites
+
+1. **Profile configured:**
+   - Copy `bin/jira/profiles.example/example.env.template` to `bin/jira/profiles/personal.env`
+   - Fill in your Jira credentials
+   - Create symlink: `ln -sf personal.env profiles/default`
+
+2. **CLI accessible:**
+   - Wrapper script exists: `~/bin/jira`
+   - Run `jira --help` to verify
+
+---
+
+## Test 1: CLI Help
+
+**Command:**
+```bash
+jira --help
+```
+
+**Expected:** Shows all available commands (search, get, create, update, etc.)
+
+**Success Criteria:**
+- ✅ Help text displays
+- ✅ All commands listed
+- ✅ Exit code 0
+
+---
+
+## Test 2: Profile Listing
+
+**Command:**
+```bash
+jira profiles
+```
+
+**Expected:** Lists available profiles with default indicator.
+
+**Success Criteria:**
+- ✅ Profiles displayed
+- ✅ Default profile marked
+- ✅ Shows Jira URL for each
+
+---
+
+## Test 3: Search Issues
+
+**Command:**
+```bash
+jira search "test" --limit 5
+```
+
+**Expected:** Returns table of matching issues.
+
+**Success Criteria:**
+- ✅ Table displays with columns: #, Key, Type, Summary, Status, Assignee
+- ✅ Results limited to 5
+- ✅ Prompt shows: "Which to load?"
+
+---
+
+## Test 4: Search with JQL
+
+**Command:**
+```bash
+jira search "project = PROJ AND status = 'In Progress'"
+```
+
+**Expected:** Returns issues matching JQL query.
+
+**Success Criteria:**
+- ✅ JQL detected and used directly
+- ✅ Results filtered correctly
+
+---
+
+## Test 5: Get Issue Details
+
+**Command:**
+```bash
+jira get PROJ-123
+```
+
+**Expected:** Returns full issue details.
+
+**Success Criteria:**
+- ✅ Key, Type, Status, Summary displayed
+- ✅ Description shown
+- ✅ Assignee/Reporter shown
+- ✅ Labels displayed
+- ✅ Links shown (if any)
+
+---
+
+## Test 6: List Projects
+
+**Command:**
+```bash
+jira projects
+```
+
+**Expected:** Lists accessible projects.
+
+**Success Criteria:**
+- ✅ Project keys displayed
+- ✅ Project names displayed
+- ✅ Default project marked (if set)
+
+---
+
+## Test 7: List Issue Types
+
+**Command:**
+```bash
+jira types --project PROJ
+```
+
+**Expected:** Lists available issue types for project.
+
+**Success Criteria:**
+- ✅ Types listed (Bug, Story, Task, Epic, Sub-task, etc.)
+
+---
+
+## Test 8: List Transitions
+
+**Command:**
+```bash
+jira transitions PROJ-123
+```
+
+**Expected:** Lists available status transitions.
+
+**Success Criteria:**
+- ✅ Available transitions shown
+- ✅ Target status for each
+
+---
+
+## Test 9: Cross-Instance Search
+
+**Command:**
+```bash
+jira search "test" -p all
+```
+
+**Expected:** Searches all configured profiles in parallel.
+
+**Success Criteria:**
+- ✅ Results from all instances
+- ✅ Instance indicator column shows source
+- ✅ Handles missing/offline instances gracefully
+
+---
+
+## Test 10: GitHub Dev Integration
+
+**Command:**
+```bash
+jira dev PROJ-123
+```
+
+**Expected:** Shows linked branches, commits, PRs.
+
+**Success Criteria:**
+- ✅ Branches listed (if any)
+- ✅ Pull requests listed (if any)
+- ✅ Commit count shown
+- ✅ Graceful handling when no dev info
+
+---
+
+## Test 11: Label Operations
+
+**Commands:**
+```bash
+jira labels                      # List all labels
+jira search --label urgent       # Search by label
+```
+
+**Expected:** Labels listed and searchable.
+
+**Success Criteria:**
+- ✅ Labels displayed
+- ✅ Search filters by label correctly
+
+---
+
+## Test 12: Link Types
+
+**Command:**
+```bash
+jira link-types
+```
+
+**Expected:** Lists available link types.
+
+**Success Criteria:**
+- ✅ Link types displayed (blocks, is blocked by, relates to, etc.)
+- ✅ Inward/outward names shown
+
+---
+
+## Skill Routing Tests
+
+### SKILL-001: Search Recognition
+
+**User Query:**
+```
+"search jira for authentication bugs"
+```
+
+**Expected Claude Behavior:**
+- Recognizes Jira skill activation
+- Executes: `jira search "authentication bugs"`
+- Shows table and waits for selection
+
+---
+
+### SKILL-002: Two-Phase Enforcement
+
+**User Query:**
+```
+"what issues are in project PROJ"
+```
+
+**Expected Claude Behavior:**
+- Executes search: `jira search --project PROJ`
+- Shows results table
+- **WAITS** for user to select items
+- Does NOT auto-load details
+
+---
+
+### SKILL-003: Instance Routing
+
+**User Query:**
+```
+"search work jira for deployment issues"
+```
+
+**Expected Claude Behavior:**
+- Recognizes "work jira" → `-p work`
+- Executes: `jira search "deployment issues" -p work`
+
+---
+
+## Error Handling Tests
+
+### ERR-001: Invalid Profile
+
+**Command:**
+```bash
+jira search "test" -p nonexistent
+```
+
+**Expected:** Clear error message about missing profile.
+
+---
+
+### ERR-002: Network Error
+
+**Test:** Disconnect network, run command.
+
+**Expected:** Graceful timeout with clear error message.
+
+---
+
+### ERR-003: Invalid Credentials
+
+**Test:** Use wrong API token.
+
+**Expected:** Authentication error with guidance.
+
+---
+
+### ERR-004: Issue Not Found
+
+**Command:**
+```bash
+jira get INVALID-999
+```
+
+**Expected:** Clear "issue not found" message.
+
+---
+
+## Quick Checklist
+
+Run these before release:
+
+- [ ] `jira --help` works
+- [ ] `jira profiles` lists profiles
+- [ ] `jira search "test"` returns results
+- [ ] `jira get <KEY>` shows details
+- [ ] `jira projects` lists projects
+- [ ] Error messages are clear

--- a/.claude/skills/Jira/CHANGELOG.md
+++ b/.claude/skills/Jira/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+All notable changes to the Jira skill will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] - 2025-12-16
+
+### Added
+
+- **Saved Filters Support** (SMS-340)
+  - `jira filters` command to list favourite/saved filters
+  - `--filter` flag on search to use saved filter by name or ID
+  - `--owner` flag to filter filters by owner name
+  - `--mine` flag to show only your own filters
+  - Share permissions display (global, project, group, user)
+
+- **Quick Filters** (Service Desk patterns)
+  - Built-in JQL templates for common queries
+  - `--quick` flag on search (open, my open, done, created today, etc.)
+  - `jira search --quick list` to show available quick filters
+  - Project-aware: uses `JIRA_DEFAULT_PROJECT` or `--project` flag
+
+- **Search Ordering**
+  - `--order` flag: updated, created, key, priority, status
+  - `--asc` flag for ascending order (default: descending)
+  - Default: ORDER BY updated DESC
+
+- **Single-Ticket Workflow**
+  - `jira open <KEY|index>` - Opens ticket for focused work
+  - `jira status` - Shows currently opened ticket
+  - `jira close` - Closes opened ticket
+  - Operations work on opened ticket without key
+
+- **Vision Support** (SMS-336)
+  - `--vision` flag on load/open to analyze image attachments
+  - Uses OpenAI Vision API for screenshot analysis
+  - Supports PNG, JPEG, GIF, WebP formats
+
+- **CLI Improvements**
+  - Merged `get` command into `load` (SMS-339)
+  - Load by index from search: `jira load 1,2,5`
+  - Load by range: `jira load 1-10`
+  - Profile storage in `~/.claude/jira/profiles/` for persistence (SMS-305)
+  - Change issue type via `jira update --type Epic` (SMS-304)
+  - Project-to-profile auto-detection with `jira setup` (SMS-334)
+
+### Fixed
+
+- JQL filtering not working in search (SMS-303)
+
+### Changed
+
+- Search now defaults to ORDER BY updated DESC
+- Two-phase workflow enforced: search → load (never auto-load)
+- Profile auto-detection uses `JIRA_PROJECTS` config (SMS-334)
+
+### Documentation
+
+- SKILL.md updated with filter and quick filter workflow routing
+- Quick Filter Reference table added
+- Ordering documentation added
+
+## [1.0.0] - 2025-12-12
+
+### Added
+
+- **Core CLI** (`bin/jira/jira.ts`)
+  - Search issues with text or JQL
+  - Get full issue details
+  - Create issues (all types including sub-tasks and epics)
+  - Update issue fields
+  - Transition issue status
+  - Add comments
+
+- **Multi-Instance Support**
+  - Profile-based configuration (`profiles/*.env`)
+  - Default profile via symlink
+  - Cross-instance search with `-p all`
+  - Auto-detection of instance from issue key
+
+- **Issue Linking**
+  - Create/remove links between issues
+  - Link to epics
+  - List all links on an issue
+  - Support for all standard link types
+
+- **GitHub Integration**
+  - View branches linked to issues
+  - View pull requests and their status
+  - View commit counts
+  - Suggest branch names
+
+- **Label Management**
+  - List all labels
+  - Add/remove labels from issues
+  - Search by label (AND/OR logic)
+
+- **Output Formats**
+  - Table (human-readable)
+  - JSON (machine-readable)
+  - Markdown (for notes)
+
+- **Skill Layer** (`.claude/skills/Jira/`)
+  - SKILL.md with routing
+  - Two-phase workflow (search → get)
+  - CORE routing integration
+  - Comprehensive documentation
+
+### Architecture
+
+- TypeScript + Bun (no Python, no MCP)
+- Direct Jira REST API v3 integration
+- Basic Auth with API token
+- CLI-first, deterministic design
+
+### Documentation
+
+- README.md with quick start
+- docs/CLI-REFERENCE.md - Full command reference
+- docs/CONCEPTS.md - Architecture and concepts
+- ACCEPTANCE_TESTS.md - Manual test cases

--- a/.claude/skills/Jira/README.md
+++ b/.claude/skills/Jira/README.md
@@ -1,0 +1,295 @@
+# Jira Skill
+
+TypeScript CLI for Jira issue management following PAI's deterministic-first architecture.
+
+**Key Concept:** All Jira operations go through a CLI (`jira`) that wraps the Jira REST API. Multi-instance support allows managing personal and work Jira from a single interface. Two-phase retrieval keeps token usage efficient.
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+cd bin/jira && bun install
+
+# 2. Create wrapper script
+echo '#!/bin/bash
+cd /path/to/PAI/bin/jira && exec bun run jira.ts "$@"' > ~/bin/jira
+chmod +x ~/bin/jira
+
+# 3. Create profiles directory (persistent location)
+mkdir -p ~/.claude/jira/profiles
+
+# 4. Configure a profile
+cp bin/jira/profiles.example/example.env.template ~/.claude/jira/profiles/personal.env
+# Edit ~/.claude/jira/profiles/personal.env with your credentials
+
+# 5. Set default profile
+cd ~/.claude/jira/profiles && ln -sf personal.env default
+
+# 6. (Optional) Auto-discover projects
+jira setup
+
+# 7. Test it works
+jira --help
+jira profiles
+```
+
+## Documentation
+
+### Getting Started
+
+| Doc | Purpose | When to Read |
+|-----|---------|--------------|
+| [Jira Setup](#jira-cloud-setup) | Get API token, configure profile | First setup |
+| [Profile Configuration](#profile-configuration) | Multi-instance setup | Multiple Jira instances |
+
+### Concepts & Reference
+
+| Doc | Purpose | When to Read |
+|-----|---------|--------------|
+| [Concepts](./docs/CONCEPTS.md) | Multi-instance, two-phase workflow, labels | Understanding the system |
+| [CLI Reference](./docs/CLI-REFERENCE.md) | Full `jira` command reference | Using the CLI |
+
+### For Claude
+
+| Doc | Purpose |
+|-----|---------|
+| [SKILL.md](./SKILL.md) | Skill definition (loaded by Claude) |
+| [ACCEPTANCE_TESTS.md](./ACCEPTANCE_TESTS.md) | Manual test cases |
+
+## Components
+
+### `jira` CLI
+
+Single CLI for all Jira operations.
+
+```bash
+# Discovery (compact, low tokens)
+jira search "authentication"     # Text search
+jira search --project PROJ       # Project filter
+jira search -p all               # Cross-instance search
+jira projects                    # List projects
+jira transitions PROJ-123        # Available transitions
+
+# Load (full details)
+jira get PROJ-123                # Full issue details
+
+# Write operations
+jira create -p PROJ -t Bug -s "Summary"
+jira update PROJ-123 --description "New desc"
+jira transition PROJ-123 "Done"
+jira comment PROJ-123 "Comment text"
+
+# Issue linking
+jira link PROJ-123 blocks PROJ-456
+jira link PROJ-123 --epic EPIC-100
+jira links PROJ-123
+
+# GitHub integration
+jira dev PROJ-123                # Show branches, PRs, commits
+
+# Labels
+jira labels                      # List all labels
+jira label add PROJ-123 urgent
+jira search --label urgent
+```
+
+## Jira Cloud Setup
+
+### 1. Create API Token
+
+API tokens are required for Jira Cloud authentication. Each Jira instance needs its own token.
+
+**Step-by-step:**
+
+1. Log into your Atlassian account at https://id.atlassian.com
+2. Navigate to **Security** > **API tokens** or go directly to:
+   https://id.atlassian.com/manage-profile/security/api-tokens
+3. Click **Create API token**
+4. Enter a label (e.g., "PAI Jira CLI")
+5. Click **Create**
+6. **Copy the token immediately** - it's only shown once!
+7. Store it safely (password manager, secure note, etc.)
+
+**Important notes:**
+- Tokens inherit your account permissions - they can do anything you can do
+- Tokens don't expire automatically, but you can revoke them anytime
+- Create separate tokens for different applications for better security
+- If you have multiple Jira instances (personal + work), you need a token for each
+
+### 2. Find Your Jira URL
+
+Your Jira Cloud URL is: `https://your-domain.atlassian.net`
+
+You can find this in your browser when logged into Jira.
+
+### 3. Get Your Username
+
+Your username is your **Atlassian account email address** (the email you use to log in).
+
+**Note:** This is NOT your display name or Jira username - it must be the email address.
+
+## Profile Configuration
+
+Profiles live in `~/.claude/jira/profiles/` as `.env` files. This location persists across git branch checkouts.
+
+### Single Instance
+
+```bash
+# ~/.claude/jira/profiles/personal.env
+JIRA_URL=https://your-domain.atlassian.net
+JIRA_USERNAME=your-email@example.com
+JIRA_API_TOKEN=your-api-token
+JIRA_DEFAULT_PROJECT=PROJ
+JIRA_PROJECTS=PROJ,SMS,PAI    # For auto-detection (optional)
+```
+
+Set as default:
+```bash
+cd ~/.claude/jira/profiles && ln -sf personal.env default
+```
+
+### Multiple Instances
+
+```bash
+# ~/.claude/jira/profiles/personal.env
+JIRA_URL=https://personal.atlassian.net
+JIRA_USERNAME=me@personal.com
+JIRA_API_TOKEN=token-1
+JIRA_DEFAULT_PROJECT=SIDE
+JIRA_PROJECTS=SIDE,PAI
+
+# ~/.claude/jira/profiles/work.env
+JIRA_URL=https://company.atlassian.net
+JIRA_USERNAME=me@company.com
+JIRA_API_TOKEN=token-2
+JIRA_DEFAULT_PROJECT=PROJ
+JIRA_PROJECTS=PROJ,API
+```
+
+Usage:
+```bash
+jira search "bug" -p personal    # Search personal Jira
+jira search "bug" -p work        # Search work Jira
+jira search "bug" -p all         # Search all instances
+jira get SMS-123                 # Auto-selects personal (SMS in JIRA_PROJECTS)
+```
+
+### Auto-Discovery with Setup
+
+Run `jira setup` to auto-discover projects and configure `JIRA_PROJECTS`:
+
+```bash
+jira setup                # Discover for all profiles
+jira setup -p personal    # Just one profile
+```
+
+### Environment Variables (Alternative)
+
+If you don't use profiles, set these environment variables:
+
+```bash
+export JIRA_URL=https://your-domain.atlassian.net
+export JIRA_USERNAME=your-email@example.com
+export JIRA_API_TOKEN=your-api-token
+export JIRA_DEFAULT_PROJECT=PROJ
+```
+
+## Two-Phase Workflow
+
+The CLI follows a two-phase pattern for token efficiency:
+
+### Phase 1: Search (Discovery)
+
+```bash
+jira search "authentication" --limit 10
+```
+
+Returns compact index:
+```
+| #  | Key      | Type  | Summary                    | Status      | Assignee |
+|----|----------|-------|----------------------------|-------------|----------|
+| 1  | PROJ-123 | Bug   | Auth token expiring early  | In Progress | alice    |
+| 2  | PROJ-456 | Story | Add OAuth2 support         | To Do       | -        |
+
+Which to load? (1,2,3 / all / --type Bug)
+```
+
+### Phase 2: Load (Detail)
+
+```bash
+jira get PROJ-123
+```
+
+Returns full details with description, comments, links, dev info.
+
+**Why two phases?** Loading full details for 50 issues wastes tokens. Search first, then load only what you need.
+
+## Cross-Instance Search
+
+Search all configured profiles in parallel:
+
+```bash
+jira search "deployment" -p all
+```
+
+Returns merged results with instance indicator:
+
+```
+| #  | Instance | Key       | Type  | Summary              | Status |
+|----|----------|-----------|-------|----------------------|--------|
+| 1  | personal | SIDE-42   | Task  | Deploy v2.0          | To Do  |
+| 2  | work     | PROJ-789  | Story | Production deploy    | Done   |
+```
+
+## Claude Code Integration
+
+The Jira skill works standalone via CLI. For natural language integration with Claude Code, CORE/SKILL.md includes routing:
+
+```markdown
+**When user asks about Jira issues, tickets, or project management:**
+Examples: "search jira", "create issue", "update ticket", "find issues"
+→ **READ:** ${PAI_DIR}/skills/Jira/SKILL.md
+→ **EXECUTE:** Follow two-phase workflow: SEARCH → GET
+```
+
+This enables queries like "Search jira for authentication bugs" to automatically invoke the CLI.
+
+## Output Formats
+
+```bash
+jira search "bug" --format table      # Default: human-readable
+jira search "bug" --format json       # Machine-readable
+jira search "bug" --format markdown   # For notes/docs
+```
+
+## Troubleshooting
+
+### "No profiles configured"
+
+Create a profile:
+```bash
+cp profiles.example/example.env.template profiles/personal.env
+# Edit with your credentials
+ln -sf personal.env profiles/default
+```
+
+### "401 Unauthorized"
+
+Check your API token:
+1. Token may have expired - create a new one
+2. Username should be your email, not display name
+3. URL should include `https://`
+
+### "Project not found"
+
+List accessible projects:
+```bash
+jira projects
+```
+
+### "Issue not found"
+
+The issue key may be from a different instance:
+```bash
+jira get PROJ-123 -p work  # Specify instance
+```

--- a/.claude/skills/Jira/SKILL.md
+++ b/.claude/skills/Jira/SKILL.md
@@ -1,0 +1,483 @@
+---
+name: Jira
+description: |
+  Jira issue tracking integration via TypeScript CLI.
+
+  USE WHEN: "create issue", "search jira", "update ticket", "find issues",
+  "jira status", "transition to done", "add comment", "link issues",
+  "what branches are linked", "show PR status", "change issue type",
+  "show my filters", "use saved filter", "search with filter",
+  "open issues in HD", "my open tickets", "created today", "unassigned".
+
+  Two-phase retrieval: SEARCH (show index, wait) → LOAD (only when user requests)
+
+  Profile auto-detection: CLI automatically selects profile based on project key.
+  Quick filters: Built-in Service Desk filters (open, my open, created today, etc.)
+---
+
+# Jira Skill
+
+**Purpose:** Search, create, update, and manage Jira issues via CLI.
+
+## Workflow Routing
+
+**When user wants to search/find issues:**
+Examples: "search jira for X", "find issues about Y", "what tickets are open", "issues in project Z"
+→ **EXECUTE:** `jira search "<query>"` or `jira search --project <PROJECT>`
+→ **ORDER:** Add `--order <field>` (updated, created, key, priority, status) and `--asc` for ascending
+→ **WAIT:** Show results table, wait for user to select
+
+**When user wants to load/view issues:**
+Examples: "load 1,2,3", "show me PROJ-123", "get details on that ticket", "load all as JSON"
+→ **EXECUTE:** `jira load <key|indices|all>` - loads full details
+→ **NOTE:** Use `--format json` for structured context, `--vision` for image analysis
+
+**When user wants to work on/interact with an issue:**
+Examples: "open PROJ-123", "work on that ticket", "I want to update PROJ-456"
+→ **EXECUTE:** `jira open <KEY|index>` - opens ticket for single-ticket operations
+→ **THEN:** `update`, `comment`, `transition` work on opened ticket without key
+→ **FINALLY:** `jira close` when done
+
+**When user asks what ticket is open:**
+Examples: "what's open", "current ticket", "status"
+→ **EXECUTE:** `jira status` - shows currently opened ticket
+
+**When user wants to create an issue:**
+Examples: "create a ticket for X", "new bug in project Y", "add task for Z"
+→ **EXECUTE:** `jira create --project <PROJECT> --type <TYPE> --summary "<summary>"`
+
+**When user wants to update an issue:**
+Examples: "update PROJ-123", "change the description", "assign to me", "change type to Epic"
+→ **EXECUTE:** `jira update <KEY> [--summary] [--description] [--assignee] [--type]`
+
+**When user wants to change issue type:**
+Examples: "change SMS-123 to Epic", "convert to Story", "make it a Bug"
+→ **EXECUTE:** `jira update <KEY> --type <TYPE>`
+
+**When user wants to transition an issue:**
+Examples: "move to done", "start working on PROJ-123", "close this ticket"
+→ **EXECUTE:** `jira transition <KEY> "<status>"`
+
+**When user wants to add a comment:**
+Examples: "add comment to PROJ-123", "note on that ticket"
+→ **EXECUTE:** `jira comment <KEY> "<text>"`
+
+**When user asks about branches/PRs:**
+Examples: "what branches are linked", "show PR status", "dev info for PROJ-123"
+→ **EXECUTE:** `jira dev <KEY>`
+
+**When user wants to link issues:**
+Examples: "link PROJ-123 to PROJ-456", "add to epic", "blocks relationship"
+→ **EXECUTE:** `jira link <KEY1> "<type>" <KEY2>` or `jira link <KEY> --epic <EPIC>`
+
+**When user wants to manage labels:**
+Examples: "add label urgent", "remove label", "what labels are on this"
+→ **EXECUTE:** `jira label add <KEY> <label>` or `jira label remove <KEY> <label>`
+
+**When user wants to use saved filters:**
+Examples: "show my filters", "list jira filters", "use my sprint filter", "search with filter"
+→ **EXECUTE:** `jira filters` - list favourite/saved filters
+→ **THEN:** `jira search --filter "<name>"` - search using a saved filter
+
+**When user wants quick/default filters:**
+Examples: "show open issues in HD", "my open tickets", "what was created today", "unassigned issues"
+→ **EXECUTE:** `jira search --quick "<filter>" --project <PROJECT>`
+→ **LIST:** `jira search --quick list` - show available quick filters
+
+**Quick Filter Reference:**
+| User Says | Quick Filter |
+|-----------|--------------|
+| "open issues" | `--quick "open"` |
+| "my open issues" | `--quick "my open"` |
+| "assigned to me" | `--quick "assigned to me"` |
+| "unassigned" | `--quick "unassigned"` |
+| "reported by me" | `--quick "reported by me"` |
+| "done/completed" | `--quick "done"` |
+| "created today" | `--quick "created today"` |
+| "updated recently" | `--quick "updated recently"` |
+| "high priority" | `--quick "high priority"` |
+
+---
+
+## Instance Routing (Profile Selection)
+
+The CLI supports multiple Jira instances via profiles. **Auto-detection** selects the correct profile based on project key.
+
+### Automatic Profile Detection
+
+When `JIRA_PROJECTS` is configured in profiles, the CLI auto-detects:
+
+```bash
+jira get SMS-123              # Auto-selects personal (SMS is in personal.env)
+jira get ETG-456              # Auto-selects work (ETG is in work.env)
+```
+
+### Manual Profile Override
+
+| User Says | Profile Flag |
+|-----------|--------------|
+| "in work Jira" / "work instance" | `-p work` |
+| "in personal Jira" / "my board" | `-p personal` |
+| "across all Jira" / "in any instance" | `-p all` |
+| (no mention) | Auto-detect or default profile |
+
+**Cross-instance search:**
+```bash
+jira search "authentication" -p all    # Queries all instances in parallel
+```
+
+---
+
+## Quick Reference
+
+| User Says | Command |
+|-----------|---------|
+| "Search jira for X" | `jira search "X"` |
+| "Find issues in project Y" | `jira search --project Y` |
+| "Show oldest first" | `jira search --order created --asc` |
+| "Order by priority" | `jira search --order priority` |
+| "Newest issues first" | `jira search --order created` |
+| "Load issues 1,2,5" | `jira load 1,2,5` |
+| "Load all as JSON" | `jira load all -f json` |
+| "Show me PROJ-123" | `jira load PROJ-123` |
+| "Open PROJ-123 to work on it" | `jira open PROJ-123` |
+| "Open #3 from search" | `jira open 3` |
+| "What ticket is open?" | `jira status` |
+| "Done with this ticket" | `jira close` |
+| "Create bug for login failure" | `jira create -P PROJECT -T Bug -s "Login failure"` |
+| "Create story under epic" | `jira create -T Story -s "Feature" --epic EPIC-100` |
+| "Create subtask" | `jira create -T Subtask -s "Task" --parent PROJ-123` |
+| "Move PROJ-123 to done" | `jira transition PROJ-123 "Done"` |
+| "Change to Epic" | `jira update PROJ-123 --type Epic` |
+| "Comment on PROJ-123" | `jira comment PROJ-123 "text"` |
+| "What projects are available?" | `jira projects` |
+| "What can I transition to?" | `jira transitions PROJ-123` |
+| "Link PROJ-123 blocks PROJ-456" | `jira link PROJ-123 blocks PROJ-456` |
+| "Add PROJ-123 to epic EPIC-100" | `jira link PROJ-123 --epic EPIC-100` |
+| "Show branches for PROJ-123" | `jira dev PROJ-123` |
+| "Add label 'urgent' to PROJ-123" | `jira label add PROJ-123 urgent` |
+| "Remove label from issue" | `jira label remove PROJ-123 urgent` |
+| "Search by label" | `jira search --label urgent` |
+| "Search across all instances" | `jira search "query" -p all` |
+| "Show my saved filters" | `jira filters` |
+| "Show filters by owner" | `jira filters "name" --owner "Paige"` |
+| "Show only my filters" | `jira filters "name" --mine` |
+| "Search using my filter" | `jira search --filter "Filter Name"` |
+| "Use filter by ID" | `jira search --filter 12345` |
+| "Open issues in HD" | `jira search --quick "open" -P HD` |
+| "My open HD tickets" | `jira search --quick "my open" -P HD` |
+| "Created today in HD" | `jira search --quick "created today" -P HD` |
+| "Unassigned HD tickets" | `jira search --quick "unassigned" -P HD` |
+| "High priority open" | `jira search --quick "high priority" -P HD` |
+| "List quick filters" | `jira search --quick list` |
+| "Analyze screenshots in ticket" | `jira load PROJ-123 --vision` |
+
+---
+
+## Two-Phase Workflow
+
+**CRITICAL: Follow the same pattern as Context skill.**
+
+🚫 **NEVER AUTO-LOAD:** After search, STOP and wait for user to select items.
+
+### Phase 1: Search (Discovery)
+```bash
+jira search "authentication"
+```
+
+Returns compact table with useful fields:
+```
+#  Key       Type   Summary                      Status       Created     Labels
+─────────────────────────────────────────────────────────────────────────────────────
+1  PROJ-123  Bug    Auth token expiring early    In Progress  2025-12-10  security, urgent
+2  PROJ-456  Story  Add OAuth2 support           To Do        2025-12-08  authentication
+
+Which to load? (jira load <KEY> / jira load 1,2,5 / jira load all -f json)
+```
+
+**STOP AND WAIT** for user selection.
+
+### Phase 2: Load (Detail)
+
+```bash
+jira load PROJ-123           # By key
+jira load 1,2,5              # By index from search
+jira load 1-10               # Range from search
+jira load all                # All from search
+jira load all -f json        # JSON for context loading
+jira load PROJ-123 --vision  # With image analysis
+```
+
+Returns full issue details with description, comments, links, dev info.
+
+**JSON format** is structured for context loading:
+```json
+[{
+  "key": "PROJ-123",
+  "summary": "...",
+  "description": "...",
+  "comments": [...]
+}]
+```
+
+---
+
+## Single-Ticket Workflow (Open/Close)
+
+For safe, one-at-a-time ticket interaction:
+
+```bash
+# 1. Search and find tickets
+jira search "authentication bugs"
+
+# 2. Open ONE ticket to work on
+jira open 3                    # Open #3 from search
+# or: jira open SMS-123        # Open by key
+
+# 3. Perform operations (no key needed)
+jira update --summary "Fixed auth bug"
+jira comment "Root cause was expired token"
+jira transition "Done"
+
+# 4. Close when done
+jira close
+```
+
+**Why single-ticket mode?**
+- Prevents accidental bulk modifications
+- Clear context for each operation
+- Safe for work/production instances
+- Operations confirm which ticket they're modifying
+
+**Commands show opened ticket:**
+```
+Updating opened ticket: SMS-123
+Updated SMS-123
+```
+
+---
+
+## Configuration
+
+### Initial Setup
+
+**First-time setup for new installations:**
+
+```bash
+# 1. Create profiles directory
+mkdir -p ~/.claude/jira/profiles
+
+# 2. Create profile files (one per Jira instance)
+# See "Profile Format" below
+
+# 3. Run setup to discover projects (optional but recommended)
+jira setup
+
+# 4. Set default profile
+cd ~/.claude/jira/profiles && ln -sf personal.env default
+```
+
+### Profile Location
+
+Profiles are stored in `~/.claude/jira/profiles/` for persistence across branch checkouts.
+
+**Why?** Profile files contain API tokens and are gitignored. Storing them in `~/.claude/` ensures they survive `git checkout` operations.
+
+### Profile Format
+
+```bash
+# ~/.claude/jira/profiles/personal.env
+JIRA_URL=https://your-domain.atlassian.net
+JIRA_USERNAME=your-email@example.com
+JIRA_API_TOKEN=your-api-token
+JIRA_DEFAULT_PROJECT=PROJ
+JIRA_PROJECTS=PROJ,SMS,PAI      # Projects this profile handles (for auto-detection)
+```
+
+**Required fields:**
+- `JIRA_URL` - Your Jira instance URL
+- `JIRA_USERNAME` - Your Atlassian account email
+- `JIRA_API_TOKEN` - API token from https://id.atlassian.com/manage-profile/security/api-tokens
+
+**Optional fields:**
+- `JIRA_DEFAULT_PROJECT` - Default project when `--project` not specified
+- `JIRA_PROJECTS` - Comma-separated list of projects for auto-detection
+
+### Setup Command (Project Discovery)
+
+After configuring profiles, run setup to auto-discover projects:
+
+```bash
+jira setup                      # Discover projects for all profiles
+jira setup -p personal          # Just one profile
+```
+
+Setup will:
+1. Query each Jira instance for accessible projects
+2. Display discovered projects for confirmation
+3. Write `JIRA_PROJECTS=...` to profile files
+
+**Note:** Setup is optional. You can manually edit `JIRA_PROJECTS` or always use `-p` flag.
+
+### Default Profile
+
+Set default profile via symlink:
+```bash
+cd ~/.claude/jira/profiles && ln -sf personal.env default
+```
+
+When no `-p` flag and project not auto-detected, the default profile is used.
+
+---
+
+## Update Options
+
+The update command supports multiple field changes:
+
+```bash
+jira update <KEY> [options]
+
+Options:
+  --summary, -s <text>     New summary
+  --description, -d <text> New description
+  --assignee, -a <user>    New assignee (account ID)
+  --type, -t <type>        Change issue type (Task, Story, Epic, Bug, Subtask)
+  --priority <name>        New priority
+  --labels <l1,l2>         Replace all labels
+  --label <label>          Add single label (repeatable)
+```
+
+**Examples:**
+```bash
+jira update SMS-123 --type Epic                    # Change to Epic
+jira update SMS-123 --summary "New title"          # Change summary
+jira update SMS-123 --type Story --priority High   # Multiple changes
+```
+
+---
+
+## CLI Help
+
+```bash
+jira --help              # Show all commands
+jira search --help       # Search command help
+jira profiles            # List available profiles
+jira config              # Show current configuration
+jira config -p work      # Show specific profile config
+jira setup               # Discover and configure projects
+```
+
+---
+
+## Troubleshooting
+
+**"No Jira configuration found"**
+- Create a profile in `~/.claude/jira/profiles/`
+- Or set a default: `ln -sf personal.env default`
+
+**"Profile not found: X"**
+- Check `jira profiles` for available profiles
+- Create the missing profile .env file
+
+**"Authentication failed"**
+- Verify `JIRA_API_TOKEN` is correct
+- Generate new token at https://id.atlassian.com/manage-profile/security/api-tokens
+
+**Search returns wrong project's issues**
+- Ensure JQL syntax is correct: `project = SMS` (not `project: SMS`)
+- Check profile has correct `JIRA_URL`
+
+---
+
+## Vision Support for Screenshots
+
+Service Desk tickets often contain embedded screenshots that are hard to understand from filenames alone:
+```
+!image-20251216-023637.png|width=1087,alt="screenshot"!
+```
+
+The `--vision` flag analyzes image attachments using OpenAI Vision API:
+
+```bash
+jira load HD-210123 --vision         # Analyze images in ticket
+jira load 1,2,3 --vision             # Batch analyze from search
+jira load all --vision -f json       # JSON with vision analysis
+jira open HD-210123 --vision         # Open with vision analysis
+```
+
+**Requirements:**
+- `OPENAI_API_KEY` in environment or `~/.claude/.env`
+- Supports: PNG, JPEG, GIF, WebP
+
+**Output:**
+```
+Image Attachments (3):
+────────────────────────────────────────
+  screenshot-error.png
+    → Shows a dialog box with error "Connection timeout" and retry button.
+  user-interface.png
+    → Admin panel showing user permissions table with role assignments.
+```
+
+**Configuration:**
+- `OPENAI_VISION_MODEL` - Model to use (default: gpt-5.2)
+- `OPENAI_VISION_MAX_TOKENS` - Max response tokens (default: 300)
+- Limits to first 5 images per ticket to manage API costs
+
+---
+
+## Saved Filters
+
+Jira filters are saved JQL queries that can be starred as favourites. Use them for complex, reusable searches.
+
+### List Filters
+
+```bash
+jira filters                     # List favourite filters (starred in Jira)
+jira filters "sprint"            # Search filters by name
+jira filters "HD" --owner "Paige"  # Filter by owner name
+jira filters "HD" --mine         # Show only your filters
+jira filters -f json             # JSON output for automation
+```
+
+**Output:**
+```
+Favourite filters:
+
+#  ID       Name                                    Owner
+─────────────────────────────────────────────────────────────────────────
+★ 1  12345    My Active Issues                        Andreas
+★ 2  12346    Current Sprint                          Andreas
+★ 3  12347    Bugs in Review                          Andreas
+
+Use with search: jira search --filter "My Active Issues"
+Or by ID:        jira search --filter 12345
+```
+
+### Search Using Filter
+
+```bash
+jira search --filter "My Active Issues"     # By name
+jira search --filter 12345                   # By ID
+jira search --filter "Sprint" --limit 50     # With options
+```
+
+The filter's JQL is retrieved and used for the search. Additional options like `--limit` can be combined.
+
+**Note:** Filters are tied to the Jira instance, so cross-instance search (`-p all`) cannot use `--filter`.
+
+---
+
+## Future Enhancements
+
+### Service Desk / Help Desk Projects
+
+Additional fields to support:
+- Priority, Request type, Components, Support team
+- Request category, Request participants
+- Custom fields specific to the project
+
+For high-volume scenarios:
+- Filter by priority: `jira search --priority High`
+- Filter by component: `jira search --component "API"`
+- Summary statistics by status/priority

--- a/.claude/skills/Jira/docs/CLI-REFERENCE.md
+++ b/.claude/skills/Jira/docs/CLI-REFERENCE.md
@@ -1,0 +1,547 @@
+# CLI Reference
+
+Complete reference for the `jira` command-line tool.
+
+## Global Options
+
+These options apply to all commands:
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--profile <name>` | `-p` | Use specific profile (or `all` for cross-instance) |
+| `--format <type>` | `-f` | Output format: `table`, `json`, `markdown` |
+| `--help` | `-h` | Show help |
+
+---
+
+## Search Commands
+
+### `jira search`
+
+Search for issues using text or JQL.
+
+```bash
+# Text search (converted to JQL)
+jira search "authentication bug"
+
+# Direct JQL
+jira search "project = PROJ AND status = 'In Progress'"
+
+# With filters
+jira search "API" --project PROJ --type Bug --status "In Progress"
+
+# Cross-instance
+jira search "deployment" -p all
+
+# With labels
+jira search --label urgent --label high-priority
+
+# Limit results
+jira search "bug" --limit 20
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--project <key>` | Filter by project |
+| `--type <type>` | Filter by issue type (Bug, Story, Task, etc.) |
+| `--status <status>` | Filter by status |
+| `--assignee <user>` | Filter by assignee |
+| `--label <label>` | Filter by label (can use multiple) |
+| `--any-label <labels...>` | Match any of these labels (OR logic) |
+| `--limit <n>` | Max results (default: 20) |
+| `--format <type>` | Output format |
+
+**Output (table format):**
+
+```
+| #  | Key      | Type  | Summary                    | Status      | Assignee |
+|----|----------|-------|----------------------------|-------------|----------|
+| 1  | PROJ-123 | Bug   | Auth token expiring early  | In Progress | alice    |
+| 2  | PROJ-456 | Story | Add OAuth2 support         | To Do       | -        |
+
+Which to load? (1,2,3 / all / --type Bug)
+```
+
+---
+
+### `jira get`
+
+Get full details for a specific issue.
+
+```bash
+jira get PROJ-123
+
+# From specific instance
+jira get PROJ-123 -p work
+
+# JSON output
+jira get PROJ-123 --format json
+```
+
+**Output includes:**
+- Key, Type, Status, Priority
+- Summary and Description
+- Assignee and Reporter
+- Labels
+- Links (blocks, is blocked by, epic)
+- Comments (last 5)
+- Dev info (branches, PRs)
+
+---
+
+## Write Commands
+
+### `jira create`
+
+Create a new issue.
+
+```bash
+# Minimal
+jira create --project PROJ --type Bug --summary "Login fails on Safari"
+
+# With description
+jira create -p PROJ -t Story -s "Add dark mode" \
+  --description "Users want dark mode support"
+
+# With assignee and labels
+jira create -p PROJ -t Task -s "Update docs" \
+  --assignee alice \
+  --labels documentation,urgent
+
+# As sub-task
+jira create -p PROJ -t Sub-task -s "Write tests" \
+  --parent PROJ-123
+
+# Under epic
+jira create -p PROJ -t Story -s "New feature" \
+  --epic PROJ-100
+```
+
+**Options:**
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--project <key>` | `-p` | Yes* | Project key |
+| `--type <type>` | `-t` | Yes | Issue type |
+| `--summary <text>` | `-s` | Yes | Issue summary |
+| `--description <text>` | `-d` | No | Issue description |
+| `--assignee <user>` | `-a` | No | Assignee username |
+| `--labels <labels>` | `-l` | No | Comma-separated labels |
+| `--parent <key>` | | No | Parent issue (for sub-tasks) |
+| `--epic <key>` | | No | Epic to add issue to |
+| `--priority <priority>` | | No | Priority (Highest, High, Medium, Low, Lowest) |
+
+*Uses default project if not specified.
+
+---
+
+### `jira update`
+
+Update an existing issue.
+
+```bash
+# Update summary
+jira update PROJ-123 --summary "New summary"
+
+# Update description
+jira update PROJ-123 --description "Updated description"
+
+# Change assignee
+jira update PROJ-123 --assignee bob
+
+# Add labels
+jira update PROJ-123 --add-labels urgent,reviewed
+
+# Remove labels
+jira update PROJ-123 --remove-labels wontfix
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--summary <text>` | New summary |
+| `--description <text>` | New description |
+| `--assignee <user>` | New assignee |
+| `--add-labels <labels>` | Labels to add |
+| `--remove-labels <labels>` | Labels to remove |
+| `--priority <priority>` | New priority |
+
+---
+
+### `jira transition`
+
+Change issue status.
+
+```bash
+# Transition to status
+jira transition PROJ-123 "Done"
+jira transition PROJ-123 "In Progress"
+
+# See available transitions first
+jira transitions PROJ-123
+```
+
+---
+
+### `jira comment`
+
+Add a comment to an issue.
+
+```bash
+jira comment PROJ-123 "This is my comment"
+
+# Multi-line (use quotes)
+jira comment PROJ-123 "Line 1
+Line 2
+Line 3"
+```
+
+---
+
+## Discovery Commands
+
+### `jira projects`
+
+List accessible projects.
+
+```bash
+jira projects
+
+# From specific instance
+jira projects -p work
+
+# All instances
+jira projects -p all
+```
+
+**Output:**
+
+```
+| Key  | Name              | Lead    |
+|------|-------------------|---------|
+| PROJ | Main Project      | alice   |
+| API  | API Development   | bob     |
+```
+
+---
+
+### `jira types`
+
+List issue types for a project.
+
+```bash
+jira types --project PROJ
+
+# Or use default project
+jira types
+```
+
+**Output:**
+
+```
+| Name     | Subtask |
+|----------|---------|
+| Bug      | No      |
+| Story    | No      |
+| Task     | No      |
+| Epic     | No      |
+| Sub-task | Yes     |
+```
+
+---
+
+### `jira transitions`
+
+List available transitions for an issue.
+
+```bash
+jira transitions PROJ-123
+```
+
+**Output:**
+
+```
+| ID | Name          | To Status   |
+|----|---------------|-------------|
+| 11 | Start Work    | In Progress |
+| 21 | Done          | Done        |
+| 31 | Won't Do      | Won't Do    |
+```
+
+---
+
+## Link Commands
+
+### `jira link`
+
+Create a link between issues.
+
+```bash
+# Standard link
+jira link PROJ-123 blocks PROJ-456
+jira link PROJ-123 "is blocked by" PROJ-456
+jira link PROJ-123 "relates to" PROJ-456
+
+# Add to epic
+jira link PROJ-123 --epic EPIC-100
+```
+
+---
+
+### `jira unlink`
+
+Remove a link between issues.
+
+```bash
+jira unlink PROJ-123 PROJ-456
+```
+
+---
+
+### `jira links`
+
+Show all links on an issue.
+
+```bash
+jira links PROJ-123
+```
+
+**Output:**
+
+```
+| Type       | Direction | Issue     | Summary              |
+|------------|-----------|-----------|----------------------|
+| blocks     | outward   | PROJ-456  | Blocked feature      |
+| Epic Link  | inward    | EPIC-100  | Q4 Roadmap           |
+```
+
+---
+
+### `jira link-types`
+
+List available link types.
+
+```bash
+jira link-types
+```
+
+**Output:**
+
+```
+| Name       | Inward           | Outward          |
+|------------|------------------|------------------|
+| Blocks     | is blocked by    | blocks           |
+| Clones     | is cloned by     | clones           |
+| Duplicate  | is duplicated by | duplicates       |
+| Relates    | relates to       | relates to       |
+```
+
+---
+
+## Label Commands
+
+### `jira labels`
+
+List all labels in the instance.
+
+```bash
+jira labels
+
+# From specific instance
+jira labels -p work
+```
+
+---
+
+### `jira label add`
+
+Add labels to an issue.
+
+```bash
+jira label add PROJ-123 urgent
+jira label add PROJ-123 reviewed documentation
+```
+
+---
+
+### `jira label remove`
+
+Remove labels from an issue.
+
+```bash
+jira label remove PROJ-123 wontfix
+```
+
+---
+
+## GitHub Integration
+
+### `jira dev`
+
+Show development information for an issue.
+
+```bash
+jira dev PROJ-123
+
+# Branches only
+jira dev PROJ-123 --branches
+
+# Pull requests only
+jira dev PROJ-123 --prs
+
+# Suggest branch name
+jira dev PROJ-123 --create-branch
+```
+
+**Output:**
+
+```
+Development Info for PROJ-123
+=============================
+
+Branches (2):
+  - feature/PROJ-123-auth-fix (repo: myapp)
+  - PROJ-123-hotfix (repo: myapp)
+
+Pull Requests (1):
+  - #42: Fix authentication (MERGED)
+    https://github.com/org/myapp/pull/42
+
+Commits: 5
+
+Suggested branch name: feature/PROJ-123-login-fails-on-safari
+```
+
+---
+
+## Configuration Commands
+
+### `jira profiles`
+
+List configured profiles.
+
+```bash
+jira profiles
+```
+
+**Output:**
+
+```
+| Name     | URL                              | Default |
+|----------|----------------------------------|---------|
+| personal | https://me.atlassian.net         | *       |
+| work     | https://company.atlassian.net    |         |
+```
+
+---
+
+### `jira config`
+
+Show current configuration.
+
+```bash
+jira config
+
+# Show specific profile
+jira config -p work
+```
+
+**Output:**
+
+```
+Profile: personal (default)
+URL: https://me.atlassian.net
+Username: me@example.com
+Default Project: PROJ
+```
+
+---
+
+## Output Formats
+
+### Table (default)
+
+Human-readable table format.
+
+```bash
+jira search "bug" --format table
+```
+
+### JSON
+
+Machine-readable JSON.
+
+```bash
+jira search "bug" --format json
+```
+
+### Markdown
+
+For inclusion in notes or documentation.
+
+```bash
+jira get PROJ-123 --format markdown
+```
+
+---
+
+## Examples by Use Case
+
+### Find and fix a bug
+
+```bash
+# 1. Search for bugs
+jira search "login" --type Bug --status "To Do"
+
+# 2. Get details on one
+jira get PROJ-123
+
+# 3. Start working
+jira transition PROJ-123 "In Progress"
+
+# 4. Create branch (see suggested name)
+jira dev PROJ-123 --create-branch
+
+# 5. Add comment when done
+jira comment PROJ-123 "Fixed in PR #42"
+
+# 6. Close it
+jira transition PROJ-123 "Done"
+```
+
+### Create a feature with subtasks
+
+```bash
+# 1. Create the story
+jira create -p PROJ -t Story -s "Add dark mode" --epic PROJ-100
+
+# Output: Created PROJ-456
+
+# 2. Add subtasks
+jira create -p PROJ -t Sub-task -s "Design mockups" --parent PROJ-456
+jira create -p PROJ -t Sub-task -s "Implement CSS" --parent PROJ-456
+jira create -p PROJ -t Sub-task -s "Write tests" --parent PROJ-456
+```
+
+### Cross-instance status check
+
+```bash
+# Find all your in-progress issues across all Jira instances
+jira search "assignee = currentUser() AND status = 'In Progress'" -p all
+```
+
+### Label-based workflow
+
+```bash
+# Find urgent items
+jira search --label urgent --label p0
+
+# Add review label
+jira label add PROJ-123 needs-review
+
+# Find items needing review
+jira search --label needs-review --assignee me
+```

--- a/.claude/skills/Jira/docs/CONCEPTS.md
+++ b/.claude/skills/Jira/docs/CONCEPTS.md
@@ -1,0 +1,326 @@
+# Concepts
+
+Core concepts behind the Jira skill architecture.
+
+## CLI-First Architecture
+
+Following PAI's deterministic-first principle, the Jira skill is built as:
+
+```
+Goal: Jira integration
+    ↓
+Code: bin/jira/jira.ts (TypeScript CLI)
+    ↓
+CLI: jira search|create|update|transition
+    ↓
+Prompts: SKILL.md translates natural language → CLI
+    ↓
+Agents: Claude executes workflows
+```
+
+**Why CLI-first?**
+- **Deterministic:** Same input → same output, testable without AI
+- **Scriptable:** Can be used in automation, CI/CD, scripts
+- **Debuggable:** Easy to test commands directly
+- **Composable:** Combine with other CLI tools (`|`, `xargs`, etc.)
+
+---
+
+## Multi-Instance Profiles
+
+The CLI supports multiple Jira instances through profile files.
+
+### Profile Structure
+
+```
+bin/jira/
+├── profiles/              ← Your profiles (gitignored)
+│   ├── personal.env
+│   ├── work.env
+│   └── default → personal.env  (symlink)
+└── profiles.example/      ← Template (example.env.template)
+    └── example.env.template
+```
+
+### Profile Contents
+
+```bash
+# profiles/personal.env
+JIRA_URL=https://your-domain.atlassian.net
+JIRA_USERNAME=your-email@example.com
+JIRA_API_TOKEN=your-api-token
+JIRA_DEFAULT_PROJECT=PROJ
+```
+
+### Profile Selection
+
+| Command | Profile Used |
+|---------|--------------|
+| `jira search "bug"` | Default profile |
+| `jira search "bug" -p work` | Work profile |
+| `jira search "bug" -p personal` | Personal profile |
+| `jira search "bug" -p all` | All profiles (parallel) |
+
+### Default Profile
+
+Set via symlink:
+```bash
+ln -sf personal.env profiles/default
+```
+
+Or set `JIRA_DEFAULT_PROFILE` environment variable.
+
+### Fallback Chain
+
+1. `-p <profile>` flag
+2. `profiles/default` symlink
+3. Environment variables (`JIRA_URL`, etc.)
+
+---
+
+## Two-Phase Retrieval
+
+Inspired by the Context skill's `obs search` → `obs load` pattern.
+
+### The Problem
+
+Loading full details for 50 issues:
+- Wastes tokens (descriptions, comments, links)
+- Slow API calls
+- Information overload
+
+### The Solution
+
+**Phase 1: Search (Discovery)**
+```bash
+jira search "authentication"
+```
+
+Returns compact index:
+```
+| #  | Key      | Type  | Summary                    | Status      |
+|----|----------|-------|----------------------------|-------------|
+| 1  | PROJ-123 | Bug   | Auth token expiring        | In Progress |
+| 2  | PROJ-456 | Story | Add OAuth2 support         | To Do       |
+```
+
+**Phase 2: Load (Detail)**
+```bash
+jira get PROJ-123
+```
+
+Returns full details for selected issue(s).
+
+### Claude Integration
+
+When Claude searches Jira:
+1. Runs `jira search` → shows table
+2. **Waits** for user to select items
+3. User says "load 1,2" → runs `jira get`
+
+This keeps context window lean.
+
+---
+
+## Cross-Instance Search
+
+Query all configured profiles in parallel.
+
+### How It Works
+
+```bash
+jira search "deployment" -p all
+```
+
+1. Loads all profiles from `profiles/`
+2. Sends search to each instance in parallel
+3. Merges results with instance indicator
+4. Handles timeouts gracefully (shows partial results)
+
+### Output
+
+```
+| #  | Instance | Key       | Summary              | Status |
+|----|----------|-----------|----------------------|--------|
+| 1  | personal | SIDE-42   | Deploy v2.0          | To Do  |
+| 2  | work     | PROJ-789  | Production deploy    | Done   |
+```
+
+### Auto-Detection
+
+When you `jira get PROJ-123`, the CLI:
+1. Checks cached project→instance mapping
+2. If known, uses that instance
+3. If unknown, queries all instances
+
+This means you can usually omit `-p` for `get` operations.
+
+---
+
+## Labels as Tags
+
+Use Jira labels like Obsidian vault tags.
+
+### Taxonomy Alignment
+
+If your vault uses tags like:
+- `#project/pai`
+- `#status/blocked`
+- `#priority/p0`
+
+Use matching Jira labels:
+- `project-pai`
+- `status-blocked`
+- `priority-p0`
+
+### Label Operations
+
+```bash
+# List all labels
+jira labels
+
+# Search by label
+jira search --label priority-p0
+jira search --any-label urgent blocked  # OR logic
+
+# Add/remove labels
+jira label add PROJ-123 needs-review
+jira label remove PROJ-123 wontfix
+```
+
+### AND vs OR Logic
+
+```bash
+# AND: issues with BOTH labels
+jira search --label urgent --label p0
+
+# OR: issues with ANY of the labels
+jira search --any-label urgent p0 blocked
+```
+
+---
+
+## Issue Hierarchy
+
+Jira supports issue hierarchy:
+
+```
+Epic (EPIC-100)
+├── Story (PROJ-123)
+│   ├── Sub-task (PROJ-124)
+│   └── Sub-task (PROJ-125)
+└── Story (PROJ-126)
+```
+
+### Creating Hierarchy
+
+```bash
+# Create story under epic
+jira create -t Story -s "New feature" --epic EPIC-100
+
+# Create sub-task under story
+jira create -t Sub-task -s "Write tests" --parent PROJ-123
+```
+
+### Linking to Epic
+
+```bash
+# Add existing issue to epic
+jira link PROJ-123 --epic EPIC-100
+```
+
+---
+
+## GitHub Integration
+
+The dev panel shows branches, PRs, and commits linked to issues.
+
+### How Linking Works
+
+1. Include issue key in branch name: `feature/PROJ-123-fix-auth`
+2. Include issue key in PR title or description
+3. Jira automatically links via GitHub integration
+
+### Viewing Dev Info
+
+```bash
+jira dev PROJ-123
+```
+
+Shows:
+- Branches containing the issue key
+- Pull requests referencing the issue
+- Commit count
+- PR status (Open, Merged, Declined)
+
+### Branch Name Suggestion
+
+```bash
+jira dev PROJ-123 --create-branch
+```
+
+Suggests: `feature/PROJ-123-summary-as-slug`
+
+---
+
+## Authentication
+
+### API Token (Current)
+
+Uses Basic Auth with API token:
+
+```
+Authorization: Basic base64(email:api_token)
+```
+
+Get token from: https://id.atlassian.com/manage-profile/security/api-tokens
+
+### OAuth 2.0 (Future)
+
+Enterprise SSO integration planned for v1.1.
+
+---
+
+## API Reference
+
+The CLI wraps Jira REST API v3:
+
+| Operation | Endpoint |
+|-----------|----------|
+| Search | `GET /rest/api/3/search` |
+| Get Issue | `GET /rest/api/3/issue/{key}` |
+| Create Issue | `POST /rest/api/3/issue` |
+| Update Issue | `PUT /rest/api/3/issue/{key}` |
+| Transitions | `GET /rest/api/3/issue/{key}/transitions` |
+| Transition | `POST /rest/api/3/issue/{key}/transitions` |
+| Comment | `POST /rest/api/3/issue/{key}/comment` |
+| Link Types | `GET /rest/api/3/issueLinkType` |
+| Create Link | `POST /rest/api/3/issueLink` |
+| Dev Info | `GET /rest/dev-status/latest/issue/detail` |
+| Projects | `GET /rest/api/3/project` |
+| Issue Types | `GET /rest/api/3/issuetype` |
+
+---
+
+## Error Handling
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| 401 Unauthorized | Invalid credentials | Check API token |
+| 403 Forbidden | No permission | Check project access |
+| 404 Not Found | Issue doesn't exist | Check issue key |
+| 400 Bad Request | Invalid input | Check field values |
+
+### Profile Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "No profiles found" | No `.env` files | Create profile |
+| "Profile not found" | Typo in `-p` | Check profile name |
+| "Missing JIRA_URL" | Incomplete profile | Check profile contents |
+
+### Network Errors
+
+The CLI has a 30-second timeout. For cross-instance search, partial results are returned if some instances timeout.

--- a/.claude/skills/Jira/workflows/create-issue.md
+++ b/.claude/skills/Jira/workflows/create-issue.md
@@ -1,0 +1,155 @@
+# Create Issue Workflow
+
+**Purpose:** Create new Jira issues with appropriate fields and project targeting.
+
+## Trigger Phrases
+- "create a jira ticket"
+- "new issue for [topic]"
+- "add a bug for [problem]"
+- "create story for [feature]"
+- "make a task for [work]"
+
+---
+
+## Workflow Steps
+
+### Step 1: Gather Required Information
+
+**Required fields:**
+- **Type**: Bug, Story, Task, Epic, Sub-task
+- **Summary**: Brief title (required)
+- **Project**: Which Jira instance (work/personal, defaults to configured default)
+
+**Optional fields:**
+- **Description**: Detailed description
+- **Priority**: Highest, High, Medium, Low, Lowest
+- **Labels**: Comma-separated labels
+- **Assignee**: User to assign (default: unassigned)
+- **Components**: Project components
+- **Epic**: Parent epic key
+
+### Step 2: Confirm Details
+
+Before creating, confirm with user:
+
+```
+Creating issue:
+  Project: INNOV (work)
+  Type: Bug
+  Summary: Login fails with SSO when using Chrome
+  Priority: High
+  Labels: security, authentication
+
+Proceed? (y/n or edit fields)
+```
+
+### Step 3: Create Issue
+
+```bash
+jira create --type Bug --summary "Login fails with SSO" --priority High --labels "security,authentication"
+```
+
+### Step 4: Report Result
+
+```
+✅ Created INNOV-47: Login fails with SSO when using Chrome
+   URL: https://company.atlassian.net/browse/INNOV-47
+   Status: Open
+   Assignee: Unassigned
+```
+
+---
+
+## Command Reference
+
+### Basic Creation
+
+```bash
+# Minimal (type + summary required)
+jira create --type Bug --summary "Button not responding"
+
+# With description
+jira create --type Story --summary "Add dark mode" --description "User preference for dark theme across the app"
+
+# Pipe description from stdin
+echo "Detailed description here..." | jira create --type Bug --summary "API timeout"
+```
+
+### With All Options
+
+```bash
+jira create \
+  --project work \
+  --type Story \
+  --summary "Implement user preferences API" \
+  --description "REST endpoints for user settings management" \
+  --priority High \
+  --labels "api,backend" \
+  --assignee "me" \
+  --epic "INNOV-10"
+```
+
+### Personal Project
+
+```bash
+jira create --project personal --type Task --summary "Review insurance documents"
+```
+
+---
+
+## Issue Types
+
+| Type | Use For |
+|------|---------|
+| Bug | Defects, errors, unexpected behavior |
+| Story | User-facing features |
+| Task | Technical work, non-feature items |
+| Epic | Large initiatives containing multiple stories |
+| Sub-task | Child of another issue |
+
+---
+
+## From Conversation Context
+
+When user discusses a problem and asks to create a ticket:
+
+1. **Extract key information** from conversation
+2. **Suggest issue type** based on context (bug vs story vs task)
+3. **Draft summary and description** from discussion
+4. **Confirm with user** before creating
+
+Example:
+```
+User: "The login is broken when using SSO. Can you create a ticket for that?"
+
+Claude: I'll create a bug ticket for this:
+
+  Type: Bug
+  Summary: Login fails when using SSO authentication
+  Description: Users are unable to log in when using SSO.
+               The login page shows an error after redirect.
+  Priority: High (blocking user access)
+
+Shall I create this? (y/n or suggest changes)
+```
+
+---
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Project not found" | Invalid project key | Check `jira projects` for valid aliases |
+| "Issue type not valid" | Wrong type for project | Check `jira types --project work` |
+| "Required field missing" | Missing summary or type | Provide all required fields |
+| "Permission denied" | No create permission | Check Jira permissions |
+
+---
+
+## Best Practices
+
+1. **Be specific in summaries** - Good: "Login fails with SSO on Chrome" / Bad: "Login broken"
+2. **Add context in description** - Include steps to reproduce, expected vs actual
+3. **Set appropriate priority** - Don't make everything High
+4. **Use labels consistently** - Check existing labels with `jira search --labels`
+5. **Link to parent epic** - Keep work organized under epics

--- a/.claude/skills/Jira/workflows/manage-issue.md
+++ b/.claude/skills/Jira/workflows/manage-issue.md
@@ -1,0 +1,212 @@
+# Manage Issue Workflow
+
+**Purpose:** Update, transition, and comment on existing Jira issues.
+
+## Trigger Phrases
+- "move [issue] to done"
+- "update [issue]"
+- "transition [issue] to [status]"
+- "add comment to [issue]"
+- "assign [issue] to [person]"
+- "change priority of [issue]"
+
+---
+
+## Operations
+
+### 1. View Issue Details
+
+```bash
+# Full issue details
+jira view INNOV-42
+
+# Output includes:
+# - Key, Type, Status, Priority
+# - Summary and Description
+# - Assignee, Reporter
+# - Labels, Components
+# - Comments (recent)
+# - Linked issues
+# - Created/Updated dates
+```
+
+### 2. Transition Status
+
+Move issue through workflow states:
+
+```bash
+# Common transitions
+jira transition INNOV-42 "In Progress"
+jira transition INNOV-42 "In Review"
+jira transition INNOV-42 "Done"
+
+# Check available transitions
+jira transitions INNOV-42
+```
+
+**Available Transitions** depend on current status and workflow:
+- Open → In Progress
+- In Progress → In Review
+- In Review → Done
+- Any → Blocked (with resolution)
+
+### 3. Update Fields
+
+```bash
+# Single field
+jira update INNOV-42 --assignee "jane.doe"
+jira update INNOV-42 --priority High
+jira update INNOV-42 --labels "security,urgent"
+
+# Multiple fields
+jira update INNOV-42 --assignee me --priority High --labels "urgent"
+
+# Update description
+echo "Updated description..." | jira update INNOV-42 --description -
+```
+
+### 4. Add Comments
+
+```bash
+# Simple comment
+jira comment INNOV-42 "Fixed in commit abc123"
+
+# Multi-line comment
+jira comment INNOV-42 "Investigation complete:
+- Root cause: race condition in auth flow
+- Fix: added mutex lock
+- Testing: unit tests added"
+
+# From stdin
+echo "Detailed analysis..." | jira comment INNOV-42
+```
+
+### 5. Link Issues
+
+```bash
+# Link to another issue
+jira link INNOV-42 INNOV-38 "blocks"
+jira link INNOV-42 INNOV-50 "is blocked by"
+jira link INNOV-42 INNOV-45 "relates to"
+```
+
+---
+
+## Common Workflows
+
+### Bug Fix Workflow
+
+```bash
+# 1. Pick up the bug
+jira transition INNOV-42 "In Progress"
+jira update INNOV-42 --assignee me
+
+# 2. Add investigation notes
+jira comment INNOV-42 "Investigating: appears to be auth token expiry issue"
+
+# 3. Fix complete, ready for review
+jira transition INNOV-42 "In Review"
+jira comment INNOV-42 "Fix in PR #123"
+
+# 4. After approval
+jira transition INNOV-42 "Done"
+jira comment INNOV-42 "Deployed to production"
+```
+
+### Story Completion
+
+```bash
+# Start work
+jira transition INNOV-38 "In Progress"
+
+# Update with progress
+jira comment INNOV-38 "API endpoints complete, starting UI"
+
+# Ready for review
+jira transition INNOV-38 "In Review"
+
+# Done
+jira transition INNOV-38 "Done"
+```
+
+### Blocking Issue
+
+```bash
+# Mark as blocked
+jira transition INNOV-42 "Blocked"
+jira comment INNOV-42 "Blocked by: waiting for API access from external team"
+jira link INNOV-42 EXT-15 "is blocked by"
+
+# When unblocked
+jira transition INNOV-42 "In Progress"
+jira comment INNOV-42 "Unblocked: API access granted"
+```
+
+---
+
+## Batch Operations
+
+### Update Multiple Issues
+
+```bash
+# From previous search results
+jira search --assignee "old.user" --status open --format index
+jira batch-update 1-10 --assignee "new.user"
+
+# Or by key list
+jira batch-update INNOV-42,INNOV-43,INNOV-44 --labels "sprint-5"
+```
+
+### Bulk Transition
+
+```bash
+# Move all "In Review" to "Done"
+jira search --status "In Review" --format index
+jira batch-transition all "Done"
+```
+
+---
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Transition not available" | Invalid status change | Check `jira transitions INNOV-42` |
+| "Issue not found" | Wrong key | Verify issue key exists |
+| "Field not editable" | Permission or workflow restriction | Check field permissions |
+| "User not found" | Invalid assignee | Use email or account ID |
+
+---
+
+## Field Reference
+
+| Field | Flag | Example |
+|-------|------|---------|
+| Assignee | `--assignee` | `me`, `john.doe@company.com` |
+| Priority | `--priority` | `Highest`, `High`, `Medium`, `Low`, `Lowest` |
+| Labels | `--labels` | `"security,urgent"` (comma-separated) |
+| Components | `--components` | `"backend,api"` |
+| Fix Version | `--fix-version` | `"v2.1.0"` |
+| Sprint | `--sprint` | Sprint name or ID |
+| Story Points | `--story-points` | Numeric value |
+| Description | `--description` | Text or `-` for stdin |
+
+---
+
+## Integration with Context
+
+When discussing issues already loaded in context:
+
+1. **Reference by key** - Use exact issue key from loaded context
+2. **Batch operations** - Can update multiple issues mentioned in conversation
+3. **Smart suggestions** - Claude can suggest transitions based on discussion
+
+Example:
+```
+User: "The SSO bug is fixed, can you close it?"
+Claude: [finds INNOV-42 in loaded context]
+        Moving INNOV-42 to Done...
+        ✅ INNOV-42 transitioned to Done
+
+        Would you like me to add a comment about the fix?
+```

--- a/.claude/skills/Jira/workflows/search-issues.md
+++ b/.claude/skills/Jira/workflows/search-issues.md
@@ -1,0 +1,188 @@
+# Search Issues Workflow
+
+**Purpose:** Find Jira issues using JQL queries and load selected issues into context.
+
+## Trigger Phrases
+- "what jira issues do I have"
+- "search jira for [query]"
+- "my open tickets"
+- "issues in [project]"
+- "bugs assigned to me"
+- "what's in the backlog"
+
+## CRITICAL: Iterative Search → Load Loop
+
+**This is an ITERATIVE workflow. Each cycle has two steps: Search → Load.**
+**User may run multiple cycles until they have enough context.**
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  SEARCH → LOAD LOOP                 │
+│                                                     │
+│   ┌─────────┐     ┌──────┐     ┌───────────────┐   │
+│   │ SEARCH  │ ──► │ WAIT │ ──► │ LOAD selected │   │
+│   └─────────┘     └──────┘     └───────────────┘   │
+│        ▲                              │            │
+│        │                              ▼            │
+│        │         ┌──────────────────────────┐      │
+│        └──────── │ Need more context? ──────┼──► Done
+│                  └──────────────────────────┘      │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+### Step 1: SEARCH (then STOP and WAIT)
+
+Run search with `--format index`:
+```bash
+# Text search
+jira search "authentication bug" --format index
+
+# By assignee
+jira search --assignee me --format index
+
+# Combined filters
+jira search --project work --status open --type Bug --format index
+
+# Custom JQL
+jira search --jql "project = INNOV AND assignee = currentUser()" --format index
+```
+
+**Parse the output** and present as markdown table:
+
+| # | Key | Type | Status | Summary | Assignee |
+|---|-----|------|--------|---------|----------|
+| 1 | INNOV-42 | Bug | Open | Login fails with SSO | me |
+| 2 | INNOV-38 | Story | In Progress | Add OAuth2 support | me |
+...
+
+**STOP.** Ask user:
+> "Found N issues. Which to load? (e.g., `1,2,5` or `all` or `1-10`)"
+
+**WAIT for user response.**
+
+---
+
+### Step 2: LOAD (then check if more needed)
+
+When user selects (e.g., "1,2,5"):
+```bash
+jira load 1,2,5
+```
+
+Summarize what was loaded, then ask:
+> "Loaded 3 issues. Need more context? You can:
+> - Search again with different criteria
+> - Load more from the previous search
+> - Ask questions about what's loaded"
+
+---
+
+## Search Parameters
+
+### Filter Options
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--project` | Project alias (work/personal) | `--project work` |
+| `--assignee` | Issue assignee | `--assignee me`, `--assignee "john.doe"` |
+| `--status` | Issue status | `--status open`, `--status "In Progress"` |
+| `--type` | Issue type | `--type Bug`, `--type Story` |
+| `--priority` | Issue priority | `--priority High` |
+| `--labels` | Issue labels | `--labels "security"` |
+| `--updated` | Updated within | `--updated 7d`, `--updated 1w` |
+| `--created` | Created within | `--created 30d` |
+| `--jql` | Custom JQL query | `--jql "project = INNOV AND ..."` |
+
+### Common JQL Patterns
+
+```bash
+# My open issues
+jira search --assignee me --status open --format index
+
+# Unassigned bugs in project
+jira search --project work --type Bug --assignee unassigned --format index
+
+# High priority items
+jira search --priority High --status open --format index
+
+# Recently updated
+jira search --project work --updated 7d --format index
+
+# Custom JQL for complex queries
+jira search --jql "project = INNOV AND status IN ('Open', 'In Progress') AND labels = 'security' ORDER BY priority DESC" --format index
+```
+
+---
+
+## Iteration Examples
+
+**Example 1: Single search, partial load**
+```
+User: "What jira issues do I have?"
+Claude: [shows 15 results] "Which to load?"
+User: "1-5"
+Claude: [loads 5] "Need more?"
+User: "Also 8"
+Claude: [loads 1 more] "Now have 6 issues loaded."
+```
+
+**Example 2: Multiple searches**
+```
+User: "My open bugs"
+Claude: [shows 8 results] "Which to load?"
+User: "all"
+Claude: [loads 8] "Need more context?"
+User: "Also search for security-related stories"
+Claude: [new search, shows 4 results] "Which to load?"
+User: "all"
+Claude: [loads 4 more] "Now have 12 issues total."
+```
+
+**Example 3: Refine search**
+```
+User: "Issues in INNOV project"
+Claude: [shows 50 results] "Which to load?"
+User: "Too many. Filter to just bugs"
+Claude: [runs filtered search, shows 12 results] "Which to load?"
+```
+
+---
+
+## Key Principles
+
+1. **Always STOP after showing results** - Never auto-load
+2. **User controls what gets loaded** - They manage their context window
+3. **Support iteration** - Multiple searches, cumulative loading
+4. **Summarize loaded context** - Help user track what's in context
+5. **Use project aliases** - `work` and `personal` map to configured Jira instances
+
+---
+
+## Output Format
+
+Search results are cached in `~/.cache/jira/last-search.json` for the load command:
+
+```json
+{
+  "timestamp": "2025-01-15T10:30:00Z",
+  "query": "--assignee me --status open",
+  "project": "work",
+  "results": [
+    {
+      "index": 1,
+      "key": "INNOV-42",
+      "type": "Bug",
+      "status": "Open",
+      "summary": "Login fails with SSO",
+      "assignee": "me",
+      "priority": "High",
+      "created": "2025-01-10",
+      "updated": "2025-01-14"
+    }
+  ]
+}
+```
+
+Load command reads this cache and fetches full details for selected indices.

--- a/bin/jira/bun.lock
+++ b/bin/jira/bun.lock
@@ -1,0 +1,23 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "jira-cli",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+
+    "@types/node": ["@types/node@25.0.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg=="],
+
+    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/bin/jira/jira.ts
+++ b/bin/jira/jira.ts
@@ -1,0 +1,1683 @@
+#!/usr/bin/env bun
+
+/**
+ * jira - PAI JIRA CLI
+ *
+ * Deterministic command-line interface for Jira operations.
+ * Supports multiple Jira instances via profile-based configuration.
+ *
+ * Commands:
+ *   search      Search issues (JQL or text)
+ *   get         Get issue details
+ *   create      Create new issue
+ *   update      Update issue
+ *   transition  Change issue status
+ *   comment     Add comment
+ *   transitions List available transitions
+ *   projects    List projects
+ *   types       List issue types
+ *   labels      List/manage labels
+ *   label       Add/remove label from issue
+ *   filters     List saved filters
+ *   link        Create issue link
+ *   unlink      Remove issue link
+ *   link-types  List link types
+ *   links       Show issue links
+ *   dev         Show GitHub dev info
+ *   config      Show configuration
+ *   profiles    List profiles
+ */
+
+import {
+  getConfig,
+  listProfiles,
+  getAllConfigs,
+  loadProfile,
+  cacheProjectProfile,
+  getCachedProfile,
+  getProjectKeyFromIssue,
+  getProfileForProject,
+  writeProfileProjects,
+  type JiraConfig,
+} from "./lib/config";
+import {
+  JiraClient,
+  textToJql,
+  type CreateIssueInput,
+  type JiraIssue,
+  type JiraFilter,
+  type JiraFilterSharePermission,
+} from "./lib/api";
+import {
+  formatIssueIndex,
+  formatIssueDetail,
+  formatProjects,
+  formatTransitions,
+  formatLinkTypes,
+  formatDevInfo,
+  formatLabels,
+  formatProfiles,
+  suggestBranchName,
+  type OutputFormat,
+} from "./lib/format";
+import {
+  isVisionAvailable,
+  getVisionConfig,
+  analyzeAttachments,
+  formatVisionAnalysis,
+} from "./lib/vision";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ============================================================================
+// Quick Filters (Service Desk Default Filters)
+// ============================================================================
+
+const QUICK_FILTERS: Record<string, string> = {
+  // Open/closed status
+  "all": "project = {project}",
+  "all work items": "project = {project}",
+  "open": "project = {project} AND resolution = Unresolved",
+  "open work items": "project = {project} AND resolution = Unresolved",
+  "my open": "project = {project} AND assignee = currentUser() AND resolution = Unresolved",
+  "my open work items": "project = {project} AND assignee = currentUser() AND resolution = Unresolved",
+  "done": "project = {project} AND statusCategory = Done",
+  "done work items": "project = {project} AND statusCategory = Done",
+
+  // Reporter/assignee
+  "reported by me": "project = {project} AND reporter = currentUser()",
+  "assigned to me": "project = {project} AND assignee = currentUser()",
+  "unassigned": "project = {project} AND assignee IS EMPTY AND resolution = Unresolved",
+
+  // Time-based
+  "viewed recently": "project = {project} AND issuekey IN issueHistory()",
+  "created recently": "project = {project} AND created >= -7d",
+  "resolved recently": "project = {project} AND resolved >= -7d",
+  "updated recently": "project = {project} AND updated >= -7d",
+  "created today": "project = {project} AND created >= startOfDay()",
+  "updated today": "project = {project} AND updated >= startOfDay()",
+
+  // Priority
+  "high priority": "project = {project} AND priority IN (High, Highest) AND resolution = Unresolved",
+  "critical": "project = {project} AND priority = Highest AND resolution = Unresolved",
+};
+
+function getQuickFilter(name: string, project: string): string | null {
+  const key = name.toLowerCase().trim();
+  const jql = QUICK_FILTERS[key];
+  if (!jql) return null;
+  return jql.replace(/\{project\}/g, project);
+}
+
+function listQuickFilters(): void {
+  console.log("Available quick filters:\n");
+  const seen = new Set<string>();
+  for (const [name, jql] of Object.entries(QUICK_FILTERS)) {
+    if (!seen.has(jql)) {
+      console.log(`  "${name}"`);
+      seen.add(jql);
+    }
+  }
+  console.log("\nUsage: jira search --quick \"open\" --project HD");
+}
+
+// ============================================================================
+// Search Result Cache (for load command)
+// ============================================================================
+
+const CACHE_DIR = join(homedir(), ".claude", "jira", "cache");
+const CACHE_FILE = join(CACHE_DIR, "last-search.json");
+
+interface SearchCache {
+  timestamp: string;
+  profileName: string;
+  issues: Array<{ key: string; summary: string; _instance?: string }>;
+}
+
+async function saveSearchCache(
+  issues: Array<JiraIssue & { _instance?: string }>,
+  profileName: string
+): Promise<void> {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+  const cache: SearchCache = {
+    timestamp: new Date().toISOString(),
+    profileName,
+    issues: issues.map(i => ({
+      key: i.key,
+      summary: i.fields.summary,
+      _instance: i._instance,
+    })),
+  };
+  writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2));
+}
+
+function loadSearchCache(): SearchCache | null {
+  if (!existsSync(CACHE_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(CACHE_FILE, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse selection string (e.g., "1,2,5", "1-10", "all", "SMS-123") to issue keys
+ * Cache is optional - only needed for index-based selection
+ */
+function parseSelection(selection: string, cache: SearchCache | null): string[] {
+  if (selection === "all") {
+    if (!cache) {
+      console.error("No search results cached. Run 'jira search' first for 'all' selection.");
+      process.exit(1);
+    }
+    return cache.issues.map(i => i.key);
+  }
+
+  const keys: string[] = [];
+  const parts = selection.split(",");
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (/^[A-Z]+-\d+$/i.test(trimmed)) {
+      // Direct issue key: "SMS-123" (check first to avoid confusion with ranges)
+      keys.push(trimmed.toUpperCase());
+    } else if (trimmed.includes("-") && /^\d+-\d+$/.test(trimmed)) {
+      // Range: "1-5"
+      if (!cache) {
+        console.error("No search results cached. Run 'jira search' first for index selection.");
+        process.exit(1);
+      }
+      const [start, end] = trimmed.split("-").map(n => parseInt(n, 10));
+      for (let i = start; i <= end && i <= cache.issues.length; i++) {
+        if (i > 0) keys.push(cache.issues[i - 1].key);
+      }
+    } else if (/^\d+$/.test(trimmed)) {
+      // Single number: "3"
+      if (!cache) {
+        console.error("No search results cached. Run 'jira search' first for index selection.");
+        process.exit(1);
+      }
+      const idx = parseInt(trimmed, 10);
+      if (idx > 0 && idx <= cache.issues.length) {
+        keys.push(cache.issues[idx - 1].key);
+      }
+    }
+  }
+
+  return [...new Set(keys)]; // Deduplicate
+}
+
+// ============================================================================
+// Opened Ticket (for single-ticket workflow)
+// ============================================================================
+
+const OPENED_FILE = join(CACHE_DIR, "opened.json");
+
+interface OpenedTicket {
+  key: string;
+  summary: string;
+  profileName: string;
+  openedAt: string;
+}
+
+function saveOpenedTicket(ticket: OpenedTicket): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+  writeFileSync(OPENED_FILE, JSON.stringify(ticket, null, 2));
+}
+
+function loadOpenedTicket(): OpenedTicket | null {
+  if (!existsSync(OPENED_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(OPENED_FILE, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function clearOpenedTicket(): boolean {
+  if (!existsSync(OPENED_FILE)) return false;
+  try {
+    const { unlinkSync } = require("fs");
+    unlinkSync(OPENED_FILE);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the issue key for write operations.
+ * Uses opened ticket if no explicit key provided.
+ */
+function getWriteTargetKey(explicitKey: string | undefined): string | null {
+  if (explicitKey) return explicitKey;
+  const opened = loadOpenedTicket();
+  return opened?.key || null;
+}
+
+// ============================================================================
+// Help Text
+// ============================================================================
+
+const HELP = `
+jira - PAI JIRA CLI
+
+USAGE:
+  jira <command> [options]
+
+COMMANDS:
+  search <query>         Search issues (JQL or text)
+  load <sel>             Load issue details (key, indices, or 'all')
+  open <key>             Open ticket for interaction (single-ticket mode)
+  close                  Close opened ticket
+  status                 Show currently opened ticket
+  create                 Create new issue
+  update <key>           Update issue
+  transition <key> <status>  Change issue status
+  comment <key> <text>   Add comment to issue
+  transitions <key>      List available transitions
+  projects               List accessible projects
+  types [project]        List issue types
+  labels [key]           List labels (or labels on issue)
+  label add <key> <label>    Add label to issue
+  label remove <key> <label> Remove label from issue
+  filters [name]         List saved/favourite filters
+  link <key1> <type> <key2>  Link two issues
+  link <key> --epic <epic>   Add issue to epic
+  unlink <key1> <key2>       Remove link between issues
+  link-types             List available link types
+  links <key>            Show all links on issue
+  dev <key>              Show GitHub dev info (branches, PRs, commits)
+  config                 Show current configuration
+  profiles               List available profiles
+  setup                  Discover projects and configure auto-detection
+
+GLOBAL OPTIONS:
+  --profile, -p <name>   Use specific profile (or 'all' for federated search)
+  --format, -f <fmt>     Output format: table (default), json, markdown
+  --help, -h             Show this help
+
+SEARCH OPTIONS:
+  --project, -P <key>    Filter by project
+  --filter <name|id>     Use a saved Jira filter
+  --quick, -q <name>     Use a quick filter (e.g., "open", "my open", "created today")
+  --label <label>        Filter by label (AND logic, repeatable)
+  --any-label <label>    Filter by label (OR logic, repeatable)
+  --order <field>        Order by: updated (default), created, key, priority, status
+  --asc                  Ascending order (default: descending)
+  --limit, -l <n>        Limit results (default: 20)
+
+CREATE OPTIONS:
+  --project, -P <key>    Project key (or use default)
+  --type, -T <type>      Issue type: Epic, Story, Task, Bug, Sub-task
+  --summary, -s <text>   Issue summary
+  --description, -d <text>  Description
+  --assignee, -a <user>  Assign to user
+  --labels <l1,l2>       Comma-separated labels
+  --label <label>        Single label (repeatable)
+  --epic <key>           Parent epic
+  --parent <key>         Parent issue (for sub-tasks)
+  --priority <name>      Priority level
+
+UPDATE OPTIONS:
+  --summary, -s <text>   New summary
+  --description, -d <text>  New description
+  --assignee, -a <user>  New assignee
+  --type, -t <type>      Change issue type (e.g., Story → Epic)
+  --priority <name>      New priority
+  --labels <l1,l2>       Replace all labels
+  --label <label>        Add label (repeatable)
+
+DEV OPTIONS:
+  --branches             Show only branches
+  --prs                  Show only pull requests
+  --create-branch        Output suggested branch name
+  --checkout             Create and checkout branch (requires git)
+
+VISION OPTIONS:
+  --vision               Analyze image attachments with AI (requires OPENAI_API_KEY)
+
+FILTER OPTIONS:
+  --owner, -o <name>     Filter filters by owner name (partial match)
+  --mine, --my           Show only your filters
+  --favourites           Show only starred/favourite filters
+
+EXAMPLES:
+  # Search
+  jira search "login bug"
+  jira search "project = PAI AND status = Open"
+  jira search --label project/pai --limit 10
+  jira search -p all "urgent"              # Search all instances
+
+  # Quick filters (Service Desk defaults)
+  jira search --quick "open" --project HD          # Open work items
+  jira search --quick "my open" -P HD              # My open work items
+  jira search --quick "created today" -P HD        # Created today
+  jira search --quick list                         # List all quick filters
+
+  # Saved filters
+  jira search --filter "My Active Issues"  # Use saved filter
+  jira filters                             # List saved filters
+  jira filters "HD" --owner "Paige"        # Filter by owner
+
+  # Load issues
+  jira load PAI-123                        # By key
+  jira load 1,2,5                          # By index from search
+  jira load 1-10                           # Range from search
+  jira load all -f json                    # All from search as JSON
+  jira load PAI-123 --vision               # With image analysis
+
+  # Create
+  jira create --type Bug --summary "Fix login" --labels "project/pai,urgent"
+  jira create --type Story --summary "New feature" --epic PAI-100
+  jira create --type Sub-task --summary "Write tests" --parent PAI-123
+  jira transition PAI-123 "In Progress"
+  jira comment PAI-123 "Fixed in commit abc123"
+
+  # Labels
+  jira labels                              # List all labels
+  jira labels --prefix "project/"          # Labels starting with prefix
+  jira label add PAI-123 urgent
+  jira label remove PAI-123 urgent
+
+  # Linking
+  jira link PAI-123 "blocks" PAI-456
+  jira link PAI-123 --epic EPIC-100
+  jira unlink PAI-123 PAI-456
+  jira links PAI-123
+
+  # GitHub integration
+  jira dev PAI-123                         # Show branches, PRs, commits
+  jira dev PAI-123 --create-branch         # Suggest branch name
+
+  # Configuration
+  jira profiles                            # List profiles
+  jira config                              # Show current config
+`;
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    console.log(HELP);
+    process.exit(0);
+  }
+
+  const command = args[0];
+  const rawCommandArgs = args.slice(1);
+
+  // Parse global options and filter them out
+  let profileName: string | undefined;
+  let format: OutputFormat = "table";
+  const commandArgs: string[] = [];
+
+  for (let i = 0; i < rawCommandArgs.length; i++) {
+    if (rawCommandArgs[i] === "--profile" || rawCommandArgs[i] === "-p") {
+      profileName = rawCommandArgs[++i];
+    } else if (rawCommandArgs[i] === "--format" || rawCommandArgs[i] === "-f") {
+      const fmt = rawCommandArgs[++i];
+      if (["table", "json", "markdown", "index"].includes(fmt)) {
+        format = fmt as OutputFormat;
+      }
+    } else {
+      commandArgs.push(rawCommandArgs[i]);
+    }
+  }
+
+  try {
+    switch (command) {
+      case "search":
+        await handleSearch(commandArgs, profileName, format);
+        break;
+      case "load":
+        await handleLoad(commandArgs, profileName, format);
+        break;
+      case "get":
+        // Deprecated: use 'load' instead
+        console.error("Note: 'get' is deprecated. Use 'jira load <key>' instead.\n");
+        await handleLoad(commandArgs, profileName, format);
+        break;
+      case "open":
+        await handleOpen(commandArgs, profileName);
+        break;
+      case "close":
+        handleClose();
+        break;
+      case "status":
+        handleStatus();
+        break;
+      case "create":
+        await handleCreate(commandArgs, profileName);
+        break;
+      case "update":
+        await handleUpdate(commandArgs, profileName);
+        break;
+      case "transition":
+        await handleTransition(commandArgs, profileName);
+        break;
+      case "comment":
+        await handleComment(commandArgs, profileName);
+        break;
+      case "transitions":
+        await handleTransitions(commandArgs, profileName, format);
+        break;
+      case "projects":
+        await handleProjects(profileName, format);
+        break;
+      case "types":
+        await handleTypes(commandArgs, profileName, format);
+        break;
+      case "labels":
+        await handleLabels(commandArgs, profileName, format);
+        break;
+      case "label":
+        await handleLabelOp(commandArgs, profileName);
+        break;
+      case "filters":
+        await handleFilters(commandArgs, profileName, format);
+        break;
+      case "link":
+        await handleLink(commandArgs, profileName);
+        break;
+      case "unlink":
+        await handleUnlink(commandArgs, profileName);
+        break;
+      case "link-types":
+        await handleLinkTypes(profileName, format);
+        break;
+      case "links":
+        await handleLinks(commandArgs, profileName, format);
+        break;
+      case "dev":
+        await handleDev(commandArgs, profileName, format);
+        break;
+      case "config":
+        await handleConfig(profileName);
+        break;
+      case "profiles":
+        handleProfiles();
+        break;
+      case "setup":
+        await handleSetup(profileName);
+        break;
+      default:
+        console.error(`Unknown command: ${command}`);
+        console.log("Run 'jira --help' for usage.");
+        process.exit(1);
+    }
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}
+
+// ============================================================================
+// Command Handlers
+// ============================================================================
+
+async function handleSearch(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  // Parse options
+  let query = "";
+  let project: string | undefined;
+  let filterNameOrId: string | undefined;
+  let quickFilterName: string | undefined;
+  const labels: string[] = [];
+  const anyLabels: string[] = [];
+  let limit = 20;
+  let orderBy = "updated";  // Default order
+  let ascending = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--project" || arg === "-P") {
+      project = args[++i];
+    } else if (arg === "--filter") {
+      filterNameOrId = args[++i];
+    } else if (arg === "--quick" || arg === "-q") {
+      quickFilterName = args[++i];
+    } else if (arg === "--label") {
+      labels.push(args[++i]);
+    } else if (arg === "--any-label") {
+      anyLabels.push(args[++i]);
+    } else if (arg === "--order") {
+      orderBy = args[++i];
+    } else if (arg === "--asc") {
+      ascending = true;
+    } else if (arg === "--limit" || arg === "-l") {
+      limit = parseInt(args[++i], 10);
+    } else if (!arg.startsWith("-") && !arg.startsWith("--")) {
+      query = arg;
+    }
+  }
+
+  // Handle quick filters (Service Desk defaults)
+  if (quickFilterName) {
+    // List quick filters if requested
+    if (quickFilterName === "list" || quickFilterName === "help") {
+      listQuickFilters();
+      return;
+    }
+
+    // Get project from flag or config
+    const config = getConfig(profileName);
+    const effectiveProject = project || config.defaultProject;
+    if (!effectiveProject) {
+      console.error("Quick filters require --project or JIRA_DEFAULT_PROJECT in profile");
+      console.error("\nUsage: jira search --quick \"open\" --project HD");
+      process.exit(1);
+    }
+
+    const quickJql = getQuickFilter(quickFilterName, effectiveProject);
+    if (!quickJql) {
+      console.error(`Unknown quick filter: "${quickFilterName}"`);
+      console.error("\nAvailable quick filters:");
+      listQuickFilters();
+      process.exit(1);
+    }
+
+    query = quickJql;
+    project = undefined; // Already in JQL
+    console.log(`Using quick filter: ${quickFilterName}`);
+    console.log(`JQL: ${query}\n`);
+  }
+
+  // If using a saved filter, get its JQL first
+  if (filterNameOrId) {
+    // Cannot use filter with federated search
+    if (profileName === "all") {
+      console.error("Cannot use --filter with federated search (-p all)");
+      process.exit(1);
+    }
+    const config = getConfig(profileName);
+    const client = new JiraClient(config);
+    try {
+      query = await client.getFilterJql(filterNameOrId);
+      console.log(`Using filter: ${filterNameOrId}`);
+      console.log(`JQL: ${query}\n`);
+    } catch (err) {
+      console.error(`Filter error: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  }
+
+  // Build JQL
+  // If using a filter, the query is already JQL - don't transform
+  let jql = filterNameOrId ? query : (query ? textToJql(query) : "");
+  if (project) {
+    jql = jql ? `project = ${project} AND (${jql})` : `project = ${project}`;
+  }
+  if (labels.length) {
+    const labelClause = labels.map(l => `labels = "${l}"`).join(" AND ");
+    jql = jql ? `(${jql}) AND ${labelClause}` : labelClause;
+  }
+  if (anyLabels.length) {
+    const labelClause = `labels IN (${anyLabels.map(l => `"${l}"`).join(", ")})`;
+    jql = jql ? `(${jql}) AND ${labelClause}` : labelClause;
+  }
+  // Add ORDER BY clause (unless filter already has one)
+  const orderDirection = ascending ? "ASC" : "DESC";
+  const orderClause = `ORDER BY ${orderBy} ${orderDirection}`;
+  if (!jql) {
+    jql = orderClause;
+  } else if (!jql.toUpperCase().includes("ORDER BY")) {
+    jql += ` ${orderClause}`;
+  }
+
+  // Federated search (all profiles)
+  if (profileName === "all") {
+    const configs = getAllConfigs();
+    const allIssues: Array<JiraIssue & { _instance: string }> = [];
+
+    await Promise.all(
+      configs.map(async (config) => {
+        try {
+          const client = new JiraClient(config);
+          const result = await client.searchIssues(jql, { maxResults: limit });
+          for (const issue of result.issues) {
+            allIssues.push({ ...issue, _instance: config.profileName });
+            cacheProjectProfile(getProjectKeyFromIssue(issue.key), config.profileName);
+          }
+        } catch (err) {
+          console.error(`[${config.profileName}] ${err instanceof Error ? err.message : err}`);
+        }
+      })
+    );
+
+    console.log(`Found ${allIssues.length} issues across ${configs.length} instances:\n`);
+    console.log(formatIssueIndex(allIssues, format, true));
+
+    // Save federated search results for load command
+    await saveSearchCache(allIssues, "all");
+    console.log(`\nWhich to load? (jira load <KEY> / jira load 1,2,5 / jira load all -f json)`);
+    return;
+  }
+
+  // Single instance search
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const result = await client.searchIssues(jql, { maxResults: limit });
+
+  // Cache project mappings
+  for (const issue of result.issues) {
+    cacheProjectProfile(getProjectKeyFromIssue(issue.key), config.profileName);
+  }
+
+  const totalText = result.total !== undefined
+    ? `${result.total} issues${result.total > limit ? ` (showing ${limit})` : ""}`
+    : `${result.issues.length} issues${result.isLast === false ? " (more available)" : ""}`;
+  console.log(`Found ${totalText}:\n`);
+  console.log(formatIssueIndex(result.issues, format));
+
+  // Save search results for load command
+  await saveSearchCache(result.issues, config.profileName);
+  console.log(`\nWhich to load? (jira load <KEY> / jira load 1,2,5 / jira load all -f json)`);
+}
+
+async function handleLoad(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  const selection = args.find(a => !a.startsWith("-"));
+  const useVision = args.includes("--vision");
+
+  if (!selection) {
+    console.error("Usage: jira load <selection> [--vision]\n");
+    console.error("Examples:");
+    console.error("  jira load SMS-123    Load issue by key");
+    console.error("  jira load 1,2,5      Load issues 1, 2, 5 from last search");
+    console.error("  jira load 1-10       Load issues 1 through 10 from search");
+    console.error("  jira load all        Load all issues from last search");
+    console.error("  jira load all -f json   Load all as JSON for context");
+    console.error("  jira load SMS-123 --vision  Load with image analysis");
+    process.exit(1);
+  }
+
+  // Check vision availability
+  if (useVision && !isVisionAvailable()) {
+    console.error("Vision requires OPENAI_API_KEY environment variable.");
+    console.error("Set it in your shell or add to ~/.claude/.env");
+    process.exit(1);
+  }
+
+  // Cache is optional - only needed for index-based selection
+  const cache = loadSearchCache();
+  const keys = parseSelection(selection, cache);
+
+  if (keys.length === 0) {
+    console.error(`No issues matched selection: ${selection}`);
+    if (cache) {
+      console.error(`Last search had ${cache.issues.length} results.`);
+    }
+    process.exit(1);
+  }
+
+  console.error(`Loading ${keys.length} issue(s)...\n`);
+
+  // Collect all issues with full details
+  const loadedIssues: JiraIssue[] = [];
+  const groupedByProfile = new Map<string, string[]>();
+
+  // Group keys by profile (for federated searches)
+  for (const key of keys) {
+    const issueCache = cache.issues.find(i => i.key === key);
+    const profile = issueCache?._instance || profileName || getProfileForProject(getProjectKeyFromIssue(key));
+    if (!groupedByProfile.has(profile || "default")) {
+      groupedByProfile.set(profile || "default", []);
+    }
+    groupedByProfile.get(profile || "default")!.push(key);
+  }
+
+  // Fetch issues (grouped by profile for efficiency)
+  for (const [profile, profileKeys] of groupedByProfile) {
+    const config = getConfig(profile === "default" ? profileName : profile);
+    const client = new JiraClient(config);
+
+    for (const key of profileKeys) {
+      try {
+        const issue = await client.getIssue(key, ["comment", "issuelinks", "subtasks"]);
+        loadedIssues.push(issue);
+      } catch (err) {
+        console.error(`[${key}] ${err instanceof Error ? err.message : err}`);
+      }
+    }
+  }
+
+  // Vision analysis if requested
+  const visionResults = new Map<string, Array<{ filename: string; mimeType: string; analysis: string; error?: string }>>();
+
+  if (useVision) {
+    const visionConfig = getVisionConfig();
+    if (visionConfig) {
+      console.error("Analyzing image attachments...\n");
+      for (const [profile, profileKeys] of groupedByProfile) {
+        const config = getConfig(profile === "default" ? profileName : profile);
+        const client = new JiraClient(config);
+        for (const key of profileKeys) {
+          try {
+            const analyses = await analyzeAttachments(client, key, visionConfig);
+            if (analyses.length > 0) {
+              visionResults.set(key, analyses);
+            }
+          } catch (err) {
+            console.error(`[${key}] Vision error: ${err instanceof Error ? err.message : err}`);
+          }
+        }
+      }
+    }
+  }
+
+  // Output based on format
+  if (format === "json") {
+    // JSON format: structured for context loading
+    const output = loadedIssues.map(issue => ({
+      key: issue.key,
+      summary: issue.fields.summary,
+      type: issue.fields.issuetype.name,
+      status: issue.fields.status.name,
+      priority: issue.fields.priority?.name,
+      assignee: issue.fields.assignee?.displayName,
+      reporter: issue.fields.reporter?.displayName,
+      labels: issue.fields.labels,
+      created: issue.fields.created,
+      updated: issue.fields.updated,
+      description: formatDescriptionText(issue.fields.description),
+      comments: (issue.fields.comment?.comments || []).map(c => ({
+        author: c.author.displayName,
+        created: c.created,
+        body: formatDescriptionText(c.body),
+      })),
+      ...(visionResults.has(issue.key) && {
+        attachments: visionResults.get(issue.key)!.map(a => ({
+          filename: a.filename,
+          mimeType: a.mimeType,
+          analysis: a.analysis,
+          ...(a.error && { error: a.error }),
+        })),
+      }),
+    }));
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    // Table format: human readable
+    for (const issue of loadedIssues) {
+      console.log(formatIssueDetail(issue, format));
+
+      // Add vision analysis if available
+      if (visionResults.has(issue.key)) {
+        console.log("\n" + formatVisionAnalysis(visionResults.get(issue.key)!));
+      }
+
+      console.log("\n" + "═".repeat(60) + "\n");
+    }
+    console.log(`Loaded ${loadedIssues.length} issue(s).`);
+  }
+}
+
+/**
+ * Helper to extract text from ADF or plain string description
+ */
+function formatDescriptionText(desc: string | object | null | undefined): string {
+  if (!desc) return "";
+  if (typeof desc === "string") return desc;
+  // ADF format - extract text
+  try {
+    const extractText = (node: unknown): string => {
+      if (!node || typeof node !== "object") return "";
+      const n = node as { type?: string; text?: string; content?: unknown[] };
+      if (n.type === "text" && typeof n.text === "string") return n.text;
+      if (Array.isArray(n.content)) {
+        return n.content.map(extractText).join("");
+      }
+      return "";
+    };
+    return extractText(desc);
+  } catch {
+    return "";
+  }
+}
+
+async function handleOpen(args: string[], profileName: string | undefined) {
+  let issueKey = args.find(a => !a.startsWith("-") && !/^\d+$/.test(a) || /^\d+$/.test(a));
+  const useVision = args.includes("--vision");
+
+  // Support opening by index from last search
+  if (issueKey && /^\d+$/.test(issueKey)) {
+    const cache = loadSearchCache();
+    if (cache) {
+      const idx = parseInt(issueKey, 10);
+      if (idx > 0 && idx <= cache.issues.length) {
+        issueKey = cache.issues[idx - 1].key;
+      }
+    }
+  }
+
+  if (!issueKey) {
+    console.error("Usage: jira open <issue-key|index> [--vision]");
+    console.error("\nExamples:");
+    console.error("  jira open SMS-123           Open by key");
+    console.error("  jira open 3                 Open #3 from last search");
+    console.error("  jira open SMS-123 --vision  Open with image analysis");
+    process.exit(1);
+  }
+
+  // Check vision availability
+  if (useVision && !isVisionAvailable()) {
+    console.error("Vision requires OPENAI_API_KEY environment variable.");
+    process.exit(1);
+  }
+
+  // Auto-detect profile
+  if (!profileName) {
+    const projectKey = getProjectKeyFromIssue(issueKey);
+    profileName = getProfileForProject(projectKey);
+  }
+
+  // Fetch issue to verify it exists and get summary
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+
+  try {
+    const issue = await client.getIssue(issueKey);
+
+    // Save as opened ticket
+    saveOpenedTicket({
+      key: issue.key,
+      summary: issue.fields.summary,
+      profileName: config.profileName,
+      openedAt: new Date().toISOString(),
+    });
+
+    console.log(`Opened: ${issue.key}`);
+    console.log(`  ${issue.fields.summary}`);
+    console.log(`  Status: ${issue.fields.status.name} | Type: ${issue.fields.issuetype.name}`);
+
+    // Vision analysis if requested
+    if (useVision) {
+      const visionConfig = getVisionConfig();
+      if (visionConfig) {
+        console.log("\nAnalyzing image attachments...\n");
+        try {
+          const analyses = await analyzeAttachments(client, issue.key, visionConfig);
+          console.log(formatVisionAnalysis(analyses));
+        } catch (err) {
+          console.error(`Vision error: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+    }
+
+    console.log(`\nYou can now run: update, comment, transition, label (without specifying key)`);
+  } catch (err) {
+    console.error(`Failed to open: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
+}
+
+function handleClose() {
+  const opened = loadOpenedTicket();
+  if (!opened) {
+    console.log("No ticket currently opened.");
+    return;
+  }
+
+  clearOpenedTicket();
+  console.log(`Closed: ${opened.key}`);
+  console.log(`  ${opened.summary}`);
+}
+
+function handleStatus() {
+  const opened = loadOpenedTicket();
+  if (!opened) {
+    console.log("No ticket currently opened.");
+    console.log("\nUse 'jira open <key>' to open a ticket for interaction.");
+    return;
+  }
+
+  const openedTime = new Date(opened.openedAt);
+  const elapsed = Math.round((Date.now() - openedTime.getTime()) / 60000);
+
+  console.log(`Currently opened: ${opened.key}`);
+  console.log(`  ${opened.summary}`);
+  console.log(`  Profile: ${opened.profileName}`);
+  console.log(`  Opened: ${elapsed} minutes ago`);
+  console.log(`\nAvailable actions: update, comment, transition, label`);
+}
+
+async function handleCreate(args: string[], profileName: string | undefined) {
+  const input: CreateIssueInput = {
+    project: "",
+    issuetype: "Task",
+    summary: "",
+  };
+  const labels: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "--project":
+      case "-P":
+        input.project = args[++i];
+        break;
+      case "--type":
+      case "-T":
+        input.issuetype = args[++i];
+        break;
+      case "--summary":
+      case "-s":
+        input.summary = args[++i];
+        break;
+      case "--description":
+      case "-d":
+        input.description = args[++i];
+        break;
+      case "--assignee":
+      case "-a":
+        input.assignee = args[++i];
+        break;
+      case "--labels":
+        labels.push(...args[++i].split(",").map(l => l.trim()));
+        break;
+      case "--label":
+        labels.push(args[++i]);
+        break;
+      case "--epic":
+        input.epicKey = args[++i];
+        break;
+      case "--parent":
+        input.parent = args[++i];
+        break;
+      case "--priority":
+        input.priority = args[++i];
+        break;
+    }
+  }
+
+  if (labels.length) {
+    input.labels = labels;
+  }
+
+  const config = getConfig(profileName);
+
+  // Use default project if not specified
+  if (!input.project) {
+    if (config.defaultProject) {
+      input.project = config.defaultProject;
+    } else {
+      console.error("Missing required: --project (or set JIRA_DEFAULT_PROJECT in profile)");
+      process.exit(1);
+    }
+  }
+
+  if (!input.summary) {
+    console.error("Missing required: --summary");
+    process.exit(1);
+  }
+
+  const client = new JiraClient(config);
+  const result = await client.createIssue(input);
+
+  console.log(`Created ${result.key}`);
+  if (input.epicKey) {
+    console.log(`  in epic ${input.epicKey}`);
+  }
+  if (input.parent) {
+    console.log(`  as sub-task of ${input.parent}`);
+  }
+}
+
+async function handleUpdate(args: string[], profileName: string | undefined) {
+  const explicitKey = args.find(a => !a.startsWith("-") && /^[A-Z]+-\d+$/i.test(a));
+  const issueKey = getWriteTargetKey(explicitKey);
+
+  if (!issueKey) {
+    console.error("No ticket opened. Either:");
+    console.error("  1. Open a ticket: jira open SMS-123");
+    console.error("  2. Specify key: jira update SMS-123 --summary ...");
+    process.exit(1);
+  }
+
+  // Show which ticket we're updating if using opened ticket
+  if (!explicitKey) {
+    console.log(`Updating opened ticket: ${issueKey}`);
+  }
+
+  const updates: Record<string, string | string[] | undefined> = {};
+  const labels: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "--summary":
+      case "-s":
+        updates.summary = args[++i];
+        break;
+      case "--description":
+      case "-d":
+        updates.description = args[++i];
+        break;
+      case "--assignee":
+      case "-a":
+        updates.assignee = args[++i];
+        break;
+      case "--priority":
+        updates.priority = args[++i];
+        break;
+      case "--type":
+      case "-t":
+        updates.issuetype = args[++i];
+        break;
+      case "--labels":
+        labels.push(...args[++i].split(",").map(l => l.trim()));
+        break;
+      case "--label":
+        labels.push(args[++i]);
+        break;
+    }
+  }
+
+  if (labels.length) {
+    updates.labels = labels;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    console.error("No updates specified");
+    process.exit(1);
+  }
+
+  // Auto-detect profile from issue key
+  if (!profileName) {
+    const projectKey = getProjectKeyFromIssue(issueKey);
+    profileName = getProfileForProject(projectKey);
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  await client.updateIssue(issueKey, updates);
+
+  console.log(`Updated ${issueKey}`);
+}
+
+async function handleTransition(args: string[], profileName: string | undefined) {
+  // Parse args: either "KEY STATUS" or just "STATUS" (if ticket opened)
+  const nonFlags = args.filter(a => !a.startsWith("-"));
+  let issueKey: string | null;
+  let statusName: string | undefined;
+
+  if (nonFlags.length >= 2 && /^[A-Z]+-\d+$/i.test(nonFlags[0])) {
+    // Explicit key: "transition SMS-123 Done"
+    issueKey = nonFlags[0];
+    statusName = nonFlags[1];
+  } else if (nonFlags.length >= 1) {
+    // Use opened ticket: "transition Done"
+    issueKey = getWriteTargetKey(undefined);
+    statusName = nonFlags[0];
+  } else {
+    issueKey = null;
+    statusName = undefined;
+  }
+
+  if (!issueKey || !statusName) {
+    console.error("Usage: jira transition [issue-key] <status-name>");
+    console.error("\nExamples:");
+    console.error("  jira transition SMS-123 Done    (explicit key)");
+    console.error("  jira transition Done            (uses opened ticket)");
+    process.exit(1);
+  }
+
+  // Show which ticket if using opened
+  if (nonFlags.length === 1) {
+    console.log(`Transitioning opened ticket: ${issueKey}`);
+  }
+
+  // Auto-detect profile from issue key
+  if (!profileName) {
+    const projectKey = getProjectKeyFromIssue(issueKey);
+    profileName = getProfileForProject(projectKey);
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+
+  // Get available transitions
+  const transitions = await client.getTransitions(issueKey);
+  const transition = transitions.find(
+    t => t.name.toLowerCase() === statusName.toLowerCase() ||
+         t.to.name.toLowerCase() === statusName.toLowerCase()
+  );
+
+  if (!transition) {
+    console.error(`Cannot transition to '${statusName}'`);
+    console.log(`Available transitions:`);
+    for (const t of transitions) {
+      console.log(`  - ${t.name} → ${t.to.name}`);
+    }
+    process.exit(1);
+  }
+
+  await client.transitionIssue(issueKey, transition.id);
+  console.log(`${issueKey} → ${transition.to.name}`);
+}
+
+async function handleComment(args: string[], profileName: string | undefined) {
+  // Parse args: either "KEY TEXT" or just "TEXT" (if ticket opened)
+  const nonFlags = args.filter(a => !a.startsWith("-"));
+  let issueKey: string | null;
+  let commentText: string | undefined;
+
+  if (nonFlags.length >= 2 && /^[A-Z]+-\d+$/i.test(nonFlags[0])) {
+    // Explicit key: "comment SMS-123 text"
+    issueKey = nonFlags[0];
+    commentText = nonFlags.slice(1).join(" ");
+  } else if (nonFlags.length >= 1) {
+    // Use opened ticket: "comment text"
+    issueKey = getWriteTargetKey(undefined);
+    commentText = nonFlags.join(" ");
+  } else {
+    issueKey = null;
+    commentText = undefined;
+  }
+
+  // Read from stdin if '-' is specified
+  if (commentText === "-") {
+    commentText = await Bun.stdin.text();
+  }
+
+  if (!issueKey || !commentText) {
+    console.error("Usage: jira comment [issue-key] <text>");
+    console.error("\nExamples:");
+    console.error("  jira comment SMS-123 \"text\"    (explicit key)");
+    console.error("  jira comment \"text\"            (uses opened ticket)");
+    console.error("  echo 'text' | jira comment -   (stdin to opened ticket)");
+    process.exit(1);
+  }
+
+  // Show which ticket if using opened
+  const usingOpened = !nonFlags[0] || !/^[A-Z]+-\d+$/i.test(nonFlags[0]);
+  if (usingOpened) {
+    console.log(`Commenting on opened ticket: ${issueKey}`);
+  }
+
+  // Auto-detect profile from issue key
+  if (!profileName) {
+    const projectKey = getProjectKeyFromIssue(issueKey);
+    profileName = getProfileForProject(projectKey);
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  await client.addComment(issueKey, commentText);
+
+  console.log(`Comment added to ${issueKey}`);
+}
+
+async function handleTransitions(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  const issueKey = args.find(a => !a.startsWith("-"));
+  if (!issueKey) {
+    console.error("Usage: jira transitions <issue-key>");
+    process.exit(1);
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const transitions = await client.getTransitions(issueKey);
+
+  console.log(`Available transitions for ${issueKey}:\n`);
+  console.log(formatTransitions(transitions, format));
+}
+
+async function handleProjects(profileName: string | undefined, format: OutputFormat) {
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const projects = await client.getProjects();
+
+  console.log(formatProjects(projects, format));
+}
+
+async function handleTypes(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  const projectKey = args.find(a => !a.startsWith("-"));
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const types = await client.getIssueTypes(projectKey);
+
+  if (format === "json") {
+    console.log(JSON.stringify(types, null, 2));
+  } else {
+    console.log("Issue types:\n");
+    for (const t of types) {
+      console.log(`  ${t.name}${t.subtask ? " (sub-task)" : ""}`);
+    }
+  }
+}
+
+async function handleLabels(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  // Check if querying labels on a specific issue
+  const issueKey = args.find(a => !a.startsWith("-") && /^[A-Z]+-\d+$/i.test(a));
+
+  if (issueKey) {
+    const config = getConfig(profileName);
+    const client = new JiraClient(config);
+    const issue = await client.getIssue(issueKey);
+
+    if (format === "json") {
+      console.log(JSON.stringify(issue.fields.labels, null, 2));
+    } else {
+      console.log(`Labels on ${issueKey}:`);
+      for (const label of issue.fields.labels) {
+        console.log(`  ${label}`);
+      }
+    }
+    return;
+  }
+
+  // List all labels
+  let prefix: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--prefix") {
+      prefix = args[++i];
+    }
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const labels = await client.getAllLabels();
+
+  console.log(formatLabels(labels, format, prefix));
+}
+
+async function handleLabelOp(args: string[], profileName: string | undefined) {
+  const op = args[0]; // add or remove
+  const issueKey = args[1];
+  const label = args[2];
+
+  if (!["add", "remove"].includes(op) || !issueKey || !label) {
+    console.error("Usage: jira label add <issue-key> <label>");
+    console.error("       jira label remove <issue-key> <label>");
+    process.exit(1);
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+
+  if (op === "add") {
+    await client.addLabels(issueKey, [label]);
+    console.log(`Added '${label}' to ${issueKey}`);
+  } else {
+    await client.removeLabels(issueKey, [label]);
+    console.log(`Removed '${label}' from ${issueKey}`);
+  }
+}
+
+async function handleFilters(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  // Parse options
+  let searchName: string | undefined;
+  let ownerFilter: string | undefined;
+  let favouritesOnly = false;
+  let showMine = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--search" || arg === "-s") {
+      searchName = args[++i];
+    } else if (arg === "--owner" || arg === "-o") {
+      ownerFilter = args[++i];
+    } else if (arg === "--mine" || arg === "--my") {
+      showMine = true;
+    } else if (arg === "--favourites" || arg === "--favorites") {
+      favouritesOnly = true;
+    } else if (!arg.startsWith("-")) {
+      searchName = arg;
+    }
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+
+  let filters: JiraFilter[];
+
+  if (favouritesOnly || !searchName) {
+    // Default: show favourite filters
+    filters = await client.getFavouriteFilters();
+    if (filters.length === 0) {
+      console.log("No favourite filters found.");
+      console.log("\nTip: Star filters in Jira to add them to favourites.");
+      console.log("Or search by name: jira filters <name>");
+      return;
+    }
+    console.log("Favourite filters:\n");
+  } else {
+    // Search filters by name
+    filters = await client.searchFilters(searchName);
+    if (filters.length === 0) {
+      console.log(`No filters found matching: ${searchName}`);
+      return;
+    }
+    console.log(`Filters matching "${searchName}":\n`);
+  }
+
+  // Apply owner filter
+  if (showMine) {
+    // Filter to current user's filters (using username from config)
+    filters = filters.filter(f =>
+      f.owner.displayName.toLowerCase().includes(config.username.split("@")[0].toLowerCase())
+    );
+    if (filters.length === 0) {
+      console.log("No filters found owned by you.");
+      return;
+    }
+  } else if (ownerFilter) {
+    filters = filters.filter(f =>
+      f.owner.displayName.toLowerCase().includes(ownerFilter.toLowerCase())
+    );
+    if (filters.length === 0) {
+      console.log(`No filters found with owner matching: ${ownerFilter}`);
+      return;
+    }
+  }
+
+  if (format === "json") {
+    console.log(JSON.stringify(filters, null, 2));
+  } else {
+    // Table format
+    console.log("#  ID       Name                                    Owner                Shared With");
+    console.log("─".repeat(100));
+    filters.forEach((f, i) => {
+      const name = f.name.length > 35 ? f.name.slice(0, 32) + "..." : f.name;
+      const star = f.favourite ? "★" : " ";
+
+      // Format share permissions
+      let sharedWith = "private";
+      if (f.sharePermissions && f.sharePermissions.length > 0) {
+        const shares = f.sharePermissions.map(p => {
+          switch (p.type) {
+            case "global": return "anyone";
+            case "loggedin":
+            case "authenticated": return "logged-in users";
+            case "project": return p.project?.key || "project";
+            case "group": return p.group?.name || "group";
+            case "user": return p.user?.displayName || "user";
+            default: return p.type;
+          }
+        });
+        sharedWith = shares.join(", ");
+        if (sharedWith.length > 20) {
+          sharedWith = sharedWith.slice(0, 17) + "...";
+        }
+      }
+
+      console.log(
+        `${star}${String(i + 1).padStart(2)}  ${f.id.padEnd(7)}  ${name.padEnd(35)}  ${f.owner.displayName.padEnd(18)}  ${sharedWith}`
+      );
+    });
+    console.log(`\nUse with search: jira search --filter "<name>"`);
+    console.log(`Or by ID:        jira search --filter ${filters[0]?.id || "12345"}`);
+  }
+}
+
+async function handleLink(args: string[], profileName: string | undefined) {
+  // Check for --epic syntax
+  const epicIndex = args.indexOf("--epic");
+  if (epicIndex !== -1) {
+    const issueKey = args.find(a => !a.startsWith("-"));
+    const epicKey = args[epicIndex + 1];
+
+    if (!issueKey || !epicKey) {
+      console.error("Usage: jira link <issue-key> --epic <epic-key>");
+      process.exit(1);
+    }
+
+    const config = getConfig(profileName);
+    const client = new JiraClient(config);
+    await client.linkToEpic(issueKey, epicKey);
+
+    console.log(`${issueKey} added to epic ${epicKey}`);
+    return;
+  }
+
+  // Standard link: jira link KEY1 "type" KEY2
+  const nonFlags = args.filter(a => !a.startsWith("-"));
+  if (nonFlags.length < 3) {
+    console.error("Usage: jira link <issue-key1> <link-type> <issue-key2>");
+    console.error("       jira link <issue-key> --epic <epic-key>");
+    process.exit(1);
+  }
+
+  const [key1, linkType, key2] = nonFlags;
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  await client.createLink(key1, key2, linkType);
+
+  console.log(`${key1} ${linkType} ${key2}`);
+}
+
+async function handleUnlink(args: string[], profileName: string | undefined) {
+  const nonFlags = args.filter(a => !a.startsWith("-"));
+  if (nonFlags.length < 2) {
+    console.error("Usage: jira unlink <issue-key1> <issue-key2>");
+    process.exit(1);
+  }
+
+  const [key1, key2] = nonFlags;
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+
+  // Get issue to find link ID
+  const issue = await client.getIssue(key1, ["issuelinks"]);
+  const link = issue.fields.issuelinks?.find(
+    l => l.inwardIssue?.key === key2 || l.outwardIssue?.key === key2
+  );
+
+  if (!link) {
+    console.error(`No link found between ${key1} and ${key2}`);
+    process.exit(1);
+  }
+
+  await client.deleteLink(link.id);
+  console.log(`Removed link between ${key1} and ${key2}`);
+}
+
+async function handleLinkTypes(profileName: string | undefined, format: OutputFormat) {
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const types = await client.getLinkTypes();
+
+  console.log(formatLinkTypes(types, format));
+}
+
+async function handleLinks(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  const issueKey = args.find(a => !a.startsWith("-"));
+  if (!issueKey) {
+    console.error("Usage: jira links <issue-key>");
+    process.exit(1);
+  }
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+  const issue = await client.getIssue(issueKey, ["issuelinks"]);
+
+  const links = issue.fields.issuelinks || [];
+
+  if (links.length === 0) {
+    console.log(`No links on ${issueKey}`);
+    return;
+  }
+
+  if (format === "json") {
+    console.log(JSON.stringify(links, null, 2));
+  } else {
+    console.log(`Links on ${issueKey}:\n`);
+    for (const link of links) {
+      if (link.outwardIssue) {
+        console.log(`  ${link.type.outward}: ${link.outwardIssue.key} - ${link.outwardIssue.fields.summary}`);
+      }
+      if (link.inwardIssue) {
+        console.log(`  ${link.type.inward}: ${link.inwardIssue.key} - ${link.inwardIssue.fields.summary}`);
+      }
+    }
+  }
+}
+
+async function handleDev(
+  args: string[],
+  profileName: string | undefined,
+  format: OutputFormat
+) {
+  const issueKey = args.find(a => !a.startsWith("-"));
+  if (!issueKey) {
+    console.error("Usage: jira dev <issue-key>");
+    process.exit(1);
+  }
+
+  const showBranches = args.includes("--branches");
+  const showPRs = args.includes("--prs");
+  const createBranch = args.includes("--create-branch");
+  const checkout = args.includes("--checkout");
+
+  const config = getConfig(profileName);
+  const client = new JiraClient(config);
+
+  // Create branch suggestion
+  if (createBranch || checkout) {
+    const issue = await client.getIssue(issueKey);
+    const branchName = suggestBranchName(issueKey, issue.fields.summary);
+
+    if (checkout) {
+      const { execSync } = await import("child_process");
+      execSync(`git checkout -b ${branchName}`, { stdio: "inherit" });
+    } else {
+      console.log(branchName);
+    }
+    return;
+  }
+
+  // Get dev info
+  const devInfo = await client.getDevInfo(issueKey);
+
+  // Filter if requested
+  if (showBranches) {
+    devInfo.commits = [];
+    devInfo.pullRequests = [];
+  } else if (showPRs) {
+    devInfo.branches = [];
+    devInfo.commits = [];
+  }
+
+  console.log(formatDevInfo(devInfo, issueKey, format));
+}
+
+async function handleConfig(profileName: string | undefined) {
+  try {
+    const config = getConfig(profileName);
+    console.log(`Profile: ${config.profileName}`);
+    console.log(`URL:     ${config.url}`);
+    console.log(`User:    ${config.username}`);
+    if (config.defaultProject) {
+      console.log(`Default: ${config.defaultProject}`);
+    }
+    if (config.projects?.length) {
+      console.log(`Projects: ${config.projects.join(", ")}`);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+function handleProfiles() {
+  const profiles = listProfiles();
+  console.log(formatProfiles(profiles));
+}
+
+async function handleSetup(profileName: string | undefined) {
+  console.log("Jira CLI Setup - Project Discovery\n");
+
+  const profiles = profileName
+    ? [{ name: profileName, url: "", isDefault: false }]
+    : listProfiles();
+
+  if (profiles.length === 0) {
+    console.error("No profiles found. Create profiles in ~/.claude/jira/profiles/ first.");
+    process.exit(1);
+  }
+
+  console.log(`Discovering projects for ${profiles.length} profile(s)...\n`);
+
+  for (const profile of profiles) {
+    console.log(`\n${profile.name}:`);
+    console.log("─".repeat(40));
+
+    try {
+      const config = loadProfile(profile.name);
+      const client = new JiraClient(config);
+      const projects = await client.getProjects();
+
+      if (projects.length === 0) {
+        console.log("  No accessible projects found");
+        continue;
+      }
+
+      const projectKeys = projects.map(p => p.key);
+      console.log(`  Found ${projects.length} projects:`);
+      for (const p of projects) {
+        console.log(`    ${p.key.padEnd(10)} ${p.name}`);
+      }
+
+      // Check current config
+      if (config.projects?.length) {
+        console.log(`\n  Currently configured: ${config.projects.join(", ")}`);
+      }
+
+      // Write to profile
+      writeProfileProjects(profile.name, projectKeys);
+      console.log(`\n  ✓ Updated JIRA_PROJECTS in ${profile.name}.env`);
+
+    } catch (error) {
+      console.error(`  Error: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  console.log("\n" + "─".repeat(40));
+  console.log("Setup complete! Auto-detection is now enabled.");
+  console.log("\nThe CLI will automatically select the correct profile based on issue key.");
+  console.log("Example: jira get SMS-123  →  auto-selects profile with SMS project");
+}
+
+// ============================================================================
+// Run
+// ============================================================================
+
+main();

--- a/bin/jira/lib/api.ts
+++ b/bin/jira/lib/api.ts
@@ -1,0 +1,655 @@
+/**
+ * JIRA REST API Client
+ *
+ * Provides typed access to Jira Cloud/Server REST API v3.
+ * Uses Basic Auth with API token.
+ */
+
+import type { JiraConfig } from "./config";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface JiraIssue {
+  key: string;
+  id: string;
+  self: string;
+  fields: {
+    summary: string;
+    description?: string | null;
+    status: { name: string; id: string };
+    issuetype: { name: string; id: string };
+    priority?: { name: string; id: string };
+    assignee?: { displayName: string; accountId: string } | null;
+    reporter?: { displayName: string; accountId: string } | null;
+    labels: string[];
+    created: string;
+    updated: string;
+    parent?: { key: string; fields: { summary: string } };
+    subtasks?: Array<{ key: string; fields: { summary: string; status: { name: string } } }>;
+    issuelinks?: IssueLink[];
+    comment?: { comments: Comment[]; total: number };
+    attachment?: Attachment[];
+    [key: string]: unknown;
+  };
+}
+
+export interface IssueLink {
+  id: string;
+  type: { name: string; inward: string; outward: string };
+  inwardIssue?: { key: string; fields: { summary: string; status: { name: string } } };
+  outwardIssue?: { key: string; fields: { summary: string; status: { name: string } } };
+}
+
+export interface Comment {
+  id: string;
+  author: { displayName: string };
+  body: string | object;
+  created: string;
+  updated: string;
+}
+
+export interface Attachment {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  content: string;  // URL to download
+  thumbnail?: string;
+  created: string;
+  author: { displayName: string; accountId: string };
+}
+
+export interface JiraProject {
+  key: string;
+  name: string;
+  id: string;
+  lead?: { displayName: string };
+  projectTypeKey: string;
+}
+
+export interface IssueType {
+  id: string;
+  name: string;
+  subtask: boolean;
+  description?: string;
+}
+
+export interface Transition {
+  id: string;
+  name: string;
+  to: { name: string; id: string };
+}
+
+export interface IssueLinkType {
+  id: string;
+  name: string;
+  inward: string;
+  outward: string;
+}
+
+export interface JiraFilterSharePermission {
+  id: number;
+  type: "global" | "project" | "group" | "user" | "loggedin" | "authenticated";
+  project?: { id: string; key: string; name: string };
+  group?: { name: string };
+  user?: { displayName: string; accountId: string };
+}
+
+export interface JiraFilter {
+  id: string;
+  name: string;
+  jql: string;
+  description?: string;
+  owner: { displayName: string; accountId: string };
+  favourite: boolean;
+  viewUrl: string;
+  sharePermissions?: JiraFilterSharePermission[];
+}
+
+export interface SearchResult {
+  issues: JiraIssue[];
+  total?: number;       // v2 API
+  maxResults?: number;  // v2 API
+  startAt?: number;     // v2 API
+  isLast?: boolean;     // v3 API
+}
+
+export interface CreateIssueInput {
+  project: string;
+  issuetype: string;
+  summary: string;
+  description?: string;
+  assignee?: string;
+  labels?: string[];
+  parent?: string;      // For sub-tasks
+  epicKey?: string;     // For linking to epic
+  priority?: string;
+}
+
+export interface UpdateIssueInput {
+  summary?: string;
+  description?: string;
+  assignee?: string;
+  labels?: string[];
+  priority?: string;
+  issuetype?: string;
+}
+
+export interface DevInfo {
+  branches: Array<{
+    name: string;
+    url: string;
+    repository: { name: string; url: string };
+  }>;
+  commits: Array<{
+    id: string;
+    message: string;
+    author: { name: string };
+    url: string;
+    timestamp: string;
+  }>;
+  pullRequests: Array<{
+    id: string;
+    name: string;
+    url: string;
+    status: string;
+    author: { name: string };
+  }>;
+}
+
+// ============================================================================
+// API Client Class
+// ============================================================================
+
+export class JiraClient {
+  private baseUrl: string;
+  private authHeader: string;
+  public profileName: string;
+
+  constructor(config: JiraConfig) {
+    this.baseUrl = config.url;
+    this.profileName = config.profileName;
+
+    // Basic auth: base64(email:api_token)
+    const credentials = `${config.username}:${config.apiToken}`;
+    this.authHeader = `Basic ${Buffer.from(credentials).toString("base64")}`;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+
+    const response = await fetch(url, {
+      method,
+      headers: {
+        "Authorization": this.authHeader,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage: string;
+
+      try {
+        const errorJson = JSON.parse(errorText);
+        errorMessage = errorJson.errorMessages?.join(", ") ||
+                       errorJson.errors ? Object.values(errorJson.errors).join(", ") :
+                       errorText;
+      } catch {
+        errorMessage = errorText;
+      }
+
+      if (response.status === 401) {
+        throw new Error(`Authentication failed. Check JIRA_API_TOKEN for profile '${this.profileName}'`);
+      }
+      if (response.status === 404) {
+        throw new Error(`Not found: ${path}`);
+      }
+
+      throw new Error(`Jira API error (${response.status}): ${errorMessage}`);
+    }
+
+    // Handle empty responses
+    const text = await response.text();
+    if (!text) return {} as T;
+
+    return JSON.parse(text) as T;
+  }
+
+  // ==========================================================================
+  // Issue Operations
+  // ==========================================================================
+
+  async getIssue(issueKey: string, expand?: string[]): Promise<JiraIssue> {
+    const expandParam = expand?.length ? `?expand=${expand.join(",")}` : "";
+    return this.request<JiraIssue>("GET", `/rest/api/2/issue/${issueKey}${expandParam}`);
+  }
+
+  async searchIssues(jql: string, options?: {
+    maxResults?: number;
+    startAt?: number;
+    fields?: string[];
+  }): Promise<SearchResult> {
+    // Use v3 search/jql API with POST (Cloud only - v2 endpoints deprecated)
+    const defaultFields = [
+      "key", "summary", "status", "issuetype", "priority",
+      "assignee", "reporter", "labels", "created", "updated", "parent"
+    ];
+
+    const body = {
+      jql,
+      maxResults: options?.maxResults ?? 50,
+      fields: options?.fields || defaultFields,
+    };
+
+    return this.request<SearchResult>("POST", "/rest/api/3/search/jql", body);
+  }
+
+  async createIssue(input: CreateIssueInput): Promise<{ key: string; id: string }> {
+    const fields: Record<string, unknown> = {
+      project: { key: input.project },
+      issuetype: { name: input.issuetype },
+      summary: input.summary,
+    };
+
+    if (input.description) {
+      // v2 API uses plain text
+      fields.description = input.description;
+    }
+
+    if (input.assignee) {
+      fields.assignee = { accountId: input.assignee };
+    }
+
+    if (input.labels?.length) {
+      fields.labels = input.labels;
+    }
+
+    if (input.parent) {
+      fields.parent = { key: input.parent };
+    }
+
+    if (input.priority) {
+      fields.priority = { name: input.priority };
+    }
+
+    const result = await this.request<{ key: string; id: string; self: string }>(
+      "POST",
+      "/rest/api/2/issue",
+      { fields }
+    );
+
+    // Link to epic if specified (separate API call)
+    if (input.epicKey) {
+      await this.linkToEpic(result.key, input.epicKey);
+    }
+
+    return { key: result.key, id: result.id };
+  }
+
+  async updateIssue(issueKey: string, input: UpdateIssueInput): Promise<void> {
+    const fields: Record<string, unknown> = {};
+
+    if (input.summary) {
+      fields.summary = input.summary;
+    }
+
+    if (input.description !== undefined) {
+      // v2 API uses plain text
+      fields.description = input.description || null;
+    }
+
+    if (input.assignee !== undefined) {
+      fields.assignee = input.assignee ? { accountId: input.assignee } : null;
+    }
+
+    if (input.labels) {
+      fields.labels = input.labels;
+    }
+
+    if (input.priority) {
+      fields.priority = { name: input.priority };
+    }
+
+    if (input.issuetype) {
+      fields.issuetype = { name: input.issuetype };
+    }
+
+    await this.request("PUT", `/rest/api/2/issue/${issueKey}`, { fields });
+  }
+
+  // ==========================================================================
+  // Transitions
+  // ==========================================================================
+
+  async getTransitions(issueKey: string): Promise<Transition[]> {
+    const result = await this.request<{ transitions: Transition[] }>(
+      "GET",
+      `/rest/api/2/issue/${issueKey}/transitions`
+    );
+    return result.transitions;
+  }
+
+  async transitionIssue(issueKey: string, transitionId: string): Promise<void> {
+    await this.request("POST", `/rest/api/2/issue/${issueKey}/transitions`, {
+      transition: { id: transitionId },
+    });
+  }
+
+  // ==========================================================================
+  // Comments
+  // ==========================================================================
+
+  async addComment(issueKey: string, body: string): Promise<Comment> {
+    // v2 API uses plain text body, v3 uses ADF
+    return this.request<Comment>("POST", `/rest/api/2/issue/${issueKey}/comment`, {
+      body,
+    });
+  }
+
+  // ==========================================================================
+  // Labels
+  // ==========================================================================
+
+  async addLabels(issueKey: string, labels: string[]): Promise<void> {
+    const issue = await this.getIssue(issueKey);
+    const currentLabels = issue.fields.labels || [];
+    const newLabels = [...new Set([...currentLabels, ...labels])];
+
+    await this.request("PUT", `/rest/api/2/issue/${issueKey}`, {
+      fields: { labels: newLabels },
+    });
+  }
+
+  async removeLabels(issueKey: string, labels: string[]): Promise<void> {
+    const issue = await this.getIssue(issueKey);
+    const currentLabels = issue.fields.labels || [];
+    const newLabels = currentLabels.filter(l => !labels.includes(l));
+
+    await this.request("PUT", `/rest/api/2/issue/${issueKey}`, {
+      fields: { labels: newLabels },
+    });
+  }
+
+  // ==========================================================================
+  // Issue Links
+  // ==========================================================================
+
+  async getLinkTypes(): Promise<IssueLinkType[]> {
+    const result = await this.request<{ issueLinkTypes: IssueLinkType[] }>(
+      "GET",
+      "/rest/api/2/issueLinkType"
+    );
+    return result.issueLinkTypes;
+  }
+
+  async createLink(
+    inwardIssue: string,
+    outwardIssue: string,
+    linkTypeName: string
+  ): Promise<void> {
+    await this.request("POST", "/rest/api/2/issueLink", {
+      type: { name: linkTypeName },
+      inwardIssue: { key: inwardIssue },
+      outwardIssue: { key: outwardIssue },
+    });
+  }
+
+  async deleteLink(linkId: string): Promise<void> {
+    await this.request("DELETE", `/rest/api/2/issueLink/${linkId}`);
+  }
+
+  async linkToEpic(issueKey: string, epicKey: string): Promise<void> {
+    // Jira Cloud uses parent field for epic hierarchy
+    // parent field requires { key: "EPIC-123" } format
+    try {
+      await this.request("PUT", `/rest/api/2/issue/${issueKey}`, {
+        fields: { parent: { key: epicKey } },
+      });
+      return;
+    } catch {
+      // Try legacy custom fields for older Jira instances
+      const legacyFields = ["customfield_10014", "customfield_10008"];
+      for (const field of legacyFields) {
+        try {
+          await this.request("PUT", `/rest/api/2/issue/${issueKey}`, {
+            fields: { [field]: epicKey },
+          });
+          return;
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    // Fall back to issue link
+    await this.createLink(issueKey, epicKey, "Epic-Story Link");
+  }
+
+  // ==========================================================================
+  // Projects and Types
+  // ==========================================================================
+
+  async getProjects(): Promise<JiraProject[]> {
+    return this.request<JiraProject[]>("GET", "/rest/api/2/project");
+  }
+
+  async getIssueTypes(projectKey?: string): Promise<IssueType[]> {
+    if (projectKey) {
+      const project = await this.request<{ issueTypes: IssueType[] }>(
+        "GET",
+        `/rest/api/2/project/${projectKey}`
+      );
+      return project.issueTypes;
+    }
+
+    return this.request<IssueType[]>("GET", "/rest/api/2/issuetype");
+  }
+
+  // ==========================================================================
+  // Development Info (GitHub Integration)
+  // ==========================================================================
+
+  async getDevInfo(issueKey: string): Promise<DevInfo> {
+    // Get issue ID first
+    const issue = await this.getIssue(issueKey);
+    const issueId = issue.id;
+
+    try {
+      // Internal dev-status API
+      const result = await this.request<{
+        detail?: Array<{
+          branches?: DevInfo["branches"];
+          pullRequests?: DevInfo["pullRequests"];
+          repositories?: Array<{
+            commits?: DevInfo["commits"];
+          }>;
+        }>;
+      }>(
+        "GET",
+        `/rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=GitHub&dataType=repository`
+      );
+
+      const detail = result.detail?.[0];
+      return {
+        branches: detail?.branches || [],
+        commits: detail?.repositories?.[0]?.commits || [],
+        pullRequests: detail?.pullRequests || [],
+      };
+    } catch {
+      // Dev-status API not available or no integration
+      return { branches: [], commits: [], pullRequests: [] };
+    }
+  }
+
+  // ==========================================================================
+  // Attachments
+  // ==========================================================================
+
+  async getAttachments(issueKey: string): Promise<Attachment[]> {
+    const issue = await this.request<JiraIssue>(
+      "GET",
+      `/rest/api/2/issue/${issueKey}?fields=attachment`
+    );
+    return issue.fields.attachment || [];
+  }
+
+  /**
+   * Download attachment content as Buffer.
+   * Jira attachments require the same auth as the API.
+   */
+  async downloadAttachment(contentUrl: string): Promise<Buffer> {
+    const response = await fetch(contentUrl, {
+      headers: {
+        "Authorization": this.authHeader,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to download attachment: ${response.status}`);
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  /**
+   * Get image attachments (for vision analysis)
+   */
+  async getImageAttachments(issueKey: string): Promise<Attachment[]> {
+    const attachments = await this.getAttachments(issueKey);
+    const imageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+    return attachments.filter(a => imageTypes.includes(a.mimeType));
+  }
+
+  // ==========================================================================
+  // Filters
+  // ==========================================================================
+
+  /**
+   * Get user's favourite/starred filters
+   */
+  async getFavouriteFilters(): Promise<JiraFilter[]> {
+    return this.request<JiraFilter[]>("GET", "/rest/api/2/filter/favourite");
+  }
+
+  /**
+   * Get a specific filter by ID
+   */
+  async getFilter(filterId: string): Promise<JiraFilter> {
+    return this.request<JiraFilter>("GET", `/rest/api/2/filter/${filterId}`);
+  }
+
+  /**
+   * Search for filters by name
+   */
+  async searchFilters(filterName?: string): Promise<JiraFilter[]> {
+    const params = new URLSearchParams();
+    if (filterName) {
+      params.set("filterName", filterName);
+    }
+    params.set("expand", "jql,description,owner,sharePermissions");
+    const queryString = params.toString();
+    const result = await this.request<{ values: JiraFilter[] }>(
+      "GET",
+      `/rest/api/2/filter/search${queryString ? `?${queryString}` : ""}`
+    );
+    return result.values || [];
+  }
+
+  /**
+   * Find filter by name or ID, return its JQL
+   */
+  async getFilterJql(filterNameOrId: string): Promise<string> {
+    // If it looks like an ID (numeric), fetch directly
+    if (/^\d+$/.test(filterNameOrId)) {
+      const filter = await this.getFilter(filterNameOrId);
+      return filter.jql;
+    }
+
+    // Otherwise search by name
+    const filters = await this.searchFilters(filterNameOrId);
+    const match = filters.find(
+      f => f.name.toLowerCase() === filterNameOrId.toLowerCase()
+    );
+    if (!match) {
+      throw new Error(`Filter not found: ${filterNameOrId}`);
+    }
+    return match.jql;
+  }
+
+  // ==========================================================================
+  // Labels Discovery
+  // ==========================================================================
+
+  async getAllLabels(): Promise<Map<string, number>> {
+    // Search all issues and count labels
+    // Note: Jira doesn't have a direct labels API, so we aggregate from search
+    const labelCounts = new Map<string, number>();
+
+    let startAt = 0;
+    const maxResults = 100;
+
+    while (true) {
+      const result = await this.searchIssues(
+        "labels is not EMPTY ORDER BY updated DESC",
+        { maxResults, startAt, fields: ["labels"] }
+      );
+
+      for (const issue of result.issues) {
+        for (const label of issue.fields.labels || []) {
+          labelCounts.set(label, (labelCounts.get(label) || 0) + 1);
+        }
+      }
+
+      if (result.issues.length < maxResults || startAt + maxResults >= result.total) {
+        break;
+      }
+
+      startAt += maxResults;
+
+      // Limit to prevent long-running queries
+      if (startAt >= 1000) break;
+    }
+
+    return labelCounts;
+  }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Convert text query to JQL if not already JQL
+ */
+export function textToJql(query: string): string {
+  // If it looks like JQL (has operators), return as-is
+  if (/\s+(=|!=|~|IN|NOT|AND|OR|ORDER BY)\s+/i.test(query)) {
+    return query;
+  }
+
+  // Otherwise, treat as text search
+  return `text ~ "${query.replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Extract ADF text content to plain text
+ */
+export function adfToText(adf: unknown): string {
+  if (!adf || typeof adf !== "object") return String(adf || "");
+
+  const doc = adf as { content?: Array<{ content?: Array<{ text?: string }> }> };
+  if (!doc.content) return "";
+
+  return doc.content
+    .flatMap(block => block.content?.map(item => item.text || "") || [])
+    .join("\n");
+}

--- a/bin/jira/lib/config.ts
+++ b/bin/jira/lib/config.ts
@@ -1,0 +1,327 @@
+/**
+ * JIRA CLI Configuration and Profile Management
+ *
+ * Supports multiple Jira instances via profile-based .env files.
+ * Profile directories (checked in order):
+ *   1. ~/.claude/jira/profiles/*.env (preferred, persistent)
+ *   2. bin/jira/profiles/*.env (fallback, local)
+ * Default profile: profiles/default (symlink)
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync, lstatSync, readlinkSync } from "fs";
+import { join, dirname, basename } from "path";
+import { homedir } from "os";
+
+export interface JiraConfig {
+  url: string;
+  username: string;
+  apiToken: string;
+  defaultProject?: string;
+  projects?: string[];  // Projects this profile handles (for auto-detection)
+  profileName: string;
+}
+
+export interface ProfileInfo {
+  name: string;
+  url: string;
+  isDefault: boolean;
+}
+
+// Profile directories: check ~/.claude/jira/profiles/ first, then local ./profiles/
+const HOME_PROFILES_DIR = join(homedir(), ".claude", "jira", "profiles");
+const LOCAL_PROFILES_DIR = join(dirname(import.meta.path), "..", "profiles");
+
+/**
+ * Get the active profiles directory.
+ * Prefers ~/.claude/jira/profiles/ if it exists and has .env files,
+ * otherwise falls back to local ./profiles/
+ */
+export function getProfilesDir(): string {
+  // Check home directory first
+  if (existsSync(HOME_PROFILES_DIR)) {
+    const files = readdirSync(HOME_PROFILES_DIR);
+    const hasProfiles = files.some(f => f.endsWith(".env") || f === "default");
+    if (hasProfiles) {
+      return HOME_PROFILES_DIR;
+    }
+  }
+  // Fall back to local profiles
+  return LOCAL_PROFILES_DIR;
+}
+
+const REQUIRED_VARS = ["JIRA_URL", "JIRA_USERNAME", "JIRA_API_TOKEN"];
+
+/**
+ * Parse a .env file into key-value pairs
+ */
+function parseEnvFile(filePath: string): Record<string, string> {
+  const content = readFileSync(filePath, "utf-8");
+  const env: Record<string, string> = {};
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) continue;
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+
+    // Remove quotes if present
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    env[key] = value;
+  }
+
+  return env;
+}
+
+/**
+ * Get the default profile name (resolves symlink)
+ */
+function getDefaultProfileName(): string | null {
+  const profilesDir = getProfilesDir();
+  const defaultPath = join(profilesDir, "default");
+
+  if (!existsSync(defaultPath)) return null;
+
+  try {
+    const stats = lstatSync(defaultPath);
+    if (stats.isSymbolicLink()) {
+      const target = readlinkSync(defaultPath);
+      return basename(target).replace(/\.env$/, "");
+    }
+    // If it's a regular file named "default", treat it as the default
+    return "default";
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load configuration from a specific profile
+ */
+export function loadProfile(profileName: string): JiraConfig {
+  const profilesDir = getProfilesDir();
+  const profilePath = join(profilesDir, `${profileName}.env`);
+
+  if (!existsSync(profilePath)) {
+    const available = listProfiles();
+    const profileList = available.map(p => p.name).join(", ");
+    throw new Error(
+      `Profile not found: ${profileName}\n` +
+      `Available profiles: ${profileList || "(none)"}\n` +
+      `Create a profile in: ${profilesDir}/`
+    );
+  }
+
+  const env = parseEnvFile(profilePath);
+
+  // Check required variables
+  const missing = REQUIRED_VARS.filter(v => !env[v]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Profile '${profileName}' missing required variables: ${missing.join(", ")}\n` +
+      `See profiles.example/example.env for template`
+    );
+  }
+
+  // Parse JIRA_PROJECTS if present
+  const projects = env.JIRA_PROJECTS
+    ? env.JIRA_PROJECTS.split(",").map(p => p.trim().toUpperCase()).filter(Boolean)
+    : undefined;
+
+  return {
+    url: env.JIRA_URL.replace(/\/$/, ""), // Remove trailing slash
+    username: env.JIRA_USERNAME,
+    apiToken: env.JIRA_API_TOKEN,
+    defaultProject: env.JIRA_DEFAULT_PROJECT,
+    projects,
+    profileName,
+  };
+}
+
+/**
+ * Load configuration from environment variables (fallback)
+ */
+export function loadFromEnv(): JiraConfig | null {
+  const url = process.env.JIRA_URL;
+  const username = process.env.JIRA_USERNAME;
+  const apiToken = process.env.JIRA_API_TOKEN;
+
+  if (!url || !username || !apiToken) return null;
+
+  return {
+    url: url.replace(/\/$/, ""),
+    username,
+    apiToken,
+    defaultProject: process.env.JIRA_DEFAULT_PROJECT,
+    profileName: "env",
+  };
+}
+
+/**
+ * Get configuration for the specified profile, default profile, or env vars
+ */
+export function getConfig(profileName?: string): JiraConfig {
+  // Explicit profile requested
+  if (profileName && profileName !== "all") {
+    return loadProfile(profileName);
+  }
+
+  // Try default profile
+  const defaultProfile = getDefaultProfileName();
+  if (defaultProfile) {
+    return loadProfile(defaultProfile);
+  }
+
+  // Fall back to environment variables
+  const envConfig = loadFromEnv();
+  if (envConfig) {
+    return envConfig;
+  }
+
+  throw new Error(
+    "No Jira configuration found.\n\n" +
+    "Options:\n" +
+    "1. Create a profile in ~/.claude/jira/profiles/ (recommended, persistent)\n" +
+    "2. Or in local profiles/ directory\n" +
+    "3. Set default: cd ~/.claude/jira/profiles && ln -s personal.env default\n" +
+    "4. Or set environment variables: JIRA_URL, JIRA_USERNAME, JIRA_API_TOKEN"
+  );
+}
+
+/**
+ * List all available profiles
+ */
+export function listProfiles(): ProfileInfo[] {
+  const profilesDir = getProfilesDir();
+  if (!existsSync(profilesDir)) return [];
+
+  const defaultProfile = getDefaultProfileName();
+  const profiles: ProfileInfo[] = [];
+
+  for (const file of readdirSync(profilesDir)) {
+    if (!file.endsWith(".env")) continue;
+    if (file === "default") continue; // Skip symlink
+
+    const name = file.replace(/\.env$/, "");
+    const profilePath = join(profilesDir, file);
+
+    try {
+      const env = parseEnvFile(profilePath);
+      profiles.push({
+        name,
+        url: env.JIRA_URL || "(not configured)",
+        isDefault: name === defaultProfile,
+      });
+    } catch {
+      profiles.push({
+        name,
+        url: "(error reading profile)",
+        isDefault: false,
+      });
+    }
+  }
+
+  return profiles.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Get all profile configs (for federated search)
+ */
+export function getAllConfigs(): JiraConfig[] {
+  const profiles = listProfiles();
+  return profiles.map(p => loadProfile(p.name));
+}
+
+/**
+ * Project-to-profile cache for auto-detection
+ */
+const projectProfileCache = new Map<string, string>();
+
+export function cacheProjectProfile(projectKey: string, profileName: string): void {
+  projectProfileCache.set(projectKey.toUpperCase(), profileName);
+}
+
+export function getCachedProfile(projectKey: string): string | undefined {
+  return projectProfileCache.get(projectKey.toUpperCase());
+}
+
+export function getProjectKeyFromIssue(issueKey: string): string {
+  const match = issueKey.match(/^([A-Z][A-Z0-9]*)-\d+$/i);
+  return match ? match[1].toUpperCase() : "";
+}
+
+/**
+ * Find which profile handles a given project key.
+ * Checks JIRA_PROJECTS in each profile, then falls back to cache.
+ */
+export function getProfileForProject(projectKey: string): string | undefined {
+  const key = projectKey.toUpperCase();
+
+  // First check configured JIRA_PROJECTS in each profile
+  const profiles = listProfiles();
+  for (const profile of profiles) {
+    try {
+      const config = loadProfile(profile.name);
+      if (config.projects?.includes(key)) {
+        // Also cache for faster future lookups
+        cacheProjectProfile(key, profile.name);
+        return profile.name;
+      }
+    } catch {
+      // Skip profiles that fail to load
+    }
+  }
+
+  // Fall back to runtime cache (populated from previous searches)
+  return getCachedProfile(key);
+}
+
+/**
+ * Write JIRA_PROJECTS to a profile .env file.
+ * Preserves existing content, updates or adds JIRA_PROJECTS line.
+ */
+export function writeProfileProjects(profileName: string, projects: string[]): void {
+  const profilesDir = getProfilesDir();
+  const profilePath = join(profilesDir, `${profileName}.env`);
+
+  if (!existsSync(profilePath)) {
+    throw new Error(`Profile not found: ${profileName}`);
+  }
+
+  const content = readFileSync(profilePath, "utf-8");
+  const projectsLine = `JIRA_PROJECTS=${projects.join(",")}`;
+
+  // Check if JIRA_PROJECTS already exists
+  const lines = content.split("\n");
+  let found = false;
+  const newLines = lines.map(line => {
+    if (line.startsWith("JIRA_PROJECTS=")) {
+      found = true;
+      return projectsLine;
+    }
+    return line;
+  });
+
+  if (!found) {
+    // Add after JIRA_DEFAULT_PROJECT or at the end
+    const insertIndex = newLines.findIndex(l => l.startsWith("JIRA_DEFAULT_PROJECT="));
+    if (insertIndex >= 0) {
+      newLines.splice(insertIndex + 1, 0, projectsLine);
+    } else {
+      // Add at end, ensuring newline
+      if (newLines[newLines.length - 1] !== "") {
+        newLines.push("");
+      }
+      newLines.push(projectsLine);
+    }
+  }
+
+  writeFileSync(profilePath, newLines.join("\n"));
+}

--- a/bin/jira/lib/format.ts
+++ b/bin/jira/lib/format.ts
@@ -1,0 +1,414 @@
+/**
+ * Output Formatters for JIRA CLI
+ *
+ * Supports: table (default), json, markdown
+ */
+
+import type { JiraIssue, JiraProject, Transition, IssueLinkType, DevInfo } from "./api";
+import { adfToText } from "./api";
+
+export type OutputFormat = "table" | "json" | "markdown" | "index";
+
+// ============================================================================
+// Issue Formatting
+// ============================================================================
+
+export interface IssueIndexRow {
+  index: number;
+  key: string;
+  type: string;
+  summary: string;
+  status: string;
+  created: string;
+  labels: string;
+  instance?: string;
+}
+
+export function formatIssueIndex(
+  issues: (JiraIssue & { _instance?: string })[],
+  format: OutputFormat,
+  showInstance?: boolean
+): string {
+  const rows: IssueIndexRow[] = issues.map((issue, i) => ({
+    index: i + 1,
+    key: issue.key,
+    type: truncate(issue.fields.issuetype?.name || "-", 10),
+    summary: truncate(issue.fields.summary, 35),
+    status: truncate(issue.fields.status.name, 12),
+    created: formatDate(issue.fields.created),
+    labels: formatLabelsShort(issue.fields.labels),
+    instance: issue._instance,
+  }));
+
+  switch (format) {
+    case "json":
+      return JSON.stringify(rows, null, 2);
+
+    case "markdown":
+      return formatMarkdownTable(
+        ["#", "Key", "Type", "Summary", "Status", "Created", "Labels"],
+        rows.map(r => [String(r.index), r.key, r.type, r.summary, r.status, r.created, r.labels])
+      );
+
+    case "index":
+    case "table":
+    default:
+      return formatTable(
+        showInstance
+          ? ["#", "Instance", "Key", "Type", "Summary", "Status", "Created", "Labels"]
+          : ["#", "Key", "Type", "Summary", "Status", "Created", "Labels"],
+        rows.map(r =>
+          showInstance
+            ? [String(r.index), r.instance || "", r.key, r.type, r.summary, r.status, r.created, r.labels]
+            : [String(r.index), r.key, r.type, r.summary, r.status, r.created, r.labels]
+        )
+      );
+  }
+}
+
+/**
+ * Format labels for index display (show first 2-3, truncated)
+ */
+function formatLabelsShort(labels: string[]): string {
+  if (!labels?.length) return "-";
+  const shown = labels.slice(0, 2).map(l => truncate(l, 12));
+  if (labels.length > 2) {
+    return shown.join(", ") + `... (+${labels.length - 2})`;
+  }
+  return shown.join(", ");
+}
+
+export function formatIssueDetail(issue: JiraIssue, format: OutputFormat): string {
+  const description = typeof issue.fields.description === "object"
+    ? adfToText(issue.fields.description)
+    : issue.fields.description || "";
+
+  switch (format) {
+    case "json":
+      return JSON.stringify(issue, null, 2);
+
+    case "markdown":
+      return formatIssueMarkdown(issue, description);
+
+    case "table":
+    default:
+      return formatIssueTable(issue, description);
+  }
+}
+
+function formatIssueTable(issue: JiraIssue, description: string): string {
+  const lines: string[] = [
+    `${issue.key}: ${issue.fields.summary}`,
+    "─".repeat(60),
+    `Type:     ${issue.fields.issuetype.name}`,
+    `Status:   ${issue.fields.status.name}`,
+    `Priority: ${issue.fields.priority?.name || "-"}`,
+    `Assignee: ${issue.fields.assignee?.displayName || "Unassigned"}`,
+    `Reporter: ${issue.fields.reporter?.displayName || "-"}`,
+    `Labels:   ${issue.fields.labels.join(", ") || "-"}`,
+    `Created:  ${formatDate(issue.fields.created)}`,
+    `Updated:  ${formatDate(issue.fields.updated)}`,
+  ];
+
+  // Parent (for sub-tasks)
+  if (issue.fields.parent) {
+    lines.push(`Parent:   ${issue.fields.parent.key} - ${issue.fields.parent.fields.summary}`);
+  }
+
+  // Description
+  if (description) {
+    lines.push("", "Description:", "─".repeat(40), truncate(description, 500));
+  }
+
+  // Sub-tasks
+  if (issue.fields.subtasks?.length) {
+    lines.push("", "Sub-tasks:", "─".repeat(40));
+    for (const sub of issue.fields.subtasks) {
+      lines.push(`  ${sub.key}: ${sub.fields.summary} [${sub.fields.status.name}]`);
+    }
+  }
+
+  // Links
+  if (issue.fields.issuelinks?.length) {
+    lines.push("", "Links:", "─".repeat(40));
+    for (const link of issue.fields.issuelinks) {
+      if (link.outwardIssue) {
+        lines.push(`  ${link.type.outward}: ${link.outwardIssue.key} - ${link.outwardIssue.fields.summary}`);
+      }
+      if (link.inwardIssue) {
+        lines.push(`  ${link.type.inward}: ${link.inwardIssue.key} - ${link.inwardIssue.fields.summary}`);
+      }
+    }
+  }
+
+  // Comments (last 3)
+  const comments = issue.fields.comment?.comments || [];
+  if (comments.length) {
+    lines.push("", `Comments (${issue.fields.comment?.total || comments.length}):`);
+    lines.push("─".repeat(40));
+    for (const comment of comments.slice(-3)) {
+      const body = typeof comment.body === "object" ? adfToText(comment.body) : comment.body;
+      lines.push(`  ${comment.author.displayName} (${formatDate(comment.created)}):`);
+      lines.push(`    ${truncate(body, 200)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatIssueMarkdown(issue: JiraIssue, description: string): string {
+  const lines: string[] = [
+    `# [${issue.key}](${issue.self.replace("/rest/api/3/issue/", "/browse/")}) ${issue.fields.summary}`,
+    "",
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| Type | ${issue.fields.issuetype.name} |`,
+    `| Status | ${issue.fields.status.name} |`,
+    `| Priority | ${issue.fields.priority?.name || "-"} |`,
+    `| Assignee | ${issue.fields.assignee?.displayName || "Unassigned"} |`,
+    `| Labels | ${issue.fields.labels.join(", ") || "-"} |`,
+  ];
+
+  if (description) {
+    lines.push("", "## Description", "", description);
+  }
+
+  return lines.join("\n");
+}
+
+// ============================================================================
+// Project Formatting
+// ============================================================================
+
+export function formatProjects(projects: JiraProject[], format: OutputFormat): string {
+  switch (format) {
+    case "json":
+      return JSON.stringify(projects, null, 2);
+
+    case "markdown":
+      return formatMarkdownTable(
+        ["Key", "Name", "Lead", "Type"],
+        projects.map(p => [p.key, p.name, p.lead?.displayName || "-", p.projectTypeKey])
+      );
+
+    case "table":
+    default:
+      return formatTable(
+        ["Key", "Name", "Lead"],
+        projects.map(p => [p.key, truncate(p.name, 30), p.lead?.displayName || "-"])
+      );
+  }
+}
+
+// ============================================================================
+// Transition Formatting
+// ============================================================================
+
+export function formatTransitions(transitions: Transition[], format: OutputFormat): string {
+  switch (format) {
+    case "json":
+      return JSON.stringify(transitions, null, 2);
+
+    case "table":
+    default:
+      return formatTable(
+        ["ID", "Name", "To Status"],
+        transitions.map(t => [t.id, t.name, t.to.name])
+      );
+  }
+}
+
+// ============================================================================
+// Link Type Formatting
+// ============================================================================
+
+export function formatLinkTypes(types: IssueLinkType[], format: OutputFormat): string {
+  switch (format) {
+    case "json":
+      return JSON.stringify(types, null, 2);
+
+    case "table":
+    default:
+      return formatTable(
+        ["Name", "Outward", "Inward"],
+        types.map(t => [t.name, t.outward, t.inward])
+      );
+  }
+}
+
+// ============================================================================
+// Dev Info Formatting
+// ============================================================================
+
+export function formatDevInfo(devInfo: DevInfo, issueKey: string, format: OutputFormat): string {
+  const hasBranches = devInfo.branches.length > 0;
+  const hasCommits = devInfo.commits.length > 0;
+  const hasPRs = devInfo.pullRequests.length > 0;
+
+  if (!hasBranches && !hasCommits && !hasPRs) {
+    return `No development info linked to ${issueKey}\n\nTip: Add '${issueKey}' to branch name or commit message to link`;
+  }
+
+  switch (format) {
+    case "json":
+      return JSON.stringify(devInfo, null, 2);
+
+    case "table":
+    default: {
+      const lines: string[] = [`Development info for ${issueKey}:`, ""];
+
+      if (hasBranches) {
+        lines.push("Branches:", "─".repeat(40));
+        for (const branch of devInfo.branches) {
+          lines.push(`  ${branch.name} (${branch.repository.name})`);
+        }
+        lines.push("");
+      }
+
+      if (hasPRs) {
+        lines.push("Pull Requests:", "─".repeat(40));
+        for (const pr of devInfo.pullRequests) {
+          lines.push(`  #${pr.id}: ${pr.name} [${pr.status}]`);
+        }
+        lines.push("");
+      }
+
+      if (hasCommits) {
+        lines.push("Recent Commits:", "─".repeat(40));
+        for (const commit of devInfo.commits.slice(0, 5)) {
+          lines.push(`  ${commit.id.slice(0, 7)}: ${truncate(commit.message, 50)} (${commit.author.name})`);
+        }
+      }
+
+      return lines.join("\n");
+    }
+  }
+}
+
+// ============================================================================
+// Label Formatting
+// ============================================================================
+
+export function formatLabels(
+  labels: Map<string, number>,
+  format: OutputFormat,
+  prefix?: string
+): string {
+  let entries = Array.from(labels.entries());
+
+  if (prefix) {
+    entries = entries.filter(([label]) => label.startsWith(prefix));
+  }
+
+  // Sort by count (descending)
+  entries.sort((a, b) => b[1] - a[1]);
+
+  switch (format) {
+    case "json":
+      return JSON.stringify(Object.fromEntries(entries), null, 2);
+
+    case "table":
+    default:
+      if (entries.length === 0) {
+        return prefix ? `No labels matching '${prefix}'` : "No labels found";
+      }
+      return formatTable(
+        ["Label", "Count"],
+        entries.map(([label, count]) => [label, String(count)])
+      );
+  }
+}
+
+// ============================================================================
+// Profile Formatting
+// ============================================================================
+
+export interface ProfileDisplay {
+  name: string;
+  url: string;
+  isDefault: boolean;
+}
+
+export function formatProfiles(profiles: ProfileDisplay[]): string {
+  if (profiles.length === 0) {
+    return "No profiles configured.\n\nCreate one: cp profiles.example/example.env profiles/personal.env";
+  }
+
+  const lines = ["Available profiles:", ""];
+  for (const p of profiles) {
+    const marker = p.isDefault ? " (default)" : "";
+    lines.push(`  ${p.name}${marker}`);
+    lines.push(`    ${p.url}`);
+  }
+
+  return lines.join("\n");
+}
+
+// ============================================================================
+// Table Helpers
+// ============================================================================
+
+function formatTable(headers: string[], rows: string[][]): string {
+  if (rows.length === 0) {
+    return "No results";
+  }
+
+  // Calculate column widths
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map(r => (r[i] || "").length))
+  );
+
+  // Build table
+  const lines: string[] = [];
+
+  // Header
+  lines.push(headers.map((h, i) => h.padEnd(widths[i])).join("  "));
+  lines.push(widths.map(w => "─".repeat(w)).join("──"));
+
+  // Rows
+  for (const row of rows) {
+    lines.push(row.map((cell, i) => (cell || "").padEnd(widths[i])).join("  "));
+  }
+
+  return lines.join("\n");
+}
+
+function formatMarkdownTable(headers: string[], rows: string[][]): string {
+  const lines: string[] = [];
+
+  lines.push(`| ${headers.join(" | ")} |`);
+  lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
+
+  for (const row of rows) {
+    lines.push(`| ${row.join(" | ")} |`);
+  }
+
+  return lines.join("\n");
+}
+
+// ============================================================================
+// Utility Helpers
+// ============================================================================
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 3) + "...";
+}
+
+function formatDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toISOString().split("T")[0];
+}
+
+/**
+ * Generate a branch name from issue
+ */
+export function suggestBranchName(issueKey: string, summary: string): string {
+  const slug = summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 40);
+
+  return `${issueKey}-${slug}`;
+}

--- a/bin/jira/lib/index.ts
+++ b/bin/jira/lib/index.ts
@@ -1,0 +1,338 @@
+/**
+ * Index formatting and load functionality for jira CLI
+ *
+ * Provides:
+ * - Numbered index output format for search results
+ * - Storing last search results for subsequent load commands
+ * - Selection parsing (1,2,4,10-15)
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { mkdir, writeFile, readFile } from "fs/promises";
+import { homedir } from "os";
+import { JiraIssue, getIssue, extractTextFromADF } from "./api";
+
+// Store last search results in a temp location
+const CACHE_DIR = join(homedir(), ".cache", "jira");
+const LAST_SEARCH_FILE = join(CACHE_DIR, "last-search.json");
+
+export interface IndexedIssue {
+  index: number;
+  key: string;
+  type: string;
+  status: string;
+  statusCategory: string;
+  priority: string;
+  summary: string;
+  assignee: string;
+  created: string;
+  updated: string;
+  labels: string[];
+  projectAlias: string;
+}
+
+export interface SearchIndex {
+  query: string;
+  projectAlias: string;
+  timestamp: string;
+  issues: IndexedIssue[];
+}
+
+/**
+ * Convert Jira issues to indexed format
+ */
+export function toIndexedIssues(
+  issues: JiraIssue[],
+  projectAlias: string,
+  startIndex: number = 1
+): IndexedIssue[] {
+  return issues.map((issue, i) => ({
+    index: startIndex + i,
+    key: issue.key,
+    type: issue.fields.issuetype?.name || "Unknown",
+    status: issue.fields.status?.name || "Unknown",
+    statusCategory: issue.fields.status?.statusCategory?.name || "Unknown",
+    priority: issue.fields.priority?.name || "None",
+    summary: issue.fields.summary,
+    assignee: issue.fields.assignee?.displayName || "Unassigned",
+    created: formatDate(issue.fields.created),
+    updated: formatDate(issue.fields.updated),
+    labels: issue.fields.labels || [],
+    projectAlias,
+  }));
+}
+
+/**
+ * Format ISO date to YYYY-MM-DD
+ */
+function formatDate(isoDate: string): string {
+  if (!isoDate) return "unknown";
+  return isoDate.split("T")[0];
+}
+
+/**
+ * Truncate string with ellipsis
+ */
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+/**
+ * Format results as numbered index table
+ */
+export function formatIndexTable(issues: IndexedIssue[], query: string): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`📋 Jira Search Results for "${query}"`);
+  lines.push("");
+  lines.push(`Found ${issues.length} issue(s)`);
+  lines.push("─".repeat(100));
+  lines.push(formatHeader());
+  lines.push("─".repeat(100));
+
+  for (const issue of issues) {
+    lines.push(formatResultRow(issue));
+  }
+
+  lines.push("");
+  lines.push("─".repeat(100));
+  lines.push("Load options: jira load <selection>");
+  lines.push("  • jira load all              - Load all results");
+  lines.push("  • jira load 1,2,5            - Load specific items");
+  lines.push("  • jira load 1-5              - Load range");
+  lines.push("  • jira view ABC-123          - View single issue directly");
+
+  return lines.join("\n");
+}
+
+/**
+ * Format results as JSON for Claude to parse
+ */
+export function formatIndexJson(issues: IndexedIssue[], query: string): string {
+  const output = {
+    query,
+    timestamp: new Date().toISOString(),
+    summary: {
+      totalCount: issues.length,
+    },
+    issues: issues.map((i) => ({
+      index: i.index,
+      key: i.key,
+      type: i.type,
+      status: i.status,
+      priority: i.priority,
+      summary: i.summary,
+      assignee: i.assignee,
+      updated: i.updated,
+      labels: i.labels.slice(0, 3),
+    })),
+    loadInstructions: {
+      command: "jira load <selection>",
+      examples: [
+        { selection: "all", description: "Load all results" },
+        { selection: "1,2,5", description: "Load specific items" },
+        { selection: "1-5", description: "Load range" },
+      ],
+    },
+  };
+
+  return JSON.stringify(output, null, 2);
+}
+
+function formatHeader(): string {
+  return " #  │ Key        │ Type    │ Status        │ Summary                              │ Assignee";
+}
+
+function formatResultRow(issue: IndexedIssue): string {
+  const num = issue.index.toString().padStart(2);
+  const key = issue.key.padEnd(10);
+  const type = truncate(issue.type, 7).padEnd(7);
+  const status = truncate(issue.status, 13).padEnd(13);
+  const summary = truncate(issue.summary, 36).padEnd(36);
+  const assignee = truncate(issue.assignee, 15);
+
+  return `${num}  │ ${key} │ ${type} │ ${status} │ ${summary} │ ${assignee}`;
+}
+
+/**
+ * Save search results to cache for subsequent load commands
+ */
+export async function saveSearchIndex(index: SearchIndex): Promise<void> {
+  if (!existsSync(CACHE_DIR)) {
+    await mkdir(CACHE_DIR, { recursive: true });
+  }
+  await writeFile(LAST_SEARCH_FILE, JSON.stringify(index, null, 2));
+}
+
+/**
+ * Load the last search index from cache
+ */
+export async function loadSearchIndex(): Promise<SearchIndex | null> {
+  if (!existsSync(LAST_SEARCH_FILE)) {
+    return null;
+  }
+
+  try {
+    const content = await readFile(LAST_SEARCH_FILE, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse selection string into array of indices
+ * Supports: "1,2,5", "1-5", "1,3-5,10", "all"
+ */
+export function parseSelection(selection: string, maxIndex: number): number[] {
+  if (selection.toLowerCase() === "all") {
+    return Array.from({ length: maxIndex }, (_, i) => i + 1);
+  }
+
+  const indices: Set<number> = new Set();
+  const parts = selection.split(",").map((s) => s.trim());
+
+  for (const part of parts) {
+    if (part.includes("-")) {
+      // Range: "1-5"
+      const [start, end] = part.split("-").map((n) => parseInt(n.trim(), 10));
+      if (!isNaN(start) && !isNaN(end)) {
+        for (let i = start; i <= end && i <= maxIndex; i++) {
+          if (i >= 1) indices.add(i);
+        }
+      }
+    } else {
+      // Single number
+      const num = parseInt(part, 10);
+      if (!isNaN(num) && num >= 1 && num <= maxIndex) {
+        indices.add(num);
+      }
+    }
+  }
+
+  return Array.from(indices).sort((a, b) => a - b);
+}
+
+/**
+ * Load issues by selection from the last search
+ */
+export async function loadBySelection(selection: string): Promise<{
+  loaded: string[];
+  content: string;
+}> {
+  const index = await loadSearchIndex();
+
+  if (!index) {
+    throw new Error("No previous search found. Run 'jira search' first.");
+  }
+
+  if (index.issues.length === 0) {
+    throw new Error("Previous search had no results.");
+  }
+
+  // Parse selection
+  const indices = parseSelection(selection, index.issues.length);
+  const selectedIssues = index.issues.filter((i) => indices.includes(i.index));
+
+  if (selectedIssues.length === 0) {
+    throw new Error(`No results match selection: ${selection}`);
+  }
+
+  // Load full details for each selected issue
+  const contents: string[] = [];
+  const loaded: string[] = [];
+
+  for (const issue of selectedIssues) {
+    try {
+      const fullIssue = await getIssue(issue.key, {
+        projectAlias: issue.projectAlias,
+      });
+      contents.push(formatIssueDetails(fullIssue));
+      loaded.push(issue.key);
+    } catch (error) {
+      console.error(`Warning: Could not load ${issue.key}: ${error}`);
+    }
+  }
+
+  return {
+    loaded,
+    content: contents.join("\n\n"),
+  };
+}
+
+/**
+ * Format full issue details for context injection
+ */
+export function formatIssueDetails(issue: JiraIssue): string {
+  const lines: string[] = [];
+
+  lines.push("=".repeat(80));
+  lines.push(`# ${issue.key}: ${issue.fields.summary}`);
+  lines.push("=".repeat(80));
+  lines.push("");
+
+  // Metadata table
+  lines.push("## Metadata");
+  lines.push(`- **Type:** ${issue.fields.issuetype?.name || "Unknown"}`);
+  lines.push(`- **Status:** ${issue.fields.status?.name || "Unknown"}`);
+  lines.push(`- **Priority:** ${issue.fields.priority?.name || "None"}`);
+  lines.push(`- **Assignee:** ${issue.fields.assignee?.displayName || "Unassigned"}`);
+  lines.push(`- **Reporter:** ${issue.fields.reporter?.displayName || "Unknown"}`);
+  lines.push(`- **Created:** ${formatDate(issue.fields.created)}`);
+  lines.push(`- **Updated:** ${formatDate(issue.fields.updated)}`);
+
+  if (issue.fields.labels?.length > 0) {
+    lines.push(`- **Labels:** ${issue.fields.labels.join(", ")}`);
+  }
+
+  if (issue.fields.components?.length) {
+    lines.push(`- **Components:** ${issue.fields.components.map((c) => c.name).join(", ")}`);
+  }
+
+  if (issue.fields.parent) {
+    lines.push(`- **Parent:** ${issue.fields.parent.key} - ${issue.fields.parent.fields.summary}`);
+  }
+
+  lines.push("");
+
+  // Description
+  if (issue.fields.description) {
+    lines.push("## Description");
+    lines.push(extractTextFromADF(issue.fields.description));
+    lines.push("");
+  }
+
+  // Comments (if loaded)
+  if (issue.fields.comment?.comments?.length) {
+    lines.push("## Comments");
+    for (const comment of issue.fields.comment.comments.slice(-5)) {
+      lines.push(`### ${comment.author.displayName} (${formatDate(comment.created)})`);
+      lines.push(extractTextFromADF(comment.body));
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format load result summary
+ */
+export function formatLoadSummary(loaded: string[], totalSize: number): string {
+  const lines: string[] = [];
+  lines.push(`✅ Loaded ${loaded.length} issue(s) (${formatSize(totalSize)})`);
+  lines.push("");
+  for (const key of loaded) {
+    lines.push(`  • ${key}`);
+  }
+  return lines.join("\n");
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/bin/jira/lib/search.ts
+++ b/bin/jira/lib/search.ts
@@ -1,0 +1,180 @@
+/**
+ * JQL query building for jira CLI
+ * Converts user-friendly options to JQL queries
+ */
+
+import { getCredentials } from "./config";
+import { searchIssues, JiraSearchResult, getMyself } from "./api";
+
+export interface SearchOptions {
+  projectAlias?: string;
+  text?: string;
+  assignee?: string;
+  status?: string;
+  type?: string;
+  priority?: string;
+  labels?: string[];
+  updated?: string;  // e.g., "7d", "1w", "30d"
+  created?: string;
+  jql?: string;      // Raw JQL override
+  maxResults?: number;
+}
+
+/**
+ * Build JQL query from search options
+ */
+export function buildJQL(options: SearchOptions, currentUserAccountId?: string): string {
+  // If raw JQL provided, use it directly
+  if (options.jql) {
+    return options.jql;
+  }
+
+  const clauses: string[] = [];
+  const credentials = getCredentials(options.projectAlias);
+
+  // Always filter by project
+  clauses.push(`project = "${credentials.projectKey}"`);
+
+  // Text search
+  if (options.text) {
+    clauses.push(`text ~ "${escapeJQL(options.text)}"`);
+  }
+
+  // Assignee
+  if (options.assignee) {
+    if (options.assignee.toLowerCase() === "me") {
+      clauses.push("assignee = currentUser()");
+    } else if (options.assignee.toLowerCase() === "unassigned") {
+      clauses.push("assignee IS EMPTY");
+    } else {
+      clauses.push(`assignee = "${escapeJQL(options.assignee)}"`);
+    }
+  }
+
+  // Status
+  if (options.status) {
+    const status = options.status.toLowerCase();
+    if (status === "open") {
+      clauses.push('statusCategory != "Done"');
+    } else if (status === "done" || status === "closed") {
+      clauses.push('statusCategory = "Done"');
+    } else if (status === "in progress" || status === "inprogress") {
+      clauses.push('statusCategory = "In Progress"');
+    } else {
+      clauses.push(`status = "${escapeJQL(options.status)}"`);
+    }
+  }
+
+  // Issue type
+  if (options.type) {
+    clauses.push(`issuetype = "${escapeJQL(options.type)}"`);
+  }
+
+  // Priority
+  if (options.priority) {
+    clauses.push(`priority = "${escapeJQL(options.priority)}"`);
+  }
+
+  // Labels
+  if (options.labels && options.labels.length > 0) {
+    for (const label of options.labels) {
+      clauses.push(`labels = "${escapeJQL(label)}"`);
+    }
+  }
+
+  // Updated within timeframe
+  if (options.updated) {
+    const jqlTime = parseTimeToJQL(options.updated);
+    if (jqlTime) {
+      clauses.push(`updated >= ${jqlTime}`);
+    }
+  }
+
+  // Created within timeframe
+  if (options.created) {
+    const jqlTime = parseTimeToJQL(options.created);
+    if (jqlTime) {
+      clauses.push(`created >= ${jqlTime}`);
+    }
+  }
+
+  // Combine with AND and add default ordering
+  return clauses.join(" AND ") + " ORDER BY updated DESC";
+}
+
+/**
+ * Escape special characters in JQL string values
+ */
+function escapeJQL(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'");
+}
+
+/**
+ * Parse user-friendly time format to JQL
+ * e.g., "7d" -> "-7d", "1w" -> "-1w", "30d" -> "-30d"
+ */
+function parseTimeToJQL(time: string): string | null {
+  const match = time.match(/^(\d+)([dwmh])$/i);
+  if (!match) return null;
+
+  const [, amount, unit] = match;
+  const jqlUnit = unit.toLowerCase();
+
+  // Jira supports: h (hour), d (day), w (week)
+  if (["h", "d", "w"].includes(jqlUnit)) {
+    return `-${amount}${jqlUnit}`;
+  }
+
+  // Convert months to days (approximate)
+  if (jqlUnit === "m") {
+    const days = parseInt(amount) * 30;
+    return `-${days}d`;
+  }
+
+  return null;
+}
+
+/**
+ * Execute search with built JQL
+ */
+export async function search(options: SearchOptions): Promise<JiraSearchResult> {
+  const jql = buildJQL(options);
+
+  return searchIssues(jql, {
+    projectAlias: options.projectAlias,
+    maxResults: options.maxResults || 50,
+  });
+}
+
+/**
+ * Get my open issues
+ */
+export async function getMyOpenIssues(
+  projectAlias?: string,
+  maxResults?: number
+): Promise<JiraSearchResult> {
+  return search({
+    projectAlias,
+    assignee: "me",
+    status: "open",
+    maxResults,
+  });
+}
+
+/**
+ * Get recently updated issues
+ */
+export async function getRecentIssues(
+  projectAlias?: string,
+  days: number = 7,
+  maxResults?: number
+): Promise<JiraSearchResult> {
+  return search({
+    projectAlias,
+    updated: `${days}d`,
+    maxResults,
+  });
+}

--- a/bin/jira/lib/vision.ts
+++ b/bin/jira/lib/vision.ts
@@ -1,0 +1,206 @@
+/**
+ * Vision Analysis for Jira Attachments
+ *
+ * Uses OpenAI Vision API to analyze image attachments in tickets.
+ * Checks OPENAI_API_KEY from environment or ~/.claude/.env fallback.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import type { Attachment } from "./api";
+import type { JiraClient } from "./api";
+
+export interface VisionAnalysis {
+  filename: string;
+  mimeType: string;
+  analysis: string;
+  error?: string;
+}
+
+export interface VisionConfig {
+  apiKey: string;
+  model?: string;
+  maxTokens?: number;
+}
+
+/**
+ * Load API key from ~/.claude/.env if not in environment
+ */
+function loadApiKeyFromDotEnv(): string | null {
+  const envPath = join(homedir(), ".claude", ".env");
+  if (!existsSync(envPath)) return null;
+
+  try {
+    const content = readFileSync(envPath, "utf-8");
+    const match = content.match(/^OPENAI_API_KEY=(.+)$/m);
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get OpenAI API key from environment or ~/.claude/.env
+ */
+function getApiKey(): string | null {
+  return process.env.OPENAI_API_KEY || loadApiKeyFromDotEnv();
+}
+
+/**
+ * Check if vision analysis is available
+ */
+export function isVisionAvailable(): boolean {
+  return !!getApiKey();
+}
+
+/**
+ * Get OpenAI API key from environment or fallback
+ */
+export function getVisionConfig(): VisionConfig | null {
+  const apiKey = getApiKey();
+  if (!apiKey) return null;
+
+  return {
+    apiKey,
+    model: process.env.OPENAI_VISION_MODEL || "gpt-5.2",
+    maxTokens: parseInt(process.env.OPENAI_VISION_MAX_TOKENS || "300", 10),
+  };
+}
+
+/**
+ * Analyze a single image using OpenAI Vision API
+ */
+async function analyzeImage(
+  imageBuffer: Buffer,
+  mimeType: string,
+  filename: string,
+  config: VisionConfig
+): Promise<string> {
+  const base64Image = imageBuffer.toString("base64");
+  const dataUrl = `data:${mimeType};base64,${base64Image}`;
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: config.model,
+      max_completion_tokens: config.maxTokens,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `Describe this image from a Jira ticket attachment (${filename}). Focus on: what it shows, any error messages, UI elements, or technical details visible. Be concise (1-2 sentences).`,
+            },
+            {
+              type: "image_url",
+              image_url: {
+                url: dataUrl,
+                detail: "low", // Use low detail for faster/cheaper analysis
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`OpenAI API error: ${response.status} - ${error}`);
+  }
+
+  const result = await response.json() as {
+    choices: Array<{ message: { content: string } }>;
+  };
+
+  return result.choices[0]?.message?.content || "Unable to analyze image";
+}
+
+/**
+ * Analyze all image attachments for an issue
+ */
+export async function analyzeAttachments(
+  client: JiraClient,
+  issueKey: string,
+  config: VisionConfig
+): Promise<VisionAnalysis[]> {
+  const attachments = await client.getImageAttachments(issueKey);
+
+  if (attachments.length === 0) {
+    return [];
+  }
+
+  const results: VisionAnalysis[] = [];
+
+  // Process attachments (limit to first 5 to manage costs)
+  const toProcess = attachments.slice(0, 5);
+
+  for (const attachment of toProcess) {
+    try {
+      // Download the image
+      const imageBuffer = await client.downloadAttachment(attachment.content);
+
+      // Analyze with vision
+      const analysis = await analyzeImage(
+        imageBuffer,
+        attachment.mimeType,
+        attachment.filename,
+        config
+      );
+
+      results.push({
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        analysis,
+      });
+    } catch (error) {
+      results.push({
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        analysis: "",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (attachments.length > 5) {
+    results.push({
+      filename: `... and ${attachments.length - 5} more images`,
+      mimeType: "",
+      analysis: "(skipped to limit API costs)",
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Format vision analysis for display
+ */
+export function formatVisionAnalysis(analyses: VisionAnalysis[]): string {
+  if (analyses.length === 0) {
+    return "No image attachments found.";
+  }
+
+  const lines: string[] = [
+    `Image Attachments (${analyses.length}):`,
+    "─".repeat(40),
+  ];
+
+  for (const analysis of analyses) {
+    if (analysis.error) {
+      lines.push(`  ${analysis.filename} - Error: ${analysis.error}`);
+    } else {
+      lines.push(`  ${analysis.filename}`);
+      lines.push(`    → ${analysis.analysis}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/bin/jira/package.json
+++ b/bin/jira/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "jira-cli",
+  "version": "1.0.0",
+  "description": "PAI JIRA CLI - Deterministic command-line interface for Jira",
+  "type": "module",
+  "main": "jira.ts",
+  "scripts": {
+    "start": "bun run jira.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  }
+}

--- a/bin/jira/profiles.example/example.env.template
+++ b/bin/jira/profiles.example/example.env.template
@@ -1,0 +1,19 @@
+# JIRA Profile Configuration
+# Copy this file to ~/.claude/jira/profiles/<name>.env and fill in your credentials
+# Create a symlink for default: cd ~/.claude/jira/profiles && ln -sf <name>.env default
+
+# Required: Your Jira instance URL
+JIRA_URL=https://your-instance.atlassian.net
+
+# Required: Your Atlassian account email
+JIRA_USERNAME=your-email@example.com
+
+# Required: API Token (generate at: https://id.atlassian.com/manage-profile/security/api-tokens)
+JIRA_API_TOKEN=your-api-token-here
+
+# Optional: Default project for this instance (used when --project not specified)
+JIRA_DEFAULT_PROJECT=PROJ
+
+# Optional: Projects this profile handles (for auto-detection)
+# Run `jira setup` to auto-discover, or set manually
+JIRA_PROJECTS=PROJ,OTHER


### PR DESCRIPTION
## Summary

Add a Jira skill with TypeScript CLI for searching, viewing, and managing Jira issues directly from Claude Code.

### Features

**Core Functionality:**
- `jira search` - Search issues with JQL, labels, text queries
- `jira load` - View issue details, transitions, dev info
- `jira create` - Create issues and subtasks
- `jira update` - Update fields, transition status, add comments
- `jira link` - Link related issues

**Saved Filters (v1.1.0):**
- `jira filters` - List favourite/saved filters
- `jira search --filter "Filter Name"` - Search using saved filter
- `--owner` and `--mine` flags for filter discovery

**Quick Filters (v1.1.0):**
- `jira search --quick "open" -p HD` - Open issues
- `jira search --quick "my open"` - My open issues
- `jira search --quick "created today"` - Created today
- Full list: `jira search --quick list`

**Ordering (v1.1.0):**
- `jira search --order updated` - Order by field
- `jira search --asc` - Ascending order

**Single-Ticket Workflow (v1.1.0):**
- `jira open SMS-123` - Open for focused work
- `jira status` - Show opened ticket
- `jira close` - Close when done

**Vision Support (v1.1.0):**
- `jira load SMS-123 --vision` - Analyze image attachments with AI

**Multi-Profile Support:**
- Configure multiple Jira instances (Cloud + Server)
- Project-to-profile auto-detection
- Federated search across instances

## Test Plan
- [ ] `jira --help` shows available commands
- [ ] `jira search -t "test"` returns matching issues
- [ ] `jira load <KEY>` shows issue details
- [ ] `jira filters` lists saved filters
- [ ] `jira search --filter "X"` uses saved filter JQL
- [ ] `jira search --quick "open" -p HD` returns open issues
- [ ] `jira search --order created --asc` orders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)