### PR TITLE
feat: Add GitHub Codespaces devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git-lfs ca-certificates curl \
+ && git lfs install \
+ && rm -rf /var/lib/apt/lists/*
+
+# Node 20.x (change 20 to 18/22 if desired)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Codespaces (Ubuntu) + Bun",
+
+  "build": { "dockerfile": "Dockerfile" },
+
+  "remoteUser": "vscode",
+
+  "postCreateCommand": "curl -fsSL https://bun.sh/install | bash",
+  "remoteEnv": {
+    "BUN_INSTALL": "/home/vscode/.bun",
+    "PATH": "/home/vscode/.bun/bin:${containerEnv:PATH}"
+  }
+}


### PR DESCRIPTION
Add .devcontainer configuration to enable one-click development environment setup in GitHub Codespaces.
(This was based on today's repo)

Components:
- devcontainer.json: Configures Codespaces with Bun runtime
- Dockerfile: Custom container with git-lfs, Node.js 20, and Claude Code CLI

Features:
- Automatic Bun installation via postCreateCommand
- Pre-configured PATH for Bun binaries
- Git LFS support for large files
- Node.js 20.x for Claude Code CLI
- Claude Code CLI (@anthropic-ai/claude-code) pre-installed

Benefits:
- One-click setup for contributors
- Consistent development environment
- No local installation required
- Ready-to-use Claude Code environment

Tested on:
- GitHub Codespaces (Ubuntu/Bookworm base)