### PR TITLE
Add TASK Line Rule to Algorithm v0.2.25

### DIFF
--- a/Releases/v2.5/.claude/skills/PAI/Components/Algorithm/v0.2.25.md
+++ b/Releases/v2.5/.claude/skills/PAI/Components/Algorithm/v0.2.25.md
@@ -116,6 +116,28 @@ Each phase transition triggers a voice announcement via the voice server. Execut
 
 ---
 
+## TASK Line Rule
+
+The TASK line captures what the user is asking you **TO DO**, not what will eventually exist. **TASK captures the MODE, not the OUTPUT.**
+
+**The distinction:**
+
+- **MODE** = how the user wants to work (collaborate, plan, research, execute)
+- **OUTPUT** = what will eventually exist (article, code, fix)
+
+**Parse the first imperative clause literally:**
+
+| User Says | TASK Should Be |
+|-----------|----------------|
+| "Let's collaborate on X" | Collaborate on X |
+| "Help me think through W" | Think through W |
+| "Fix the bug in Z" | Fix bug in Z |
+| "Write an article about Y" | Write article about Y |
+
+**Common failure:** User says "Let's collaborate on an article about X" and TASK becomes "Write article about X" — this is WRONG. The task is "Collaborate on article about X."
+
+---
+
 ## ISC Criteria Requirements
 
 | Requirement | Example |
@@ -358,6 +380,7 @@ Complex tasks may warrant recursive Algorithm execution where subtasks run their
 | **Accepting hook hints as final** | Hook sees raw prompt only. OBSERVE adds context that changes the picture. |
 | **Asking questions as plain text instead of AskUserQuestion** | All questions to the user MUST use the AskUserQuestion tool. Never ask via inline text. The tool provides structured options, tracks answers, and respects the interaction contract. |
 | **Running independent tasks sequentially** | This wastes time. If tasks don't depend on each other, launch them as parallel agents. Fan-out is the default for 3+ independent workstreams. |
+| **TASK captures output instead of mode** | "Let's collaborate on X" → TASK should be "Collaborate on X", not "Write X". Parse the first imperative clause. MODE over OUTPUT. |
 
 ---
 
@@ -402,6 +425,10 @@ The Algorithm exists because:
 ---
 
 ## Changelog
+
+### v0.2.25.1 (2026-02-06)
+
+- **TASK Line Rule** — Added explicit parsing guidance for TASK line. TASK captures MODE (what user wants to DO), not OUTPUT (what will exist). Parse the first imperative clause literally. "Let's collaborate on X" → "Collaborate on X", not "Write X". Added to Common Failures: TASK captures output instead of mode.
 
 ### v0.2.25 (2026-01-30)
 - **Parallel-by-Default Execution** — Independent tasks MUST run concurrently via parallel agent spawning. Serial execution is only for tasks with data dependencies. Fan-out is the default pattern for 3+ independent workstreams. Added to Common Failures: sequential execution of independent tasks.


### PR DESCRIPTION
## Summary

Adds explicit parsing guidance for the TASK line to address a consistent failure mode where the model confuses MODE (what the user wants to do) with OUTPUT (what will eventually exist).

**The problem:** When a user says "Let's collaborate on an article about X", the TASK line was being generated as "Write article about X" — skipping the "collaborate" instruction entirely. This was reproducible across multiple sessions.

**The fix:**
- Added "TASK Line Rule" section with parsing guidance
- Key principle: parse the first imperative clause literally
- Added examples table showing correct parsing
- Added to Common Failures: "TASK captures output instead of mode"
- Updated changelog with v0.2.25.1

## Test Plan

- [x] Tested across multiple chat sessions with the same prompt
- [x] Verified the explicit parsing rule prevents the failure

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)