### PR TITLE
fix: Use proper file permissions in INSTALL.ts for Linux/WSL

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -103,7 +103,7 @@ async function promptChoice(question: string, choices: string[], defaultIdx = 0)
 }
 
 // ============================================================================
-// PERMISSIONS (chmod → chown → chmod)
+// PERMISSIONS (chown → chmod dirs → chmod files → chmod scripts)
 // ============================================================================
 
 function fixPermissions(targetDir: string): void {
@@ -114,25 +114,25 @@ function fixPermissions(targetDir: string): void {
   print(`${c.gray}─────────────────────────────────────────────────${c.reset}`);
 
   try {
-    // Step 1: chmod first - make files accessible
-    execSync(`chmod -R 755 "${targetDir}"`, { stdio: 'pipe' });
-    printSuccess('Step 1: chmod -R 755 (make accessible)');
-
-    // Step 2: chown - change ownership to current user
+    // Step 1: chown - change ownership to current user
     execSync(`chown -R ${info.uid}:${info.gid} "${targetDir}"`, { stdio: 'pipe' });
-    printSuccess(`Step 2: chown -R to ${info.username}`);
+    printSuccess(`Ownership set to ${info.username} (${info.uid}:${info.gid})`);
 
-    // Step 3: chmod again - set final permissions
-    execSync(`chmod -R 755 "${targetDir}"`, { stdio: 'pipe' });
-    printSuccess('Step 3: chmod -R 755 (final permissions)');
+    // Step 2: directories get rwxr-x--- (750)
+    execSync(`find "${targetDir}" -type d -exec chmod 750 {} +`, { stdio: 'pipe' });
+    printSuccess('Directories set to 750 (rwxr-x---)');
 
-    // Make scripts executable
-    for (const pattern of ['*.ts', '*.sh', '*.hook.ts']) {
+    // Step 3: regular files get rw-r----- (640)
+    execSync(`find "${targetDir}" -type f -exec chmod 640 {} +`, { stdio: 'pipe' });
+    printSuccess('Files set to 640 (rw-r-----)');
+
+    // Step 4: scripts get rwxr-x--- (750)
+    for (const pattern of ['*.ts', '*.sh', '*.py']) {
       try {
-        execSync(`find "${targetDir}" -name "${pattern}" -exec chmod 755 {} \\;`, { stdio: 'pipe' });
+        execSync(`find "${targetDir}" -type f -name "${pattern}" -exec chmod 750 {} +`, { stdio: 'pipe' });
       } catch (e) { /* ignore */ }
     }
-    printSuccess('Set executable permissions on scripts');
+    printSuccess('Scripts (.ts, .sh, .py) set to 750 (rwxr-x---)');
 
   } catch (err: any) {
     printError(`Permission fix failed: ${err.message}`);


### PR DESCRIPTION
## Summary

- Replaces `chmod -R 755` (makes ALL files executable) with granular Linux permissions
- Directories: `750` (rwxr-x---), files: `640` (rw-r-----), scripts: `750` (rwxr-x---)
- Uses `find -exec ... +` instead of `\;` for better performance

## Problem

`fixPermissions()` in INSTALL.ts runs `chmod -R 755` on the entire `~/.claude` directory, making every file executable — including JSON configs, markdown files, and YAML. On Linux/WSL, only directories and scripts should have the execute bit. This is both a security issue (unnecessary execute permissions) and breaks expectations for standard Linux file permissions.

The function also runs `chmod -R 755` three times (steps 1, 3, and the script step), which is redundant.

## Fix

Replace the three-step chmod/chown/chmod approach with:

1. `chown -R` — set ownership first
2. `find -type d -exec chmod 750` — directories only
3. `find -type f -exec chmod 640` — regular files (no execute)
4. `find -type f -name "*.ts|*.sh|*.py" -exec chmod 750` — scripts only

## Test plan

- [ ] Run INSTALL.ts on Linux/WSL
- [ ] Verify `.ts` and `.sh` files have execute permission (750)
- [ ] Verify `.json`, `.md`, `.yaml` files do NOT have execute permission (640)
- [ ] Verify directories have 750

Fixes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)