### PR TITLE
fix: INSTALL.ts v2.5 hardcodes version 2.4

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -295,7 +295,7 @@ function generateSettingsJson(config: InstallConfig): object {
 
   return {
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
-    "paiVersion": "2.4",
+    "paiVersion": "2.5",
     "env": {
       "PAI_DIR": `${HOME}/.claude`,
       "PROJECTS_DIR": config.PROJECTS_DIR || "",
@@ -330,7 +330,7 @@ function generateSettingsJson(config: InstallConfig): object {
     },
     "pai": {
       "repoUrl": "github.com/danielmiessler/PAI",
-      "version": "2.4"
+      "version": "2.5"
     },
     "techStack": {
       "browser": "arc",


### PR DESCRIPTION
INSTALL.ts in the v2.5 release hardcodes version "2.4" at lines 298 and 333, causing new installations to report v2.4 instead of v2.5.

This is a straightforward two-line fix changing the version strings to "2.5".

Fixes #612