### PR TITLE
fix: Define PAI_DIR constant to resolve ReferenceError in help text

### DIFF
--- a/.claude/Skills/Art/tools/generate-ulart-image.ts
+++ b/.claude/Skills/Art/tools/generate-ulart-image.ts
@@ -19,6 +19,16 @@ import { writeFile, readFile } from "node:fs/promises";
 import { extname, resolve } from "node:path";
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * PAI_DIR - Root directory for PAI configuration
+ * Reads from environment variable PAI_DIR, falls back to ~/.claude
+ */
+const PAI_DIR = process.env.PAI_DIR || resolve(process.env.HOME!, '.claude');
+
+// ============================================================================
 // Environment Loading
 // ============================================================================
 


### PR DESCRIPTION
**Problem:**
The Art skill's help command crashed with 'ReferenceError: PAI_DIR is not defined' when using template literals like ${PAI_DIR} without defining the variable.

**Root Cause:**
The help text used ${PAI_DIR} in template literals (lines 196-197) but the variable was never defined in the TypeScript code.

**Solution:**
Added const PAI_DIR definition that reads from process.env.PAI_DIR with a fallback to resolve(process.env.HOME!, '.claude').

**Testing:**
- Verified --help now displays correctly with proper paths
- Confirmed all image generation functionality still works
- Tested with nano-banana-pro model successfully

**Impact:**
- Fixes issue where users couldn't access built-in help documentation
- No breaking changes to existing functionality
- Works with both environment variable and fallback path