### PR TITLE
fix: Await async main() in hooks for Windows compatibility

### DIFF
--- a/Packs/pai-hook-system/src/initialize-session.ts
+++ b/Packs/pai-hook-system/src/initialize-session.ts
@@ -143,4 +143,4 @@ async function main() {
   process.exit(0);
 }
 
-main();
+await main();

--- a/Packs/pai-hook-system/src/load-core-context.ts
+++ b/Packs/pai-hook-system/src/load-core-context.ts
@@ -92,4 +92,4 @@ This context is now active for this session. Follow all instructions, preference
   process.exit(0);
 }
 
-main();
+await main();

--- a/Packs/pai-hook-system/src/security-validator.ts
+++ b/Packs/pai-hook-system/src/security-validator.ts
@@ -225,4 +225,4 @@ async function main() {
   process.exit(0);
 }
 
-main();
+await main();

--- a/Packs/pai-hook-system/src/update-tab-titles.ts
+++ b/Packs/pai-hook-system/src/update-tab-titles.ts
@@ -95,4 +95,4 @@ async function main() {
   process.exit(0);
 }
 
-main();
+await main();


### PR DESCRIPTION
## Summary

On Windows, Bun exits immediately without waiting for pending promises. When hooks have `async main()` functions called without `await`, the script exits before `main()` completes, causing hooks to produce no output.

## Changes

Changed `main();` to `await main();` in all 4 hooks:
- `initialize-session.ts`
- `load-core-context.ts`
- `security-validator.ts`
- `update-tab-titles.ts`

## Testing

- Tested on macOS: Works as before
- Tested on Windows: Hooks now produce output correctly

## Root Cause

```typescript
async function main() {
  // async operations...
}

main();  // BUG: Script exits before promise resolves on Windows
```

Fix:
```typescript
await main();  // Ensures async operations complete before exit
```

---

🤖 Discovered while setting up PAI cross-platform (Mac + Windows)