### PR TITLE
fix: Allow pai --resume to accept optional session ID

### DIFF
--- a/Releases/v2.5/.claude/skills/PAI/Tools/pai.ts
+++ b/Releases/v2.5/.claude/skills/PAI/Tools/pai.ts
@@ -390,7 +390,7 @@ function cmdWallpaper(args: string[]) {
 // Commands
 // ============================================================================
 
-async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: boolean; local?: boolean }) {
+async function cmdLaunch(options: { mcp?: string; resume?: boolean | string; skipPerms?: boolean; local?: boolean }) {
   displayBanner();
   const args = ["claude"];
 
@@ -406,6 +406,9 @@ async function cmdLaunch(options: { mcp?: string; resume?: boolean; skipPerms?: 
   // Use --dangerous flag explicitly if you really need to skip all permission checks.
   if (options.resume) {
     args.push("--resume");
+    if (typeof options.resume === "string") {
+      args.push(options.resume);
+    }
   }
 
   // Change to PAI directory unless --local flag is set
@@ -624,7 +627,7 @@ async function main() {
 
   // Parse arguments
   let mcp: string | undefined;
-  let resume = false;
+  let resume: boolean | string = false;
   let skipPerms = true;
   let local = false;
   let command: string | undefined;
@@ -649,9 +652,17 @@ async function main() {
         }
         break;
       case "-r":
-      case "--resume":
-        resume = true;
+      case "--resume": {
+        const COMMANDS = new Set(["update", "version", "help", "profiles", "mcp", "prompt"]);
+        const nextResume = args[i + 1];
+        if (nextResume && !nextResume.startsWith("-") && !COMMANDS.has(nextResume)) {
+          resume = nextResume;
+          i++;
+        } else {
+          resume = true;
+        }
         break;
+      }
       case "--safe":
         skipPerms = false;
         break;


### PR DESCRIPTION
## Summary

- Claude Code's `--resume` flag supports an optional session ID: `claude --resume <UUID>`
- `pai.ts` typed `resume` as `boolean`, so it only passed the bare `--resume` flag
- Users couldn't resume a specific session through `pai` and had to call `claude` directly
- Changes the type to `boolean | string`, captures the optional next argument, and passes it through

## Reproduction

1. Run `pai --resume abc123` (or any session ID)
2. Observe that the session ID is silently discarded
3. Claude launches the session picker instead of resuming the specific session

## Fix

- Changed `resume` variable type from `boolean` to `boolean | string`
- Updated argument parsing to capture optional session ID after `--resume`/`-r`
- Pass session ID through to `claude --resume <id>` when provided

## Usage after fix

```bash
pai --resume              # Resume last session (existing behavior)
pai --resume abc123       # Resume specific session by ID (new)
pai -r abc123             # Short form (new)
```

## Test plan

- [ ] `pai --resume` still opens session picker (backward compatible)
- [ ] `pai --resume <valid-id>` resumes the specific session
- [ ] `pai -r <valid-id>` works the same way
- [ ] `pai --resume --local` doesn't capture `--local` as a session ID (starts with `-`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)