### PR TITLE
fix(installer): Add symlink support for custom PAI_DIR skill discovery

### DIFF
--- a/Packs/pai-core-install/VERIFY.md
+++ b/Packs/pai-core-install/VERIFY.md
@@ -99,6 +99,30 @@
 - [ ] `$PAI_DIR/skills/skill-index.json` exists (run GenerateSkillIndex.ts)
 - [ ] `$PAI_DIR/skills/CORE/PaiArchitecture.md` exists (run PaiArchitecture.ts generate)
 
+### Claude Code Skill Discovery (if PAI_DIR ≠ ~/.claude)
+
+**Only check these if PAI_DIR is set to a non-default location:**
+
+- [ ] Symlink exists: `~/.claude/skills` → `$PAI_DIR/skills`
+- [ ] Symlink is valid (not broken)
+- [ ] Skills are discoverable via Claude Code
+
+```bash
+# Verify symlink
+if [ "$PAI_DIR" != "$HOME/.claude" ]; then
+  if [ -L "$HOME/.claude/skills" ]; then
+    LINK_TARGET=$(readlink "$HOME/.claude/skills")
+    if [ "$LINK_TARGET" = "$PAI_DIR/skills" ]; then
+      echo "✓ Symlink correctly points to $PAI_DIR/skills"
+    else
+      echo "⚠️ Symlink points to wrong location: $LINK_TARGET"
+    fi
+  else
+    echo "❌ No symlink found - Claude Code won't auto-discover skills"
+  fi
+fi
+```
+
 ---
 
 ## Functional Tests
@@ -271,7 +295,8 @@ In a Claude Code session:
 
 ```bash
 #!/bin/bash
-PAI_CHECK="${PAI_DIR:-$HOME/.config/pai}"
+PAI_CHECK="${PAI_DIR:-$HOME/.claude}"
+DEFAULT_CLAUDE_DIR="$HOME/.claude"
 
 echo "=== PAI Core Install v1.2.0 Verification ==="
 echo ""
@@ -371,6 +396,27 @@ else
 fi
 
 echo ""
+
+# Check Claude Code skill discovery symlink (if PAI_DIR ≠ ~/.claude)
+if [ "$PAI_CHECK" != "$DEFAULT_CLAUDE_DIR" ]; then
+  echo "🔗 Claude Code Skill Discovery:"
+  if [ -L "$DEFAULT_CLAUDE_DIR/skills" ]; then
+    LINK_TARGET=$(readlink "$DEFAULT_CLAUDE_DIR/skills")
+    if [ "$LINK_TARGET" = "$PAI_CHECK/skills" ]; then
+      echo "  ✓ Symlink correctly points to $PAI_CHECK/skills"
+    else
+      echo "  ⚠️  Symlink points to: $LINK_TARGET (expected: $PAI_CHECK/skills)"
+    fi
+  elif [ -d "$DEFAULT_CLAUDE_DIR/skills" ]; then
+    echo "  ❌ ~/.claude/skills is a directory, not a symlink"
+    echo "     Skills won't be auto-discovered by Claude Code"
+  else
+    echo "  ❌ No symlink found at ~/.claude/skills"
+    echo "     Create with: ln -s $PAI_CHECK/skills $DEFAULT_CLAUDE_DIR/skills"
+  fi
+  echo ""
+fi
+
 echo "=== Verification Complete ==="
 ```
 
@@ -391,3 +437,4 @@ Installation is complete when:
 9. ✅ `bun run $PAI_DIR/Tools/SkillSearch.ts --list` returns skill list
 10. ✅ `bun run $PAI_DIR/Tools/PaiArchitecture.ts check` shows healthy status
 11. ✅ Documentation headers are present in USER/, PAISECURITYSYSTEM/, and SYSTEM/ files
+12. ✅ If PAI_DIR ≠ ~/.claude: Symlink exists from ~/.claude/skills → $PAI_DIR/skills


### PR DESCRIPTION
## Summary

Claude Code natively scans `~/.claude/skills/` for skills, but users with custom `PAI_DIR` settings (e.g., `~/PAI`) couldn't have their skills auto-discovered. This fix:

- Updates the installer to use `config.installDir` instead of a hardcoded path
- Detects when `PAI_DIR` differs from `~/.claude` and explains the skill discovery issue
- Offers to create a symlink from `~/.claude/skills` → `$PAI_DIR/skills`
- Handles edge cases (existing symlinks, directories, conflicts)
- Updates `INSTALL.md` with a symlink question and creation step
- Updates `VERIFY.md` with symlink verification checklist and script
- Changes the default from `~/.config/pai` to `~/.claude` to match Claude Code's native path

## Problem

When `PAI_DIR` is set to something other than `~/.claude`, skills are installed to `$PAI_DIR/skills/` but Claude Code only looks in `~/.claude/skills/` natively. This meant skills wouldn't be auto-discovered, leading to confusion about why skill routing wasn't working.

## Solution

The installer now:
1. Detects if `PAI_DIR` differs from `~/.claude`
2. Explains the Claude Code skill discovery behavior
3. Offers to create a symlink to bridge the gap
4. Provides manual instructions if the user declines

## Test Plan

- [ ] Fresh install with default `PAI_DIR` (no symlink needed)
- [ ] Fresh install with custom `PAI_DIR` - accept symlink creation
- [ ] Fresh install with custom `PAI_DIR` - decline symlink, verify manual instructions shown
- [ ] Update mode preserves existing settings
- [ ] Symlink creation handles existing directory at target path
- [ ] Symlink creation handles existing symlink pointing elsewhere
- [ ] VERIFY.md script correctly reports symlink status

🤖 Generated with [Claude Code](https://claude.com/claude-code)