### PR TITLE
fix(observability): auto-install dependencies on first run

### DIFF
--- a/Packs/pai-observability-server/src/Observability/manage.sh
+++ b/Packs/pai-observability-server/src/Observability/manage.sh
@@ -7,6 +7,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Ensure bun is in PATH (for apps launched from macOS)
 export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
+# Auto-install dependencies if missing (check for specific binaries, not just dirs)
+install_deps_if_needed() {
+    # Server needs typescript
+    if [ ! -f "$SCRIPT_DIR/apps/server/node_modules/.bin/tsc" ]; then
+        echo "📦 Installing server dependencies..."
+        (cd "$SCRIPT_DIR/apps/server" && bun install)
+    fi
+    # Client needs vite
+    if [ ! -f "$SCRIPT_DIR/apps/client/node_modules/.bin/vite" ]; then
+        echo "📦 Installing client dependencies..."
+        (cd "$SCRIPT_DIR/apps/client" && bun install)
+    fi
+}
+
 case "${1:-}" in
     start)
         # Check if already running
@@ -14,6 +28,9 @@ case "${1:-}" in
             echo "❌ Already running. Use: manage.sh restart"
             exit 1
         fi
+
+        # Install dependencies if needed
+        install_deps_if_needed
 
         # Start server (silent)
         cd "$SCRIPT_DIR/apps/server"
@@ -91,6 +108,9 @@ case "${1:-}" in
             echo "❌ Already running. Use: manage.sh restart"
             exit 1
         fi
+
+        # Install dependencies if needed
+        install_deps_if_needed
 
         # Start server detached (for menu bar app use)
         cd "$SCRIPT_DIR/apps/server"


### PR DESCRIPTION
## Summary

- Adds `install_deps_if_needed()` function to `manage.sh`
- Automatically runs `bun install` when dependencies are missing
- Checks for specific binaries (tsc, vite) not just directory existence
- Works for both `start` and `start-detached` commands

## Problem

When running `manage.sh start` after a fresh clone/download, the server fails silently because dependencies aren't installed. The script outputs "✅ Observability running" but ports aren't actually bound.

## Solution

Check for required binaries before starting:
- Server needs `tsc` → checks `node_modules/.bin/tsc`
- Client needs `vite` → checks `node_modules/.bin/vite`

If missing, runs `bun install` automatically.

## Test plan

- [x] Fresh install: dependencies auto-installed
- [x] Existing install: no unnecessary reinstall
- [x] Corrupted node_modules (empty .bin): triggers reinstall

Fixes #548

🤖 Generated with [Claude Code](https://claude.ai/code)