### PR TITLE
fix: Replace hardcoded 'Daniel' user references with generic terms

### DIFF
--- a/Packs/pai-agents-skill/src/agents/Architect.md
+++ b/Packs/pai-agents-skill/src/agents/Architect.md
@@ -73,7 +73,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/Artist.md
+++ b/Packs/pai-agents-skill/src/agents/Artist.md
@@ -69,7 +69,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/ClaudeResearcher.md
+++ b/Packs/pai-agents-skill/src/agents/ClaudeResearcher.md
@@ -88,7 +88,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/CodexResearcher.md
+++ b/Packs/pai-agents-skill/src/agents/CodexResearcher.md
@@ -75,7 +75,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/Designer.md
+++ b/Packs/pai-agents-skill/src/agents/Designer.md
@@ -70,7 +70,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/Engineer.md
+++ b/Packs/pai-agents-skill/src/agents/Engineer.md
@@ -71,7 +71,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 
@@ -181,7 +181,7 @@ curl -X POST http://localhost:8888/notify \
 1. VERIFY dev server is running
 2. CONFIRM server responds
 3. VISUALLY VERIFY page loads correctly
-4. ONLY THEN tell Daniel it's ready
+4. ONLY THEN tell the user it's ready
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/GeminiResearcher.md
+++ b/Packs/pai-agents-skill/src/agents/GeminiResearcher.md
@@ -88,7 +88,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/GrokResearcher.md
+++ b/Packs/pai-agents-skill/src/agents/GrokResearcher.md
@@ -74,7 +74,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Packs/pai-agents-skill/src/agents/Intern.md
+++ b/Packs/pai-agents-skill/src/agents/Intern.md
@@ -91,7 +91,7 @@ curl -X POST http://localhost:8888/notify \
 - Your voice_id is: `d3MFdIuCfbAIwiu7jC4a` (Intern voice)
 - The message should be your COMPLETED line content
 - Send this BEFORE writing your response
-- DO NOT SKIP THIS - Daniel needs to HEAR you speak
+- DO NOT SKIP THIS - the user needs to HEAR you speak
 
 ## 🚨🚨🚨 MANDATORY OUTPUT REQUIREMENTS - NEVER SKIP 🚨🚨🚨
 

--- a/Packs/pai-agents-skill/src/agents/Pentester.md
+++ b/Packs/pai-agents-skill/src/agents/Pentester.md
@@ -90,7 +90,7 @@ curl -X POST http://localhost:8888/notify \
 - Your voice_id is: `xvHLFjaUEpx4BOf7EiDd` (Tybon's voice)
 - The message should be your COMPLETED line content
 - Send this BEFORE writing your response
-- DO NOT SKIP THIS - Daniel needs to HEAR you speak
+- DO NOT SKIP THIS - the user needs to HEAR you speak
 
 ### Final Output Format (MANDATORY - USE FOR EVERY SINGLE RESPONSE)
 ALWAYS use this standardized output format with emojis and structured sections:

--- a/Packs/pai-agents-skill/src/agents/QATester.md
+++ b/Packs/pai-agents-skill/src/agents/QATester.md
@@ -69,7 +69,7 @@ curl -X POST http://localhost:8888/notify \
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response
-- DO NOT SKIP - Daniel needs to hear you speak
+- DO NOT SKIP - the user needs to hear you speak
 
 ---
 

--- a/Releases/v2.5/.claude/hooks/RelationshipMemory.hook.ts
+++ b/Releases/v2.5/.claude/hooks/RelationshipMemory.hook.ts
@@ -15,10 +15,10 @@
  *
  * OUTPUT:
  * - Writes to: MEMORY/RELATIONSHIP/YYYY-MM/YYYY-MM-DD.md
- * - May update: skills/PAI/USER/ABOUT_DANIEL.md (significant learnings)
+ * - May update: skills/PAI/USER/ABOUT_PRINCIPAL.md (significant learnings)
  *
  * RELATIONSHIP NOTE TYPES:
- * - W (World): Objective facts about Daniel's situation
+ * - W (World): Objective facts about the principal's situation
  * - B (Biographical): What happened this session (first-person DA)
  * - O (Opinion): Preference/belief with confidence
  *
@@ -130,7 +130,7 @@ function analyzeForRelationship(entries: TranscriptEntry[]): RelationshipNote[] 
 
   // Track what happened this session
   let sessionSummary: string[] = [];
-  let danielPreferences: string[] = [];
+  let principalPreferences: string[] = [];
   let frustrations: string[] = [];
   let positives: string[] = [];
 
@@ -143,7 +143,7 @@ function analyzeForRelationship(entries: TranscriptEntry[]): RelationshipNote[] 
       if (patterns.preference.test(text)) {
         // Extract preference (simplified - would benefit from LLM analysis)
         const snippet = text.slice(0, 200);
-        danielPreferences.push(snippet);
+        principalPreferences.push(snippet);
       }
 
       if (patterns.frustration.test(text)) {

--- a/Releases/v2.5/.claude/skills/PAI/Tools/RelationshipReflect.ts
+++ b/Releases/v2.5/.claude/skills/PAI/Tools/RelationshipReflect.ts
@@ -15,7 +15,7 @@
  * ACTIONS:
  * 1. Scan MEMORY/RELATIONSHIP/ for recent notes
  * 2. Update OPINIONS.md confidence scores based on evidence
- * 3. Update ABOUT_DANIEL.md patterns and preferences
+ * 3. Update ABOUT_PRINCIPAL.md patterns and preferences
  * 4. Check for milestone achievements → OUR_STORY.md
  * 5. Queue soul updates if significant patterns emerge
  *


### PR DESCRIPTION
## Summary

- Replaces hardcoded "Daniel" user identity references with generic "the user" terminology
- Renames `danielPreferences` variable to `principalPreferences`
- Updates file references from `ABOUT_DANIEL.md` to `ABOUT_PRINCIPAL.md`

This allows PAI to work correctly for all users regardless of their configured `principal.name` in settings.json.

## Changes

**Agent Files (11 files in `Packs/pai-agents-skill/src/agents/`):**
- Changed "Daniel needs to hear you speak" → "the user needs to hear you speak"
- Changed "tell Daniel it's ready" → "tell the user it's ready" (Engineer.md)

**Hook Files:**
- `RelationshipMemory.hook.ts`: Renamed variable and updated docs
- `RelationshipReflect.ts`: Updated file reference

## What's NOT Changed

- Author attribution ("Author: Daniel Miessler") - correct as-is
- Voice name references ("Daniel" ElevenLabs voice) - correct as-is
- Repository URLs (danielmiessler/PAI) - correct as-is

## Test plan

- [ ] Verify agent voice notifications work with custom principal.name
- [ ] Verify RelationshipMemory hook runs without errors
- [ ] Verify no remaining hardcoded user identity references

Fixes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)