### PR TITLE
fix(history): normalize Windows paths in stop hooks

### DIFF
--- a/Packs/pai-history-system/src/stop-hook.ts
+++ b/Packs/pai-history-system/src/stop-hook.ts
@@ -3,7 +3,7 @@
 // Captures main agent work summaries and learnings
 
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { join, normalize } from 'path';
 import { homedir } from 'os';
 
 interface StopPayload {
@@ -132,7 +132,9 @@ async function main() {
     // Try to get response from payload first, then from transcript
     let response = payload.response;
     if (!response && payload.transcript_path) {
-      response = extractResponseFromTranscript(payload.transcript_path) || undefined;
+      // Normalize path for cross-platform compatibility (Windows backslashes)
+      const normalizedPath = normalize(payload.transcript_path);
+      response = extractResponseFromTranscript(normalizedPath) || undefined;
     }
 
     if (!response) {

--- a/Packs/pai-history-system/src/subagent-stop-hook.ts
+++ b/Packs/pai-history-system/src/subagent-stop-hook.ts
@@ -3,7 +3,7 @@
 // Routes subagent outputs to appropriate history directories
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, normalize } from 'path';
 import { homedir } from 'os';
 import { extractAgentInstanceId } from './lib/metadata-extraction';
 
@@ -210,7 +210,8 @@ async function main() {
     if (!input) process.exit(0);
 
     const parsed = JSON.parse(input);
-    const transcriptPath = parsed.transcript_path;
+    // Normalize path for cross-platform compatibility (Windows backslashes)
+    const transcriptPath = parsed.transcript_path ? normalize(parsed.transcript_path) : undefined;
     if (!transcriptPath) process.exit(0);
 
     const { result: taskOutput, agentType, description, toolInput } = await findTaskResult(transcriptPath);


### PR DESCRIPTION
## Summary

Fixes #357

The history system hooks (`stop-hook.ts` and `subagent-stop-hook.ts`) fail silently on Windows because transcript paths with backslashes aren't being normalized before use.

## Changes

- Add `normalize` import from `path` module to both hooks
- Apply `normalize()` to `transcript_path` before passing to file read operations

## Files Changed

- `Packs/pai-history-system/src/stop-hook.ts`
- `Packs/pai-history-system/src/subagent-stop-hook.ts`

## Test Plan

- [x] Verified raw event capture still works on Windows
- [x] Verified session/learning capture now works on Windows
- [x] Verified path normalization handles Windows backslash paths correctly

## Technical Details

Windows paths from Claude Code arrive as `C:\Users\...` but weren't being handled correctly. Node's `normalize()` function from the `path` module ensures cross-platform compatibility by converting path separators appropriately.

Before:
```typescript
response = extractResponseFromTranscript(payload.transcript_path);
```

After:
```typescript
const normalizedPath = normalize(payload.transcript_path);
response = extractResponseFromTranscript(normalizedPath);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)