### PR TITLE
feat: Linux compatibility fixes for cross-platform PAI

### DIFF
--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -1,0 +1,246 @@
+# PAI Platform Compatibility Status
+
+This document tracks all platform-specific code and dependencies across PAI, providing a roadmap for cross-platform support.
+
+**Last Updated:** 2026-01-01
+**Maintainer:** Community contributions welcome
+
+---
+
+## Platform Support Matrix
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| **macOS** | ✅ Fully Supported | Primary development platform |
+| **Linux** | ✅ Fully Supported | Ubuntu/Debian tested, other distros via community |
+| **Windows** | ❌ Not Supported | Community contributions welcome |
+
+---
+
+## Known Platform-Specific Issues (22 Total)
+
+### ✅ FIXED (PR #XXX - Linux Compatibility Fixes)
+
+**Critical Blockers:**
+1. ✅ `sed -i ''` syntax (macOS BSD vs GNU sed)
+   - **File:** `Packs/kai-voice-system/INSTALL.md` line 337
+   - **Fix:** Platform-aware sed with USERNAME fallback
+   - **Status:** Fixed with conditional `uname -s` detection
+
+2. ✅ `/opt/homebrew/bin` hardcoded in PATH
+   - **Files:** `kai-observability-server/src/observability/manage.sh:8`, `kai-observability-server.md:1316`
+   - **Fix:** Conditional PATH based on directory existence
+   - **Status:** Fixed with `[ -d "/opt/homebrew/bin" ]` check
+
+**Auto-Start Feature Parity:**
+3. ✅ LaunchAgent plist only (no Linux alternative)
+   - **File:** `Packs/kai-voice-system/INSTALL.md` Step 9
+   - **Fix:** Added systemd user service for Linux
+   - **Status:** Linux now has full auto-start support
+
+4. ✅ launchctl commands (macOS-only daemon management)
+   - **Context:** Part of LaunchAgent system
+   - **Fix:** systemd equivalent provided for Linux
+   - **Status:** Platform-specific but both supported
+
+5. ✅ ~/Library/LaunchAgents path (macOS directory structure)
+   - **Context:** Part of LaunchAgent system
+   - **Fix:** Linux uses `~/.config/systemd/user`
+   - **Status:** Platform-specific but both supported
+
+**Documentation:**
+6. ✅ VERIFY.md misleading "requires modifications" warning
+   - **File:** `Packs/kai-voice-system/VERIFY.md` lines 11-13
+   - **Fix:** Updated to reflect Linux is fully supported
+   - **Status:** Documentation now accurate
+
+---
+
+### 📋 ALREADY HANDLED (No Action Needed)
+
+**Audio Playback (Fixed in PR #285 - Google TTS):**
+17. ✅ afplay calls conditionally executed
+    - **File:** `Packs/kai-voice-system/src/voice/server.ts:286-336`
+    - **Status:** Runtime platform detection via `process.platform`
+    - **Implementation:** macOS uses afplay, Linux auto-detects mpg123/mpv/snap
+
+18. ✅ Linux audio player auto-detection
+    - **Status:** Fully implemented with graceful fallbacks
+    - **Priority:** mpg123 → mpv → snap/mpv → warn user
+
+19. ✅ Cross-platform notifications
+    - **macOS:** osascript (native notification center)
+    - **Linux:** notify-send (libnotify)
+    - **Status:** Both fully implemented
+
+20. ✅ process.platform checks
+    - **Status:** Correct pattern throughout codebase
+    - **Note:** Needs Windows support added (future work)
+
+21. ✅ Bun runtime
+    - **Status:** Cross-platform, no issues
+    - **Installation:** Works on macOS, Linux, Windows
+
+---
+
+### 🔮 MINOR ISSUES (Low Priority)
+
+**Documentation Inconsistencies:**
+7. 🔮 Platform check mentions paplay but code doesn't use it
+   - **File:** `Packs/kai-voice-system/INSTALL.md` platform check
+   - **Impact:** Minor - doesn't block functionality
+   - **Fix:** Either add paplay support or remove from docs
+   - **Priority:** Low - mpg123/mpv work fine
+
+8. 🔮 /Users/ hardcoded paths in examples
+   - **Files:** Various documentation showing macOS examples
+   - **Impact:** Documentation only, not actual code
+   - **Fix:** Use generic paths like `$HOME` in examples
+   - **Priority:** Low - users can adapt examples
+
+**macOS-Specific Features (Can't Test Without macOS):**
+9-14. 🔮 LaunchAgent plist internals (6 specific property keys)
+    - **Context:** macOS-only format
+    - **Status:** Not applicable to Linux
+    - **Priority:** Low - macOS functionality works
+
+15. 🔮 osascript for notifications
+    - **Status:** Already has notify-send fallback
+    - **Priority:** Low - both platforms supported
+
+16. 🔮 ~/Library/Logs for logging
+    - **Status:** Already uses `~/.config/pai` on Linux
+    - **Priority:** Low - platform-appropriate paths used
+
+---
+
+### ❌ UNSUPPORTED (Windows - Community Contributions Welcome)
+
+22. ❌ Windows support entirely absent
+    - **Audio:** No Windows Media Player integration
+    - **Notifications:** No Windows Toast notifications
+    - **Auto-start:** No Task Scheduler implementation
+    - **Shell scripts:** Assume bash (not cmd/PowerShell)
+    - **Priority:** Medium - depends on community interest
+
+**How to Contribute Windows Support:**
+1. Add Windows audio playback (Windows Media Player, ffplay, or native APIs)
+2. Implement Windows Toast notifications
+3. Create Task Scheduler auto-start alternative
+4. Convert bash scripts to cross-platform Bun/TypeScript
+5. Test on Windows 10/11
+6. Submit PR following PAI contribution guidelines
+
+---
+
+## Platform Detection Patterns
+
+**Recommended pattern (used throughout PAI):**
+
+```bash
+# Shell scripts
+OS_TYPE="$(uname -s)"
+if [ "$OS_TYPE" = "Darwin" ]; then
+  # macOS-specific code
+elif [ "$OS_TYPE" = "Linux" ]; then
+  # Linux-specific code
+else
+  echo "Unsupported platform: $OS_TYPE"
+fi
+```
+
+```typescript
+// TypeScript/Bun code
+if (process.platform === 'darwin') {
+  // macOS-specific code
+} else if (process.platform === 'linux') {
+  // Linux-specific code
+} else if (process.platform === 'win32') {
+  // Windows-specific code (future)
+}
+```
+
+**Anti-patterns to avoid:**
+- Hardcoding paths that only exist on one platform
+- Assuming package manager locations (Homebrew, apt, etc.)
+- Using platform-specific syntax without detection (sed -i '', etc.)
+- Skipping platform checks in documentation examples
+
+---
+
+## Testing Requirements
+
+Contributors fixing platform issues should:
+
+1. **Test on target platform** - Don't submit untested code
+2. **Document limitations** - Be honest about what you couldn't test
+3. **Follow PAI principles** - Simple, transparent, UNIX philosophy
+4. **Maintain backward compatibility** - Don't break existing platforms
+5. **Add to this document** - Update the inventory with your fixes
+
+**Current test coverage:**
+- macOS: Tested by Daniel Miessler
+- Linux (Ubuntu/WSL2): Tested by contributors
+- Linux (other distros): Community testing
+- Windows: Untested
+
+---
+
+## Future Work
+
+**High Priority:**
+- Windows audio playback support
+- Windows notification support
+- Windows auto-start mechanism
+
+**Medium Priority:**
+- Test on non-Ubuntu Linux distros (Fedora, Arch, etc.)
+- Improve error messages for missing dependencies
+- Add platform compatibility checks to installation
+
+**Low Priority:**
+- Support for alternative package managers
+- Docker/container deployment guide
+- Automated multi-platform testing (CI/CD)
+
+---
+
+## How to Report Platform Issues
+
+1. Check this document to see if the issue is already known
+2. Test on a clean installation (not your dev environment)
+3. Open a GitHub issue with:
+   - Platform details (OS, version, package manager)
+   - Error message or unexpected behavior
+   - Steps to reproduce
+   - Proposed solution (if you have one)
+
+**Before submitting:** Try to fix it yourself! PAI is community-driven.
+
+---
+
+## Contribution Guidelines
+
+When contributing platform fixes:
+
+1. **Fix what you can test** - Don't guess, verify
+2. **Document what you can't** - Be honest about limitations
+3. **Keep it simple** - Follow PAI's UNIX philosophy
+4. **Stay transparent** - No magic abstractions
+5. **Add tests** - At minimum, manual verification steps
+
+**Good PR example:** "feat: Add systemd auto-start for Linux (tested on Ubuntu 24.04)"
+
+**Bad PR example:** "feat: Universal auto-start abstraction framework for all platforms"
+
+---
+
+## Credits
+
+**Platform compatibility work by:**
+- Daniel Miessler - Original PAI implementation (macOS focus)
+- PR #285 - Google Cloud TTS provider, Linux audio support
+- PR #XXX - Linux compatibility fixes (sed, PATH, systemd)
+- Community contributors - Testing and bug reports
+
+Want your name here? Contribute a platform fix!

--- a/Packs/kai-observability-server.md
+++ b/Packs/kai-observability-server.md
@@ -1313,7 +1313,12 @@ export default {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Ensure bun is in PATH
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+# Only add Homebrew path if it exists (macOS-specific)
+if [ -d "/opt/homebrew/bin" ]; then
+  export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+else
+  export PATH="$HOME/.bun/bin:/usr/local/bin:$PATH"
+fi
 
 case "${1:-}" in
     start)

--- a/Packs/kai-observability-server/src/observability/manage.sh
+++ b/Packs/kai-observability-server/src/observability/manage.sh
@@ -5,7 +5,12 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Ensure bun is in PATH
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+# Only add Homebrew path if it exists (macOS-specific)
+if [ -d "/opt/homebrew/bin" ]; then
+  export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+else
+  export PATH="$HOME/.bun/bin:/usr/local/bin:$PATH"
+fi
 
 case "${1:-}" in
     start)

--- a/Packs/kai-voice-system/VERIFY.md
+++ b/Packs/kai-voice-system/VERIFY.md
@@ -8,16 +8,20 @@
 OS_TYPE="$(uname -s)"
 if [ "$OS_TYPE" = "Darwin" ]; then
   echo "✓ Platform: macOS - fully supported"
+  echo "   Audio: afplay (built-in)"
 elif [ "$OS_TYPE" = "Linux" ]; then
-  echo "⚠️  Platform: Linux - requires code modifications"
-  echo "   Verify that afplay calls have been replaced with aplay/paplay/mpv"
+  echo "✓ Platform: Linux - fully supported"
+  echo "   Audio: mpg123 (preferred) or mpv"
+  if ! command -v mpg123 &> /dev/null && ! command -v mpv &> /dev/null; then
+    echo "   ⚠️  No audio player found. Install: sudo apt install mpg123"
+  fi
 else
   echo "❌ Platform: $OS_TYPE - NOT SUPPORTED"
   echo "   Installation cannot be verified on this platform"
 fi
 ```
 
-**If OS is not macOS:** User must confirm they have modified the audio playback commands.
+**Cross-platform note:** Voice server auto-detects audio players (macOS: afplay, Linux: mpg123/mpv).
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes 4 critical Linux compatibility issues, enabling PAI installation on Google Gemini CLI and other Linux environments.

- Fix sed -i '' syntax (blocks GNU sed)
- Fix /opt/homebrew hardcoded paths
- Add systemd user service for auto-start
- Update outdated Linux warnings in docs

## Motivation

After contributing Google Cloud TTS (#285), we tested PAI installation on Linux (Ubuntu/WSL2) to enable use with Google Gemini CLI. Found several blocking issues that prevent Linux users from installing PAI without manual modifications.

## What's Changed

| File | Fix |
|------|-----|
| kai-voice-system/INSTALL.md | Platform-aware sed syntax + systemd service |
| kai-observability-server/manage.sh | Conditional Homebrew PATH |
| kai-observability-server.md | Updated PATH documentation |
| kai-voice-system/VERIFY.md | Accurate Linux support message |
| PLATFORM.md | NEW - Complete 22-issue inventory + roadmap |

## Key Improvements

**sed Command:** Added USERNAME fallback and platform detection for macOS BSD vs GNU sed

**PATH Detection:** Conditional Homebrew path only if directory exists

**systemd Auto-Start:** Full Linux support using systemd best practices (percent-h, WorkingDirectory, loginctl linger)

**Documentation:** New PLATFORM.md tracking all 22 platform issues with community contribution roadmap

## Testing

Tested on Ubuntu 24.04 (WSL2) with systemd 255:
- sed commands work without errors
- manage.sh finds bun correctly
- systemd service starts and survives logout
- Voice notifications play audio
- Platform detection patterns consistent

## Breaking Changes

None. macOS functionality unchanged. Pure additions for Linux support.

## Aligns with PAI Principles

Simple platform detection via uname, UNIX philosophy with native tools, transparent user-visible logic, deterministic behavior, removes macOS-only assumptions.

---

Generated with Claude Code