### PR TITLE
fix: Move YAML frontmatter before HTML comment in PAI skill

### DIFF
--- a/Releases/v2.5/.claude/skills/PAI/Components/00-frontmatter.md
+++ b/Releases/v2.5/.claude/skills/PAI/Components/00-frontmatter.md
@@ -1,9 +1,9 @@
+---
+name: PAI
+description: Personal AI Infrastructure core. The authoritative reference for how PAI works.
+---
 <!--
   🔨 GENERATED FILE - Do not edit directly
   Edit:   ~/.claude/skills/PAI/Components/
   Build:  bun ~/.claude/skills/PAI/Tools/CreateDynamicCore.ts
 -->
----
-name: CORE
-description: Personal AI Infrastructure core. The authoritative reference for how PAI works.
----

--- a/Releases/v2.5/.claude/skills/PAI/SKILL.md
+++ b/Releases/v2.5/.claude/skills/PAI/SKILL.md
@@ -1,13 +1,13 @@
+---
+name: PAI
+description: Personal AI Infrastructure core. The authoritative reference for how PAI works.
+---
 <!--
   🔨 GENERATED FILE - Do not edit directly
   Edit:   ~/.claude/skills/PAI/Components/
   Build:  bun ~/.claude/skills/PAI/Tools/CreateDynamicCore.ts
   Built:  29 January 2026 19:52:53
 -->
----
-name: CORE
-description: Personal AI Infrastructure core. The authoritative reference for how PAI works.
----
 
 # Intro to PAI
 


### PR DESCRIPTION
## Summary

- **Moves YAML frontmatter before the HTML build comment** in `00-frontmatter.md` — the `parseFrontmatter()` regex in `GenerateSkillIndex.ts` uses `^---` which requires frontmatter at the very start of the file
- **Renames `name: CORE` to `name: PAI`** to match the `ALWAYS_LOADED_SKILLS` array in `GenerateSkillIndex.ts`
- Applies the same fix to the pre-built `SKILL.md`

## Problem

`CreateDynamicCore.ts` assembles `SKILL.md` from numbered components in `Components/`. The first component (`00-frontmatter.md`) places an HTML comment *before* the YAML `---` delimiter:

```markdown
<!--
  🔨 GENERATED FILE - Do not edit directly
  ...
-->
---
name: CORE
description: ...
---
```

`GenerateSkillIndex.ts` line 80 uses:
```typescript
const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
```

The `^` anchor means this regex **only matches if `---` is the first content in the file**. The HTML comment breaks this, causing PAI/SKILL.md to be silently skipped during index generation.

Additionally, `name: CORE` doesn't match `ALWAYS_LOADED_SKILLS: ['PAI', ...]` (line 38-44), so even if parsed, the skill wouldn't be recognized as always-loaded.

## Fix

Reorder so frontmatter comes first, HTML comment second. Rename `CORE` → `PAI`. The `CreateDynamicCore.ts` timestamp injection (lines 104-108) works regardless of comment position.

## Test plan

- [ ] Run `bun ~/.claude/skills/PAI/Tools/GenerateSkillIndex.ts` — PAI/SKILL.md should now appear in `skill-index.json`
- [ ] Run `bun ~/.claude/skills/PAI/Tools/CreateDynamicCore.ts` — verify the rebuilt SKILL.md has frontmatter first
- [ ] Confirm `skill-index.json` lists PAI with correct `name: PAI` and `alwaysLoaded: true`

Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)