### PR TITLE
fix(pai-art-skill): Apply model-specific default sizes in Generate.ts

### DIFF
--- a/Packs/pai-art-skill/src/skills/Art/Tools/Generate.ts
+++ b/Packs/pai-art-skill/src/skills/Art/Tools/Generate.ts
@@ -297,16 +297,21 @@ function parseArgs(argv: string[]): CLIArgs {
     throw new CLIError(`Too many reference images: ${parsed.referenceImages.length}. Maximum is 14 total`);
   }
 
-  // Validate size for model
-  if (parsed.model === "gpt-image-1" && !OPENAI_SIZES.includes(parsed.size as OpenAISize)) {
-    throw new CLIError(`Invalid size for gpt-image-1: ${parsed.size}`);
+  // Validate size for model (and apply model-specific defaults)
+  if (parsed.model === "gpt-image-1") {
+    if (!parsed.size || !OPENAI_SIZES.includes(parsed.size as OpenAISize)) {
+      parsed.size = "1024x1024"; // Default for OpenAI
+    }
   } else if (parsed.model === "nano-banana-pro") {
-    if (!GEMINI_SIZES.includes(parsed.size as GeminiSize)) {
-      throw new CLIError(`Invalid size for nano-banana-pro: ${parsed.size}`);
+    if (!parsed.size || !GEMINI_SIZES.includes(parsed.size as GeminiSize)) {
+      parsed.size = "2K"; // Default for Gemini
     }
     if (!parsed.aspectRatio) parsed.aspectRatio = "16:9";
-  } else if (!REPLICATE_SIZES.includes(parsed.size as ReplicateSize)) {
-    throw new CLIError(`Invalid size: ${parsed.size}`);
+  } else {
+    // flux or nano-banana (Replicate)
+    if (!parsed.size || !REPLICATE_SIZES.includes(parsed.size as ReplicateSize)) {
+      parsed.size = "16:9"; // Default for Replicate
+    }
   }
 
   return parsed as CLIArgs;


### PR DESCRIPTION
## Summary

- Fixed broken size validation logic in Generate.ts that caused errors when using models with different size formats
- Applied sensible model-specific defaults when `--size` is omitted or invalid

Fixes #380

## Problem

The validation logic was structured as:
```typescript
if (gpt-image-1 && NOT valid) throw
else if (nano-banana-pro) { validate }
else if (NOT valid for replicate) throw
```

When using `gpt-image-1` without `--size`, the default "2K" would pass the first condition (since the size IS technically invalid for OpenAI), but then if you specify a valid OpenAI size like `1024x1024`, the first condition becomes false and it falls through to the replicate check which fails.

## Solution

Restructured to properly branch per model type and apply defaults:
- `gpt-image-1`: defaults to `1024x1024`
- `nano-banana-pro`: defaults to `2K`
- `flux`/`nano-banana`: defaults to `16:9`

## Test Plan

- [x] Tested `--model gpt-image-1` without `--size` - now defaults to 1024x1024
- [x] Tested `--model nano-banana-pro` without `--size` - works with 2K default
- [x] Generated test image successfully with Google API

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)