### PR TITLE
feat(VoiceServer): Add FIFO message queue to prevent overlapping audio

### DIFF
--- a/Releases/v2.4/.claude/VoiceServer/server.ts
+++ b/Releases/v2.4/.claude/VoiceServer/server.ts
@@ -512,6 +512,22 @@ function enqueueMessage(
 const requestCounts = new Map<string, { count: number; resetTime: number }>();
 const RATE_LIMIT = 10;
 const RATE_WINDOW = 60000;
+const RATE_CLEANUP_INTERVAL = 5 * 60 * 1000;
+
+// Periodic cleanup of stale rate limit entries to prevent memory leak
+setInterval(() => {
+  const now = Date.now();
+  let cleaned = 0;
+  for (const [ip, record] of requestCounts) {
+    if (now > record.resetTime) {
+      requestCounts.delete(ip);
+      cleaned++;
+    }
+  }
+  if (cleaned > 0) {
+    console.log(`🧹 Rate limit cleanup: removed ${cleaned} stale entries`);
+  }
+}, RATE_CLEANUP_INTERVAL);
 
 function checkRateLimit(ip: string): boolean {
   const now = Date.now();


### PR DESCRIPTION
## Problem

When launching multiple subagents simultaneously (a common pattern in PAI workflows), each agent sends a voice notification as it starts. Since these notifications arrive at the VoiceServer nearly simultaneously, multiple `afplay` processes spawn concurrently, resulting in garbled, overlapping audio output.

## Solution

This PR adds a server-side FIFO message queue that serializes voice playback:

1. **Sequence numbers** captured before any async operations guarantee arrival order
2. **Single-threaded processing** ensures only one message plays at a time
3. **Insertion sort** maintains order when messages arrive during playback
4. **Queue overflow protection** (max 100 messages) prevents memory exhaustion
5. **`try/finally` guard** ensures processing flag resets even on errors

## Changes

- Added `QueuedMessage` interface and queue state management
- Added `drainQueueInOrder()` and `processQueue()` functions
- Updated `/notify` and `/pai` endpoints to enqueue instead of play directly
- API response now includes `queue_position` and `queue_depth`
- `/health` endpoint shows queue status

## Testing

Tested with concurrent curl requests - messages now play sequentially in arrival order.

---

Thank you for PAI - it's been incredibly useful. Happy to adjust anything based on your feedback.