### PR TITLE
fix: Voice system root cause fix + hook improvements

### DIFF
--- a/.claude/agents/Architect.md
+++ b/.claude/agents/Architect.md
@@ -42,7 +42,7 @@ You are Atlas, an elite Principal Software Architect with deep expertise in syst
 After completing ANY response, you MUST immediately use the Bash tool to announce your completion:
 
 ```bash
-curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Architect completed [YOUR SPECIFIC TASK]","rate":270,"voice_enabled":true}'
+curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Architect completed [YOUR SPECIFIC TASK]","agent_type":"architect","voice_enabled":true}'
 ```
 
 **CRITICAL RULES:**

--- a/.claude/agents/Designer.md
+++ b/.claude/agents/Designer.md
@@ -49,7 +49,7 @@ OUTPUT UPON SUCCESS:
 After completing ANY response, you MUST immediately use the Bash tool to announce your completion:
 
 ```bash
-curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Designer completed [YOUR SPECIFIC TASK]","rate":240,"voice_enabled":true}'
+curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Designer completed [YOUR SPECIFIC TASK]","agent_type":"designer","voice_enabled":true}'
 ```
 
 **CRITICAL RULES:**

--- a/.claude/agents/Engineer.md
+++ b/.claude/agents/Engineer.md
@@ -44,7 +44,7 @@ You are Atlas, an elite Principal Software Engineer with deep expertise in softw
 After completing ANY response, you MUST immediately use the Bash tool to announce your completion:
 
 ```bash
-curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Engineer completed [YOUR SPECIFIC TASK]","rate":260,"voice_enabled":true}'
+curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Engineer completed [YOUR SPECIFIC TASK]","agent_type":"engineer","voice_enabled":true}'
 ```
 
 **CRITICAL RULES:**

--- a/.claude/agents/Pentester.md
+++ b/.claude/agents/Pentester.md
@@ -42,7 +42,7 @@ You are Tybon (T-A-I-B-A-N), an elite offensive security specialist with deep ex
 After completing ANY response, you MUST immediately use the Bash tool to announce your completion:
 
 ```bash
-curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Pentester completed [YOUR SPECIFIC TASK]","rate":290,"voice_enabled":true}'
+curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Pentester completed [YOUR SPECIFIC TASK]","agent_type":"pentester","voice_enabled":true}'
 ```
 
 **CRITICAL RULES:**

--- a/.claude/agents/Researcher.md
+++ b/.claude/agents/Researcher.md
@@ -69,7 +69,7 @@ ALWAYS use this standardized output format with emojis and structured sections:
 After completing ANY response, you MUST immediately use the Bash tool to announce your completion:
 
 ```bash
-curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Researcher completed [YOUR SPECIFIC TASK]","rate":280,"voice_enabled":true}'
+curl -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message":"Researcher completed [YOUR SPECIFIC TASK]","agent_type":"researcher","voice_enabled":true}'
 ```
 
 **CRITICAL RULES:**

--- a/.claude/hooks/subagent-stop-hook.ts
+++ b/.claude/hooks/subagent-stop-hook.ts
@@ -239,14 +239,19 @@ async function main() {
   }
   
   let transcriptPath: string;
+  let agentId: string | null = null;
   try {
     const parsed = JSON.parse(input);
-    transcriptPath = parsed.transcript_path;
+    // For SubagentStop, use agent_transcript_path (the agent's transcript)
+    // Fall back to transcript_path for backwards compatibility
+    transcriptPath = parsed.agent_transcript_path || parsed.transcript_path;
+    agentId = parsed.agent_id || null;
+    console.error(`📋 Agent ID: ${agentId}, Transcript: ${transcriptPath}`);
   } catch (e) {
     console.error('Invalid input JSON:', e);
     process.exit(0);
   }
-  
+
   if (!transcriptPath) {
     console.log('No transcript path provided');
     process.exit(0);


### PR DESCRIPTION
## Summary

This PR contains two phases of fixes:

1. **Initial fixes** (commit eecfaec): Patched symptoms by making emoji optional in stop-hook
2. **Root cause fix** (commit 216a2ba): Restored emojis to CORE format template

### The Root Cause Story

The voice system was designed to trigger on `🎯 COMPLETED:` lines. When commit f15f921 
stripped all emojis from the CORE/SKILL.md format template, the voice hook started failing.

**What we did wrong initially:** Made the emoji optional in stop-hook.ts regex 
(`(?:🎯\s*)?COMPLETED:`) - fixing the symptom, not the cause.

**What we should have done:** Restored the emojis to CORE/SKILL.md to match the original 
design and agent definitions (Engineer.md, Researcher.md, etc. all have `🎯 COMPLETED:`).

## Changes

### Root Cause Fix (CORE/SKILL.md)
- Restored all emojis to format template: 📋 🔍 ⚡ ✅ 📊 📁 ➡️ 📖 🎯
- Added 🗣️ CUSTOM COMPLETED line to match agent definitions
- Format now matches Engineer.md, Researcher.md, and other agents

### Voice Server (server.ts)
- Fix .env path to look in `~/.claude/.env` first, then fall back to `~/.env`
- Add `AGENT_VOICE_IDS` mapping for agent-specific ElevenLabs voices
- Add macOS `say` fallback when ElevenLabs fails or is not configured
- Support `agent_type` parameter for automatic voice selection

### Stop Hook (stop-hook.ts)
- Fix `voices.json` path to use `PAI_DIR` instead of hardcoded iCloud path
- Emoji optional in regex (kept for backward compatibility)
- Fix voice payload to only send `voice_id` if explicitly set
- Add debug logging to `~/.claude/stop-hook-debug.log`
- Fix last assistant message detection to skip tool_use-only responses

### Subagent Stop Hook (subagent-stop-hook.ts)
- Use `agent_transcript_path` instead of `transcript_path` for SubagentStop events

### Agent Definitions
- Replace deprecated `rate` parameter with `agent_type` in curl notification commands
- Affects: Engineer, Researcher, Architect, Designer, Pentester

## Test plan

- [x] Identify root cause (emojis stripped from CORE format)
- [x] Restore emojis to CORE/SKILL.md format template
- [x] Verify voice hook triggers on new format with emojis
- [x] Verify voice server loads `.env` from `~/.claude/.env`
- [x] Test agent notifications use correct voice based on `agent_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)