### PR TITLE
fix: Add missing yaml dependency for hooks

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -569,6 +569,18 @@ async function main(): Promise<void> {
   }
   printSuccess('Created MEMORY directories');
 
+  // Install dependencies (yaml is needed by hooks like SecurityValidator)
+  print('');
+  print(`${c.bold}Installing Dependencies${c.reset}`);
+  print(`${c.gray}─────────────────────────────────────────────────${c.reset}`);
+  try {
+    execSync('bun install', { cwd: CLAUDE_DIR, stdio: 'pipe' });
+    printSuccess('Dependencies installed');
+  } catch (err: any) {
+    printWarning(`Could not install dependencies: ${err.message}`);
+    printInfo('Run "cd ~/.claude && bun install" manually');
+  }
+
   // Start voice server (only if API key was provided)
   print('');
   print(`${c.bold}Voice Server${c.reset}`);

--- a/Releases/v2.5/.claude/package.json
+++ b/Releases/v2.5/.claude/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pai",
+  "private": true,
+  "description": "PAI - Personal AI Infrastructure",
+  "dependencies": {
+    "yaml": "^2.8.0"
+  }
+}


### PR DESCRIPTION
## Summary

- `SecurityValidator.hook.ts` imports `from 'yaml'`, but there is no root `package.json` in `~/.claude/`
- The `yaml` package only exists in subdirectory `package.json` files (`skills/Agents/Tools/`, `skills/Prompting/Templates/Tools/`)
- Fresh installs will fail with `Cannot find package 'yaml'` when SecurityValidator triggers
- Adds a root `package.json` with the `yaml` dependency and a `bun install` step to `INSTALL.ts`

## Affected files

Files that import from `yaml` at the root resolution scope:
- `hooks/SecurityValidator.hook.ts` (line 66)
- `skills/PAI/Tools/LoadSkillConfig.ts` (line 20)
- `skills/Evals/Tools/SuiteManager.ts` (line 10)
- `skills/Evals/Tools/AlgorithmBridge.ts` (line 13)
- `skills/Evals/Tools/FailureToTask.ts` (line 11)

## Reproduction

1. Fresh clone and install of PAI v2.5
2. Launch a session with default hooks enabled
3. Trigger any tool use (Bash, Edit, Write, Read) to fire SecurityValidator
4. Hook fails with: `Cannot find package 'yaml'`

## Fix

1. Added `Releases/v2.5/.claude/package.json` with `yaml` dependency
2. Added `bun install` step to `INSTALL.ts` after directory creation

## Test plan

- [ ] Fresh install completes without errors
- [ ] SecurityValidator hook fires successfully on tool use
- [ ] LoadSkillConfig.ts can parse YAML frontmatter
- [ ] No regressions in existing hook behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)