### PR TITLE
feat(voice): Add VOICE_STRICT_MODE for conditional voice notifications

### DIFF
--- a/Packs/kai-voice-system/README.md
+++ b/Packs/kai-voice-system/README.md
@@ -1,7 +1,7 @@
 ---
 name: Kai Voice System
-pack-id: danielmiessler-kai-voice-system-core-v1.3.0
-version: 1.3.0
+pack-id: danielmiessler-kai-voice-system-core-v1.4.0
+version: 1.4.0
 author: danielmiessler
 description: Voice notification system with multi-provider TTS (Google Cloud or ElevenLabs), prosody enhancement for natural speech, and agent personality-driven voice delivery
 type: feature
@@ -68,6 +68,10 @@ GOOGLE_TTS_VOICE=en-US-Neural2-J  # Optional, has sensible default
 # ElevenLabs (if using elevenlabs)
 ELEVENLABS_API_KEY=your_api_key
 ELEVENLABS_VOICE_ID=your_voice_id
+
+# Voice strict mode (optional)
+# When true, only speak when COMPLETED message is detected (silent skip otherwise)
+VOICE_STRICT_MODE=false
 ```
 
 ### Google Cloud TTS Voices
@@ -169,3 +173,15 @@ The prosody enhancer detects emotional context from message patterns:
 - **kai-hook-system** (required) - Hooks trigger voice notifications
 - **kai-core-install** (required) - Response format provides 🎯 COMPLETED line
 - **kai-history-system** - Complementary functionality
+
+## Changelog
+
+### 1.4.0 - 2026-01-06
+- Added `VOICE_STRICT_MODE` environment variable for silent skip when no COMPLETED found
+- When enabled, voice notifications only trigger if COMPLETED message is detected
+
+### 1.3.0 - 2025-12-29
+- Initial release with multi-provider TTS support
+- Google Cloud TTS and ElevenLabs integration
+- Prosody enhancement pipeline
+- Agent personality voice mapping


### PR DESCRIPTION
## Summary

Adds `VOICE_STRICT_MODE` environment variable to control voice notification behavior in the stop-hook-voice system. When enabled, voice notifications only trigger when an explicit `COMPLETED` message is detected in the assistant's response—eliminating unwanted "Completed task" fallback notifications.

  ### Problem

  The current implementation falls back to speaking "Completed task" whenever no `COMPLETED` pattern is found in the response. This creates unwanted voice notifications for:
  - Intermediate responses during multi-step workflows
  - Conversational exchanges that don't represent task completions
  - Error messages or clarification requests

  ### Solution

  Introduce `VOICE_STRICT_MODE` environment variable with the following behavior:

  | VOICE_STRICT_MODE | COMPLETED Found | Result |
  |-------------------|-----------------|--------|
  | unset / false     | Yes             | ✅ Speak completion message |
  | unset / false     | No              | ✅ Speak "Completed task" (fallback) |
  | **true / 1**      | Yes             | ✅ Speak completion message |
  | **true / 1**      | No              | 🔇 Skip silently |

  ## Changes

  ### Code (`Packs/kai-voice-system/src/hooks/stop-hook-voice.ts`)
  - Add `isStrictMode` constant reading `VOICE_STRICT_MODE` env var (supports `true` and `1`)
  - Change `extractCompletion()` return type from `string` to `string | null`
  - Return `null` instead of fallback when strict mode enabled and no COMPLETED found
  - Add `if (completion)` guard in `main()` to skip notification when null

  ### Documentation (`Packs/kai-hook-system/README.md`)
  - Add `VOICE_STRICT_MODE` to environment variables table
  - Bump version to 1.1.0
  - Add changelog entry

  ## Configuration

  Enable in your environment or `$PAI_DIR/.env`:

  ```bash
  VOICE_STRICT_MODE=true
```

  ## Test Plan

  - Default behavior preserved: Without VOICE_STRICT_MODE, fallback to "Completed task" still works
  - Strict mode + COMPLETED present: Voice notification fires with extracted message
  - Strict mode + no COMPLETED: Silent skip (no notification sent)
  - Build verification: TypeScript compiles without errors

  ## Backward Compatibility

  ✅ Fully backward compatible - Existing behavior unchanged when VOICE_STRICT_MODE is unset or false.

  ---
  🤖 Generated with https://claude.com/claude-code