### PR TITLE
fix(ActivityParser): Add cross-platform path support for Linux

### DIFF
--- a/Releases/v2.3/.claude/skills/CORE/Tools/ActivityParser.ts
+++ b/Releases/v2.3/.claude/skills/CORE/Tools/ActivityParser.ts
@@ -16,6 +16,7 @@
 import { parseArgs } from "util";
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 
 // ============================================================================
 // Configuration
@@ -23,8 +24,10 @@ import * as path from "path";
 
 const CLAUDE_DIR = path.join(process.env.HOME!, ".claude");
 const MEMORY_DIR = path.join(CLAUDE_DIR, "MEMORY");
-const USERNAME = process.env.USER || require("os").userInfo().username;
-const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-Users-${USERNAME}--claude`);  // Claude Code native storage
+const USERNAME = process.env.USER || os.userInfo().username;
+// Cross-platform support: macOS uses /Users/, Linux uses /home/
+const PATH_PREFIX = os.platform() === "darwin" ? "Users" : "home";
+const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-${PATH_PREFIX}-${USERNAME}--claude`);  // Claude Code native storage
 const SYSTEM_UPDATES_DIR = path.join(MEMORY_DIR, "PAISYSTEMUPDATES");  // Canonical system change history
 
 // ============================================================================


### PR DESCRIPTION
## Summary

ActivityParser.ts hardcodes macOS-specific path pattern `-Users-${USERNAME}--claude` for the Claude Code projects directory. This fails on Linux systems where home directories are under `/home/` instead of `/Users/`.

This is the same issue fixed in #[SessionHarvester PR number] for SessionHarvester.ts.

## Changes

```diff
+import * as os from "os";

-const USERNAME = process.env.USER || require("os").userInfo().username;
-const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-Users-${USERNAME}--claude`);
+const USERNAME = process.env.USER || os.userInfo().username;
+// Cross-platform support: macOS uses /Users/, Linux uses /home/
+const PATH_PREFIX = os.platform() === "darwin" ? "Users" : "home";
+const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects", `-${PATH_PREFIX}-${USERNAME}--claude`);
```

## Testing

**Linux (Ubuntu 24.04):**
- Path correctly resolves to `-home-username--claude`

**macOS (expected):**
- Path resolves to `-Users-username--claude` (unchanged behavior)

## Checklist

- [x] Tested on Linux
- [x] Maintains backward compatibility with macOS
- [x] No new dependencies (uses built-in `os` module)
- [x] Consistent with SessionHarvester fix pattern
