### PR TITLE
Fix Linux compatibility: Replace hardcoded macOS paths in Observability

### DIFF
--- a/Packs/pai-observability-server/src/Observability/apps/server/src/file-ingest.ts
+++ b/Packs/pai-observability-server/src/Observability/apps/server/src/file-ingest.ts
@@ -33,8 +33,9 @@ const agentSessions = new Map<string, string>();
 // Todo tracking per session (session_id -> current todos)
 const sessionTodos = new Map<string, any[]>();
 
-// Projects directory path - dynamically constructed from username
-const PROJECTS_DIR = join(homedir(), '.claude', 'projects', `-Users-${process.env.USER || 'user'}--claude`);
+// Projects directory path - dynamically constructed from HOME path (works on both macOS and Linux)
+const homePathEncoded = (process.env.HOME || homedir()).replace(/\//g, '-');
+const PROJECTS_DIR = join(homedir(), '.claude', 'projects', `${homePathEncoded}--claude`);
 
 /**
  * Get the most recently modified JSONL files in projects/

--- a/Packs/pai-observability-server/src/Observability/apps/server/src/task-watcher.ts
+++ b/Packs/pai-observability-server/src/Observability/apps/server/src/task-watcher.ts
@@ -39,8 +39,9 @@ const pendingDescriptions = new Set<string>();
 // Callback for task updates
 let onTaskUpdate: ((task: BackgroundTask) => void) | null = null;
 
-// Tasks directory - dynamically constructed from username
-const TASKS_DIR = `/tmp/claude/-Users-${process.env.USER || 'user'}--claude/tasks`;
+// Tasks directory - dynamically constructed from HOME path (works on both macOS and Linux)
+const homePathEncoded = (process.env.HOME || homedir()).replace(/\//g, '-');
+const TASKS_DIR = `/tmp/claude/${homePathEncoded}--claude/tasks`;
 
 // Idle threshold for determining completion (30 seconds)
 const IDLE_THRESHOLD_MS = 30000;


### PR DESCRIPTION
## Problem

PAI v2.4's Observability dashboard fails on Linux systems due to hardcoded macOS path encoding.

Both `task-watcher.ts` and `file-ingest.ts` use `-Users-` prefix which only works for macOS paths like `/Users/username`. Linux systems use `/home/username`, causing the dashboard to show empty even when agents are running.

## Solution

Replace hardcoded path construction with dynamic HOME environment variable encoding:

```typescript
// Before (macOS only)
const TASKS_DIR = \`/tmp/claude/-Users-\${process.env.USER}--claude/tasks\`;

// After (cross-platform)
const homePathEncoded = (process.env.HOME || homedir()).replace(/\//g, '-');
const TASKS_DIR = \`/tmp/claude/\${homePathEncoded}--claude/tasks\`;
```

## Impact

- **Remote tab**: Now displays background task timeline on Linux
- **Local tab**: Now displays PAI hook events on Linux  
- **Backward compatible**: macOS paths unchanged

## Testing

Tested on:
- ✅ Ubuntu 24.04 (Linux 6.14.0-37-generic)
- ✅ Confirmed both dashboard tabs functional

## Files Changed

- \`Packs/pai-observability-server/src/Observability/apps/server/src/task-watcher.ts\`
- \`Packs/pai-observability-server/src/Observability/apps/server/src/file-ingest.ts\`