### PR TITLE
fix: Update INSTALL.ts version strings from 2.4 to 2.5

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -295,7 +295,7 @@ function generateSettingsJson(config: InstallConfig): object {
 
   return {
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
-    "paiVersion": "2.4",
+    "paiVersion": "2.5",
     "env": {
       "PAI_DIR": `${HOME}/.claude`,
       "PROJECTS_DIR": config.PROJECTS_DIR || "",
@@ -330,7 +330,7 @@ function generateSettingsJson(config: InstallConfig): object {
     },
     "pai": {
       "repoUrl": "github.com/danielmiessler/PAI",
-      "version": "2.4"
+      "version": "2.5"
     },
     "techStack": {
       "browser": "arc",


### PR DESCRIPTION
## Summary
- Fixes hardcoded "2.4" version strings in `Releases/v2.5/.claude/INSTALL.ts`
- Fresh installs now correctly report PAI v2.5 in `settings.json` and statusline

## Changes
| Line | Before | After |
|------|--------|-------|
| 298 | `"paiVersion": "2.4"` | `"paiVersion": "2.5"` |
| 333 | `"version": "2.4"` | `"version": "2.5"` |

## Test plan
- [x] Applied fix to `INSTALL.ts`
- [x] Verified `settings.json` output shows "2.5" for both fields
- [x] Confirmed statusline displays correct version

Fixes #546