### PR TITLE
fix(observability): add min-h-0 to timeline container for proper scroll

### DIFF
--- a/.claude/Observability/apps/client/src/App.vue
+++ b/.claude/Observability/apps/client/src/App.vue
@@ -44,8 +44,8 @@
     </div>
 
     <!-- Timeline - Glass Panel -->
-    <div class="flex flex-col flex-1 overflow-hidden mx-4 my-4 mobile:mx-2 mobile:my-2">
-      <div class="glass-panel rounded-2xl flex-1 overflow-hidden">
+    <div class="flex flex-col flex-1 min-h-0 overflow-hidden mx-4 my-4 mobile:mx-2 mobile:my-2">
+      <div class="glass-panel rounded-2xl flex-1 min-h-0 overflow-hidden flex flex-col">
         <EventTimeline
           :events="events"
           :filters="filters"


### PR DESCRIPTION
## Summary

The EventTimeline panel in the Observability dashboard was not scrollable when content exceeded viewport height. Events near the bottom of the timeline were rendered outside the visible area with no way to scroll to them.

## Problem

The flexbox layout was missing `min-h-0` on the timeline container, causing it to overflow its parent rather than enabling scroll.

## Fix

- Added `min-h-0` to the outer flex container (`<div class="flex flex-col flex-1 min-h-0 ...">`)
- Added `min-h-0` and `flex flex-col` to the inner glass-panel for proper flex behavior

## Before/After

**Before:** Timeline content that exceeded viewport was cut off, no scrolling possible
**After:** Timeline scrolls properly, all events accessible

Fixes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)