### PR TITLE
feat(tools): add Codex CLI bridge for PAI hook integration

### DIFF
--- a/Tools/codex-bridge/README.md
+++ b/Tools/codex-bridge/README.md
@@ -1,0 +1,99 @@
+# Codex PAI Bridge
+
+Lightweight bridge that watches [OpenAI Codex CLI](https://github.com/openai/codex) session logs and triggers PAI hooks, bringing PAI's memory, observability, and automation to Codex sessions.
+
+## What It Does
+
+The bridge polls `~/.codex/sessions/` for JSONL log files, extracts user/assistant messages, and fires the same PAI hook lifecycle that Claude Code uses:
+
+1. **SessionStart** — triggers `StartupGreeting.hook.ts`
+2. **UserPromptSubmit** — triggers `AutoWorkCreation.hook.ts` (work tracking, memory)
+3. **Stop** — triggers `StopOrchestrator.hook.ts` (session summaries, learning)
+4. **Statusline** — feeds session data to `statusline-command.sh`
+
+This means Codex sessions get the same PAI benefits as Claude Code sessions: automatic work tracking, session transcripts, hook-driven automation, and statusline updates.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) runtime installed
+- [Codex CLI](https://github.com/openai/codex) installed with sessions at `~/.codex/sessions/`
+- PAI installed (hooks available at `$PAI_DIR/hooks/`)
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAI_DIR` | `~/.claude` | Root of your PAI installation |
+| `CODEX_HOME` | `~/.codex` | Root of your Codex CLI data |
+| `BUN_PATH` | auto-detected | Path to bun binary |
+
+## Usage
+
+### Watch live sessions (default)
+
+```bash
+bun Tools/codex-bridge/bridge.ts --watch
+```
+
+The bridge polls every second for new session data and processes it incrementally.
+
+### Single scan
+
+```bash
+bun Tools/codex-bridge/bridge.ts --watch --once --dry-run
+```
+
+### Test with fixture data
+
+```bash
+bun Tools/codex-bridge/bridge.ts --dry-run --test-fixture Tools/codex-bridge/fixtures/sample.jsonl
+```
+
+## Install as macOS LaunchAgent
+
+Run the installer to set up a persistent background service:
+
+```bash
+bash Tools/codex-bridge/install.sh
+```
+
+This creates a LaunchAgent at `~/Library/LaunchAgents/com.example.codex-pai-bridge.plist` that starts on login and restarts automatically.
+
+### Verify installation
+
+```bash
+bash Tools/codex-bridge/install.sh --check
+```
+
+### Uninstall
+
+```bash
+bash Tools/codex-bridge/uninstall.sh
+```
+
+## Tests
+
+```bash
+bash Tools/codex-bridge/tests/statusline-dry-run.test.sh
+bash Tools/codex-bridge/tests/watch-once.test.sh
+bash Tools/codex-bridge/tests/hook-bun-path.test.sh
+```
+
+## Self-check
+
+Verify Codex home directory exists:
+
+```bash
+bash Tools/codex-bridge/self-check.sh
+```
+
+## Architecture
+
+```
+~/.codex/sessions/**/*.jsonl  ──poll──▶  bridge.ts  ──fire──▶  PAI hooks
+                                              │
+                                              ├──▶  transcripts/*.jsonl
+                                              └──▶  statusline-command.sh
+```
+
+The bridge converts Codex's JSONL log format into PAI's hook input format, allowing a single PAI installation to serve both Claude Code and Codex CLI.

--- a/Tools/codex-bridge/bridge.ts
+++ b/Tools/codex-bridge/bridge.ts
@@ -1,0 +1,382 @@
+#!/usr/bin/env bun
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'fs';
+import { spawn } from 'child_process';
+import { join } from 'path';
+import type { CodexLogLine, CodexMessage, SessionState } from './types';
+import { runSessionStart, runStop, runUserPrompt } from './hooks';
+
+const CODEX_HOME = process.env.CODEX_HOME || `${process.env.HOME}/.codex`;
+const PAI_DIR = process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+
+const sessionsDir = join(CODEX_HOME, 'sessions');
+const bridgeDir = join(PAI_DIR, 'bridge');
+const logsDir = join(bridgeDir, 'logs');
+const transcriptsDir = join(bridgeDir, 'transcripts');
+
+for (const dir of [bridgeDir, logsDir, transcriptsDir]) {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function contentToText(content: any): string {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) => (typeof c?.text === 'string' ? c.text : ''))
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+  }
+  if (typeof content.text === 'string') return content.text;
+  return '';
+}
+
+function extractMessage(line: CodexLogLine): CodexMessage | null {
+  if (line.type !== 'response_item') return null;
+  const payload = line.payload;
+  if (!payload || payload.type !== 'message') return null;
+  const role = payload.role;
+  if (role !== 'user' && role !== 'assistant') return null;
+  const text = contentToText(payload.content);
+  if (!text) return null;
+  return { role, text };
+}
+
+function appendTranscriptLine(transcriptPath: string, message: CodexMessage): void {
+  const entry = {
+    type: message.role,
+    message: {
+      content: [{ type: 'text', text: message.text }],
+    },
+  };
+  appendFileSync(transcriptPath, JSON.stringify(entry) + '\n');
+}
+
+function buildStatuslinePayload(cwd: string) {
+  return {
+    workspace: { current_dir: cwd },
+    model: { display_name: 'codex' },
+    version: 'unknown',
+    cost: { total_duration_ms: 0 },
+    context_window: {
+      current_usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      context_window_size: 200000,
+    },
+  };
+}
+
+async function runStatusline(paiDir: string, payload: unknown, dryRun: boolean): Promise<void> {
+  const statuslinePath = join(paiDir, 'statusline-command.sh');
+  if (dryRun) {
+    console.log(`STATUSLINE -> ${statuslinePath}`);
+    return;
+  }
+  if (!existsSync(statuslinePath)) {
+    console.error(`Statusline not found: ${statuslinePath}`);
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const child = spawn('bash', [statuslinePath], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      env: { ...process.env, PAI_DIR: paiDir },
+    });
+
+    child.on('error', (error) => {
+      console.error(`Statusline failed: ${error.message}`);
+      resolve();
+    });
+
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+
+    child.on('close', () => resolve());
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function listSessionFiles(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      const fullPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function extractSessionIdFromPath(filePath: string): string | null {
+  const match = filePath.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  return match ? match[0] : null;
+}
+
+function createSessionState(filePath: string, startOffset: number): SessionState {
+  const sessionId = extractSessionIdFromPath(filePath) || undefined;
+  return {
+    filePath,
+    sessionId,
+    transcriptPath: sessionId ? join(transcriptsDir, `${sessionId}.jsonl`) : undefined,
+    lastOffset: startOffset,
+    cwd: undefined,
+    buffer: '',
+    started: false,
+  };
+}
+
+async function ensureSessionStarted(state: SessionState, dryRun: boolean): Promise<boolean> {
+  if (state.started) return true;
+  if (!state.sessionId) return false;
+  if (!state.transcriptPath) {
+    state.transcriptPath = join(transcriptsDir, `${state.sessionId}.jsonl`);
+  }
+  if (!existsSync(state.transcriptPath)) {
+    writeFileSync(state.transcriptPath, '', 'utf-8');
+  }
+  await runSessionStart({ paiDir: PAI_DIR, dryRun });
+  state.started = true;
+  return true;
+}
+
+async function processLogLine(state: SessionState, line: CodexLogLine, dryRun: boolean): Promise<void> {
+  if (line.type === 'session_meta') {
+    const payload = line.payload || {};
+    if (payload.id) {
+      if (!state.started || !state.sessionId) {
+        state.sessionId = payload.id;
+        state.transcriptPath = join(transcriptsDir, `${payload.id}.jsonl`);
+      }
+    }
+    if (payload.cwd) {
+      state.cwd = payload.cwd;
+    }
+    await ensureSessionStarted(state, dryRun);
+    return;
+  }
+
+  const message = extractMessage(line);
+  if (!message) return;
+
+  if (!state.sessionId) {
+    state.sessionId = extractSessionIdFromPath(state.filePath) || undefined;
+  }
+
+  const started = await ensureSessionStarted(state, dryRun);
+  if (!started || !state.sessionId || !state.transcriptPath) {
+    return;
+  }
+
+  appendTranscriptLine(state.transcriptPath, message);
+
+  if (message.role === 'user') {
+    await runUserPrompt(
+      {
+        session_id: state.sessionId,
+        transcript_path: state.transcriptPath,
+        hook_event_name: 'UserPromptSubmit',
+        prompt: message.text,
+        user_prompt: message.text,
+      },
+      { paiDir: PAI_DIR, dryRun }
+    );
+  }
+
+  if (message.role === 'assistant') {
+    await runStop(
+      {
+        session_id: state.sessionId,
+        transcript_path: state.transcriptPath,
+        hook_event_name: 'Stop',
+      },
+      { paiDir: PAI_DIR, dryRun }
+    );
+    await runStatusline(PAI_DIR, buildStatuslinePayload(state.cwd ?? process.cwd()), dryRun);
+  }
+}
+
+async function processSessionFile(state: SessionState, dryRun: boolean): Promise<void> {
+  let stats;
+  try {
+    stats = statSync(state.filePath);
+  } catch {
+    return;
+  }
+
+  if (stats.size < state.lastOffset) {
+    state.lastOffset = 0;
+    state.buffer = '';
+  }
+
+  if (stats.size === state.lastOffset) return;
+
+  const buffer = readFileSync(state.filePath);
+  const chunk = buffer.subarray(state.lastOffset);
+  state.lastOffset = buffer.length;
+
+  if (chunk.length === 0) return;
+
+  const combined = state.buffer + chunk.toString('utf-8');
+  const lines = combined.split('\n');
+  if (!combined.endsWith('\n')) {
+    state.buffer = lines.pop() || '';
+  } else {
+    state.buffer = '';
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    try {
+      const parsed = JSON.parse(line) as CodexLogLine;
+      await processLogLine(state, parsed, dryRun);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      console.error(`Failed to parse ${state.filePath}: ${message}`);
+    }
+  }
+}
+
+async function watchSessions(dryRun: boolean, once: boolean): Promise<void> {
+  const stateByFile = new Map<string, SessionState>();
+
+  if (!once) {
+    const existingFiles = listSessionFiles(sessionsDir);
+    for (const filePath of existingFiles) {
+      let size = 0;
+      try {
+        size = statSync(filePath).size;
+      } catch {
+        size = 0;
+      }
+      stateByFile.set(filePath, createSessionState(filePath, size));
+    }
+  }
+
+  const scan = async () => {
+    const files = listSessionFiles(sessionsDir);
+    for (const filePath of files) {
+      let state = stateByFile.get(filePath);
+      if (!state) {
+        state = createSessionState(filePath, 0);
+        stateByFile.set(filePath, state);
+      }
+      await processSessionFile(state, dryRun);
+    }
+  };
+
+  if (once) {
+    await scan();
+    return;
+  }
+
+  while (true) {
+    await scan();
+    await sleep(1000);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const fixtureIndex = args.indexOf('--test-fixture');
+  const fixturePath = fixtureIndex >= 0 ? args[fixtureIndex + 1] : null;
+  const dryRun = args.includes('--dry-run');
+  const watch = args.includes('--watch') || args.includes('--once') || !fixturePath;
+  const once = args.includes('--once');
+
+  console.log('Codex bridge starting...');
+  console.log(`CODEX_HOME=${CODEX_HOME}`);
+  console.log(`PAI_DIR=${PAI_DIR}`);
+  console.log(`sessions=${sessionsDir}`);
+
+  if (fixturePath) {
+    const sessionId = 'test';
+    const transcriptPath = join(transcriptsDir, `${sessionId}.jsonl`);
+    writeFileSync(transcriptPath, '', 'utf-8');
+
+    await runSessionStart({ paiDir: PAI_DIR, dryRun });
+
+    const raw = readFileSync(fixturePath, 'utf-8');
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as CodexLogLine;
+      const message = extractMessage(parsed);
+      if (!message) continue;
+
+      appendTranscriptLine(transcriptPath, message);
+
+      if (message.role === 'user') {
+        await runUserPrompt(
+          {
+            session_id: sessionId,
+            transcript_path: transcriptPath,
+            hook_event_name: 'UserPromptSubmit',
+            prompt: message.text,
+            user_prompt: message.text,
+          },
+          { paiDir: PAI_DIR, dryRun }
+        );
+      }
+
+      if (message.role === 'assistant') {
+        await runStop(
+          {
+            session_id: sessionId,
+            transcript_path: transcriptPath,
+            hook_event_name: 'Stop',
+          },
+          { paiDir: PAI_DIR, dryRun }
+        );
+        await runStatusline(PAI_DIR, buildStatuslinePayload(process.cwd()), dryRun);
+      }
+    }
+
+    console.log(`Wrote transcript: ${transcriptPath}`);
+    return;
+  }
+
+  if (watch) {
+    await watchSessions(dryRun, once);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/Tools/codex-bridge/com.example.codex-pai-bridge.plist
+++ b/Tools/codex-bridge/com.example.codex-pai-bridge.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.example.codex-pai-bridge</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>__BUN_PATH__</string>
+      <string>__BRIDGE_PATH__</string>
+      <string>--watch</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PAI_DIR</key>
+      <string>__PAI_DIR__</string>
+      <key>CODEX_HOME</key>
+      <string>__CODEX_HOME__</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>__PAI_DIR__/bridge/logs/bridge.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__PAI_DIR__/bridge/logs/bridge.err.log</string>
+  </dict>
+</plist>

--- a/Tools/codex-bridge/fixtures/sample.jsonl
+++ b/Tools/codex-bridge/fixtures/sample.jsonl
@@ -1,0 +1,2 @@
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi there"}]}}

--- a/Tools/codex-bridge/hooks.ts
+++ b/Tools/codex-bridge/hooks.ts
@@ -1,0 +1,65 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { spawn } from 'child_process';
+
+const BUN_PATH = process.env.BUN_PATH || process.execPath || 'bun';
+
+export type HookInput = {
+  session_id: string;
+  transcript_path: string;
+  hook_event_name: string;
+  prompt?: string;
+  user_prompt?: string;
+};
+
+type RunOptions = {
+  paiDir: string;
+  dryRun: boolean;
+};
+
+function hookPath(paiDir: string, fileName: string): string {
+  return join(paiDir, 'hooks', fileName);
+}
+
+async function runHook(
+  name: string,
+  fileName: string,
+  input: HookInput | null,
+  opts: RunOptions
+): Promise<void> {
+  const fullPath = hookPath(opts.paiDir, fileName);
+  if (opts.dryRun) {
+    console.log(`HOOK ${name} -> ${fullPath}`);
+    return;
+  }
+  if (!existsSync(fullPath)) {
+    console.error(`Hook not found: ${fullPath}`);
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const child = spawn(BUN_PATH, [fullPath], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      env: { ...process.env, PAI_DIR: opts.paiDir },
+    });
+
+    if (input) {
+      child.stdin.write(JSON.stringify(input));
+    }
+    child.stdin.end();
+
+    child.on('close', () => resolve());
+  });
+}
+
+export async function runSessionStart(opts: RunOptions): Promise<void> {
+  await runHook('SessionStart', 'StartupGreeting.hook.ts', null, opts);
+}
+
+export async function runUserPrompt(input: HookInput, opts: RunOptions): Promise<void> {
+  await runHook('UserPromptSubmit', 'AutoWorkCreation.hook.ts', input, opts);
+}
+
+export async function runStop(input: HookInput, opts: RunOptions): Promise<void> {
+  await runHook('Stop', 'StopOrchestrator.hook.ts', input, opts);
+}

--- a/Tools/codex-bridge/install.sh
+++ b/Tools/codex-bridge/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+PAI_DIR="${PAI_DIR:-$HOME/.claude}"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+PLIST_TEMPLATE="$SCRIPT_DIR/com.example.codex-pai-bridge.plist"
+PLIST_PATH="$HOME/Library/LaunchAgents/com.example.codex-pai-bridge.plist"
+LABEL="com.example.codex-pai-bridge"
+BUN_BIN="${BUN_PATH:-$(command -v bun || true)}"
+
+if [[ "${1:-}" == "--check" ]]; then
+  if [[ -f "$PLIST_PATH" ]]; then
+    echo "OK: $PLIST_PATH"
+    exit 0
+  fi
+  echo "Missing: $PLIST_PATH"
+  exit 1
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents" "$PAI_DIR/bridge/logs"
+
+BRIDGE_PATH="$SCRIPT_DIR/bridge.ts"
+if [[ ! -f "$BRIDGE_PATH" ]]; then
+  echo "Missing bridge script: $BRIDGE_PATH"
+  exit 1
+fi
+
+if [[ -z "$BUN_BIN" ]]; then
+  echo "bun was not found. Install Bun or set BUN_PATH."
+  exit 1
+fi
+
+sed -e "s|__BRIDGE_PATH__|$BRIDGE_PATH|g" \
+    -e "s|__BUN_PATH__|$BUN_BIN|g" \
+    -e "s|__PAI_DIR__|$PAI_DIR|g" \
+    -e "s|__CODEX_HOME__|$CODEX_HOME|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_PATH"
+
+launchctl unload "$PLIST_PATH" 2>/dev/null || true
+launchctl load "$PLIST_PATH"
+launchctl kickstart -k "gui/$(id -u)/$LABEL" 2>/dev/null || true
+
+echo "Installed: $PLIST_PATH"

--- a/Tools/codex-bridge/self-check.sh
+++ b/Tools/codex-bridge/self-check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+[ -d "$CODEX_HOME" ] || { echo "Missing $CODEX_HOME"; exit 1; }
+[ -d "$CODEX_HOME/sessions" ] || { echo "Missing $CODEX_HOME/sessions"; exit 1; }
+echo "OK: Codex home found at $CODEX_HOME"

--- a/Tools/codex-bridge/tests/hook-bun-path.test.sh
+++ b/Tools/codex-bridge/tests/hook-bun-path.test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd -P)
+TMP_DIR=$(mktemp -d)
+CODEX_HOME="$TMP_DIR/codex"
+PAI_DIR="$TMP_DIR/pai"
+HOOKS_DIR="$PAI_DIR/hooks"
+mkdir -p "$CODEX_HOME/sessions" "$PAI_DIR/bridge/transcripts" "$HOOKS_DIR"
+
+# Minimal hook scripts
+cat > "$HOOKS_DIR/StartupGreeting.hook.ts" <<'TS'
+console.log('startup ok');
+TS
+
+cat > "$HOOKS_DIR/AutoWorkCreation.hook.ts" <<'TS'
+console.log('user ok');
+TS
+
+cat > "$HOOKS_DIR/StopOrchestrator.hook.ts" <<'TS'
+console.log('stop ok');
+TS
+
+BUN_PATH="$(command -v bun)"
+
+# Run bridge with empty PATH so spawn('bun') fails if not fixed
+output=$(env -i PATH="" BUN_PATH="$BUN_PATH" CODEX_HOME="$CODEX_HOME" PAI_DIR="$PAI_DIR" \
+  "$BUN_PATH" "$SCRIPT_DIR/bridge.ts" --test-fixture "$SCRIPT_DIR/fixtures/sample.jsonl" 2>&1)
+
+if ! echo "$output" | grep -q "Wrote transcript:"; then
+  echo "Expected transcript output"
+  echo "$output"
+  exit 1
+fi
+
+rm -rf "$TMP_DIR"
+echo "PASS: hook-bun-path"

--- a/Tools/codex-bridge/tests/statusline-dry-run.test.sh
+++ b/Tools/codex-bridge/tests/statusline-dry-run.test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd -P)
+
+output=$(bun "$SCRIPT_DIR/bridge.ts" --dry-run --test-fixture "$SCRIPT_DIR/fixtures/sample.jsonl")
+count=$(echo "$output" | grep -c "STATUSLINE ->" || true)
+
+if [ "$count" -ne 1 ]; then
+  echo "Expected 1 statusline invocation, got $count"
+  echo "$output"
+  exit 1
+fi
+
+echo "PASS: statusline dry-run"

--- a/Tools/codex-bridge/tests/watch-once.test.sh
+++ b/Tools/codex-bridge/tests/watch-once.test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd -P)
+TMP_DIR=$(mktemp -d)
+CODEX_HOME="$TMP_DIR/codex"
+PAI_DIR="$TMP_DIR/pai"
+mkdir -p "$CODEX_HOME/sessions/2026/01/21" "$PAI_DIR/bridge/transcripts"
+
+# Minimal statusline script so the bridge doesn't error
+mkdir -p "$PAI_DIR"
+cat > "$PAI_DIR/statusline-command.sh" <<'SCRIPT'
+#!/bin/bash
+cat >/dev/null
+SCRIPT
+chmod +x "$PAI_DIR/statusline-command.sh"
+
+# Write a session file with session_meta + user + assistant
+SESSION_FILE="$CODEX_HOME/sessions/2026/01/21/rollout-2026-01-21T00-00-00-00000000-0000-0000-0000-000000000000.jsonl"
+cat > "$SESSION_FILE" <<'JSONL'
+{"timestamp":"2026-01-21T00:00:00.000Z","type":"session_meta","payload":{"id":"test-session","cwd":"/tmp"}}
+{"timestamp":"2026-01-21T00:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}}
+{"timestamp":"2026-01-21T00:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi"}]}}
+JSONL
+
+output=$(CODEX_HOME="$CODEX_HOME" PAI_DIR="$PAI_DIR" bun "$SCRIPT_DIR/bridge.ts" --watch --once --dry-run)
+
+# Expect a transcript to be written and statusline invoked once
+if ! echo "$output" | grep -q "STATUSLINE ->"; then
+  echo "Expected statusline invocation"
+  echo "$output"
+  exit 1
+fi
+
+if [ ! -f "$PAI_DIR/bridge/transcripts/test-session.jsonl" ]; then
+  echo "Expected transcript file to exist"
+  exit 1
+fi
+
+rm -rf "$TMP_DIR"
+echo "PASS: watch-once"

--- a/Tools/codex-bridge/types.ts
+++ b/Tools/codex-bridge/types.ts
@@ -1,0 +1,20 @@
+export type CodexLogLine = {
+  timestamp?: string;
+  type: string;
+  payload?: any;
+};
+
+export type CodexMessage = {
+  role: 'user' | 'assistant';
+  text: string;
+};
+
+export type SessionState = {
+  filePath: string;
+  sessionId?: string;
+  transcriptPath?: string;
+  lastOffset: number;
+  cwd?: string;
+  buffer: string;
+  started: boolean;
+};

--- a/Tools/codex-bridge/uninstall.sh
+++ b/Tools/codex-bridge/uninstall.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLIST_PATH="$HOME/Library/LaunchAgents/com.example.codex-pai-bridge.plist"
+
+if [[ -f "$PLIST_PATH" ]]; then
+  launchctl unload "$PLIST_PATH" 2>/dev/null || true
+  rm -f "$PLIST_PATH"
+  echo "Removed: $PLIST_PATH"
+else
+  echo "Not found: $PLIST_PATH"
+fi


### PR DESCRIPTION
## Summary

- Adds `Tools/codex-bridge/` — a lightweight bridge that watches OpenAI Codex CLI session logs (`~/.codex/sessions/`) and triggers PAI hooks
- Enables a single PAI installation to serve both **Claude Code** and **Codex CLI** with shared memory, work tracking, and automation
- Includes macOS LaunchAgent installer/uninstaller for persistent background operation

## What It Does

The bridge polls Codex session JSONL files and fires the same PAI hook lifecycle Claude Code uses:

| Event | Hook Triggered |
|-------|---------------|
| Session start | `StartupGreeting.hook.ts` |
| User prompt | `AutoWorkCreation.hook.ts` |
| Assistant response | `StopOrchestrator.hook.ts` |
| After response | `statusline-command.sh` |

## Files Added

```
Tools/codex-bridge/
├── bridge.ts                          # Main bridge (Bun)
├── hooks.ts                           # Hook runner
├── types.ts                           # TypeScript types
├── install.sh                         # macOS LaunchAgent installer
├── uninstall.sh                       # LaunchAgent uninstaller
├── self-check.sh                      # Codex home verification
├── com.example.codex-pai-bridge.plist # LaunchAgent template
├── README.md                          # Documentation
├── fixtures/sample.jsonl              # Test fixture
└── tests/
    ├── statusline-dry-run.test.sh     # Statusline invocation test
    ├── watch-once.test.sh             # Session watch test
    └── hook-bun-path.test.sh          # BUN_PATH resolution test
```

## Test Plan

- [x] `bash Tools/codex-bridge/tests/statusline-dry-run.test.sh` — verifies dry-run produces exactly 1 statusline call
- [x] `bash Tools/codex-bridge/tests/watch-once.test.sh` — verifies session file discovery, transcript creation, and hook firing
- [x] `bash Tools/codex-bridge/tests/hook-bun-path.test.sh` — verifies BUN_PATH propagation to spawned hooks
- [x] No personal paths or secrets in any file (`grep -rn "/Users/" Tools/codex-bridge/` returns nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)