### PR TITLE
fix(pai-hook-system): restore accidentally deleted observability.ts

### DIFF
--- a/Packs/pai-hook-system/src/lib/observability.ts
+++ b/Packs/pai-hook-system/src/lib/observability.ts
@@ -1,0 +1,58 @@
+// $PAI_DIR/hooks/lib/observability.ts
+// Sends hook events to observability dashboards
+
+export interface ObservabilityEvent {
+  source_app: string;
+  session_id: string;
+  hook_event_type: 'PreToolUse' | 'PostToolUse' | 'UserPromptSubmit' | 'Notification' | 'Stop' | 'SubagentStop' | 'SessionStart' | 'SessionEnd' | 'PreCompact';
+  timestamp: string;
+  transcript_path?: string;
+  summary?: string;
+  tool_name?: string;
+  tool_input?: any;
+  tool_output?: any;
+  agent_type?: string;
+  model?: string;
+  [key: string]: any;
+}
+
+/**
+ * Send event to observability dashboard
+ * Fails silently if dashboard is not running - doesn't block hook execution
+ */
+export async function sendEventToObservability(event: ObservabilityEvent): Promise<void> {
+  const dashboardUrl = process.env.PAI_OBSERVABILITY_URL || 'http://localhost:4000/events';
+
+  try {
+    const response = await fetch(dashboardUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'PAI-Hook/1.0'
+      },
+      body: JSON.stringify(event),
+    });
+
+    if (!response.ok) {
+      // Log error but don't throw - dashboard may be offline
+      console.error(`Observability server returned status: ${response.status}`);
+    }
+  } catch (error) {
+    // Fail silently - dashboard may not be running
+    // This is intentional - hooks should never fail due to observability issues
+  }
+}
+
+/**
+ * Helper to get current timestamp in ISO format
+ */
+export function getCurrentTimestamp(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Helper to get source app name from environment
+ */
+export function getSourceApp(): string {
+  return process.env.PAI_SOURCE_APP || process.env.DA || 'PAI';
+}


### PR DESCRIPTION
## Summary
- Restores `lib/observability.ts` to `pai-hook-system` pack
- File was accidentally deleted in commit 0faf5e4 during kai→pai rename

## Problem
`initialize-session.ts` imports from `./lib/observability` but the file doesn't exist:
```
error: Cannot find module './lib/observability'
```

This breaks the SessionStart hooks for anyone installing `pai-hook-system`.

## Fix
Restore the original file to `Packs/pai-hook-system/src/lib/observability.ts`

The file content is recovered from commit [0faf5e4](https://github.com/danielmiessler/Personal_AI_Infrastructure/commit/0faf5e4108db7ad65758e951bb66f76bed8410d3) where it was removed.

Closes #353