### PR TITLE
fix: correct jq path for PAI version in statusline script

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -91,7 +91,7 @@ DA_NAME=$(jq -r '.daidentity.name // .daidentity.displayName // .env.DA // "Assi
 DA_NAME="${DA_NAME:-Assistant}"
 
 # Get PAI version from settings
-PAI_VERSION=$(jq -r '.pai.version // "—"' "$SETTINGS_FILE" 2>/dev/null)
+PAI_VERSION=$(jq -r '.paiVersion // "—"' "$SETTINGS_FILE" 2>/dev/null)
 PAI_VERSION="${PAI_VERSION:-—}"
 
 # Extract all data from JSON in single jq call

--- a/Packs/pai-statusline/src/statusline-command.sh
+++ b/Packs/pai-statusline/src/statusline-command.sh
@@ -91,7 +91,7 @@ DA_NAME=$(jq -r '.daidentity.name // .daidentity.displayName // .env.DA // "Assi
 DA_NAME="${DA_NAME:-Assistant}"
 
 # Get PAI version from settings
-PAI_VERSION=$(jq -r '.pai.version // "—"' "$SETTINGS_FILE" 2>/dev/null)
+PAI_VERSION=$(jq -r '.paiVersion // "—"' "$SETTINGS_FILE" 2>/dev/null)
 PAI_VERSION="${PAI_VERSION:-—}"
 
 # Extract all data from JSON in single jq call

--- a/Releases/v2.3/.claude/statusline-command.sh
+++ b/Releases/v2.3/.claude/statusline-command.sh
@@ -91,7 +91,7 @@ DA_NAME=$(jq -r '.daidentity.name // .daidentity.displayName // .env.DA // "Assi
 DA_NAME="${DA_NAME:-Assistant}"
 
 # Get PAI version from settings (single source of truth)
-PAI_VERSION=$(jq -r '.pai.version // "2.0"' "$SETTINGS_FILE" 2>/dev/null)
+PAI_VERSION=$(jq -r '.paiVersion // "2.0"' "$SETTINGS_FILE" 2>/dev/null)
 PAI_VERSION="${PAI_VERSION:-2.0}"
 
 # Extract all data from JSON in single jq call


### PR DESCRIPTION
## Summary
- Fixed jq path mismatch in statusline-command.sh that caused incorrect version display
- Changed `.pai.version` to `.paiVersion` to match what install.ts writes

## Problem
The statusline script was reading from `.pai.version` in settings.json, but `install.ts` writes the version to `.paiVersion` at the root level. This caused the statusline to always show the fallback version ("2.0" or "—") instead of the actual installed version.

## Solution
Updated the jq query on line 94 in all three copies of the script:
- `.claude/statusline-command.sh`
- `Releases/v2.3/.claude/statusline-command.sh`
- `Packs/pai-statusline/src/statusline-command.sh`

## Verification
Tested locally by comparing jq queries:
```bash
# Old query returns fallback
jq -r '.pai.version // "2.0"' settings.json  # Returns: 2.0

# New query returns actual version
jq -r '.paiVersion // "2.0"' settings.json   # Returns: 2.3
```

## Test plan
- [x] Verified settings.json has `paiVersion` at root level
- [x] Tested both jq queries against settings.json
- [x] Confirmed statusline displays correct version after fix

Fixes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)