### PR TITLE
fix(PAIUpgrade): correct SKILL_DIR path from 'Upgrade' to 'PAIUpgrade'

### DIFF
--- a/Releases/v2.3/.claude/skills/PAIUpgrade/Tools/Anthropic.ts
+++ b/Releases/v2.3/.claude/skills/PAIUpgrade/Tools/Anthropic.ts
@@ -79,7 +79,7 @@ interface State {
 
 // Config
 const HOME = homedir();
-const SKILL_DIR = join(HOME, '.claude', 'skills', 'Upgrade');
+const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
 const STATE_DIR = join(SKILL_DIR, 'State');
 const STATE_FILE = join(STATE_DIR, 'last-check.json');
 const SOURCES_FILE = join(SKILL_DIR, 'sources.json');


### PR DESCRIPTION
## Summary
Fixes a path bug in the PAIUpgrade skill's Anthropic.ts tool that prevents it from running.

Fixes #468

## Problem
The `SKILL_DIR` constant was pointing to `.claude/skills/Upgrade` instead of `.claude/skills/PAIUpgrade`, causing ENOENT errors when the tool tried to:
- Load `sources.json`
- Save state to `last-check.json`

## Error Output
```
❌ Failed to load sources.json: ENOENT: no such file or directory, 
open '/home/user/.claude/skills/Upgrade/sources.json'
```

## Solution
Updated line 82 in `Releases/v2.3/.claude/skills/PAIUpgrade/Tools/Anthropic.ts`:
```typescript
// Before
const SKILL_DIR = join(HOME, '.claude', 'skills', 'Upgrade');

// After  
const SKILL_DIR = join(HOME, '.claude', 'skills', 'PAIUpgrade');
```

## Testing
After this fix:
- Tool successfully loads sources.json
- Successfully monitors 30+ Anthropic sources
- Generates comprehensive upgrade reports
- Creates State directory and saves state files

## Impact
- **Files changed**: 1
- **Lines changed**: 1  
- **Breaking changes**: None
- **Backward compatibility**: Full

This is a critical bug fix for anyone trying to use the PAIUpgrade skill to monitor Anthropic ecosystem updates.