### PR TITLE
Fix size validation for OpenAI model in Art skill (PAI v2.1)

### DIFF
--- a/Packs/pai-art-skill/src/skills/Art/Tools/Generate.ts
+++ b/Packs/pai-art-skill/src/skills/Art/Tools/Generate.ts
@@ -298,8 +298,10 @@ function parseArgs(argv: string[]): CLIArgs {
   }
 
   // Validate size for model
-  if (parsed.model === "gpt-image-1" && !OPENAI_SIZES.includes(parsed.size as OpenAISize)) {
-    throw new CLIError(`Invalid size for gpt-image-1: ${parsed.size}`);
+  if (parsed.model === "gpt-image-1") {
+    if (!OPENAI_SIZES.includes(parsed.size as OpenAISize)) {
+      throw new CLIError(`Invalid size for gpt-image-1: ${parsed.size}`);
+    }
   } else if (parsed.model === "nano-banana-pro") {
     if (!GEMINI_SIZES.includes(parsed.size as GeminiSize)) {
       throw new CLIError(`Invalid size for nano-banana-pro: ${parsed.size}`);


### PR DESCRIPTION
## What Problem This Solves

The Art skill's `Generate.ts` tool was rejecting valid OpenAI image sizes (1536x1024, 1024x1536) with an "Invalid size" error.

## Root Cause

The size validation logic was falling through to check OpenAI sizes against Replicate's aspect ratio format, causing valid sizes to be rejected.

## The Fix

Changed the validation from:
```typescript
if (parsed.model === "gpt-image-1" && !OPENAI_SIZES.includes(...))
```

To proper if-else-if structure:
```typescript
if (parsed.model === "gpt-image-1") {
  if (!OPENAI_SIZES.includes(...)) { throw error }
}
```

## Testing Done

✅ Verified OpenAI model now works with all valid sizes: 1024x1024, 1536x1024, 1024x1536
✅ Tested image generation completes successfully
✅ Confirmed no impact on other models (nano-banana-pro, flux, nano-banana)

## Example

```bash
bun run Generate.ts --model gpt-image-1 --size 1536x1024 --prompt "test" --output test.png
# Previously: Error: Invalid size: 1536x1024
# Now: Successfully generates image
```