### PR TITLE
fix: SessionEnd hooks never execute their main logic

### DIFF
--- a/Releases/v2.5/.claude/hooks/AutoWorkCreation.hook.ts
+++ b/Releases/v2.5/.claude/hooks/AutoWorkCreation.hook.ts
@@ -131,6 +131,7 @@ title: "${title}"
 session_id: "${sessionId}"
 created_at: "${timestamp}"
 status: "ACTIVE"
+completed_at: null
 `;
   writeFileSync(join(sessionPath, 'META.yaml'), meta, 'utf-8');
 


### PR DESCRIPTION
## Summary

The `SessionSummary` and `WorkCompletionLearning` hooks (both triggered at `SessionEnd`) have never worked. Four independent bugs prevent them from executing their core logic. As a result:

- Work directories are never marked `COMPLETED` (all stay `ACTIVE` forever)
- `completed_at` timestamps are never set
- Work-completion learnings are never captured
- Session state files are never cleaned up

All bugs are in the upstream code at `Releases/v2.5/.claude/hooks/`.

## The Bugs

### Bug 1: Stdin handling causes silent exit

Both `SessionSummary.hook.ts` and `WorkCompletionLearning.hook.ts` read stdin and bail if it's empty:

```typescript
// BEFORE (broken)
const input = await Bun.stdin.text();
if (!input || !input.trim()) {
  process.exit(0);  // <-- exits here every time
}
```

`SessionEnd` hooks may receive empty stdin, slow stdin, or stdin that takes time to arrive. The hooks exit before doing any work.

**Fix:** Use `Promise.race` with a 3-second timeout. Proceed regardless of stdin availability — these hooks read state from disk files, not stdin.

```typescript
// AFTER (fixed)
try {
  const input = await Promise.race([
    Bun.stdin.text(),
    new Promise<string>((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000))
  ]);
  if (input && input.trim()) {
    const data = JSON.parse(input);
    sessionId = data.session_id;
  }
} catch {
  // Timeout or parse error — proceed without session_id
}
```

### Bug 2: Field name mismatch (`work_dir` vs `session_dir`)

`AutoWorkCreation.hook.ts` writes state files with the field `session_dir`:

```json
{
  "session_id": "abc-123",
  "session_dir": "20260213-131007_my-task",
  "task_count": 1
}
```

But both `SessionSummary` and `WorkCompletionLearning` declare their interface with `work_dir`:

```typescript
interface CurrentWork {
  session_id: string;
  work_dir: string;  // <-- doesn't match what's on disk
}
```

So `currentWork.work_dir` is always `undefined`, and the hooks skip all processing.

**Fix:** Change `work_dir` to `session_dir` in both hook interfaces.

### Bug 3: Missing `completed_at` field in META.yaml template

`SessionSummary.hook.ts` tries to stamp a completion timestamp using regex:

```typescript
metaContent = metaContent.replace(/^completed_at: null$/m, `completed_at: "${timestamp}"`);
```

But `AutoWorkCreation.hook.ts` creates META.yaml without that field:

```yaml
id: "..."
title: "..."
session_id: "..."
created_at: "..."
status: "ACTIVE"
# completed_at: null  <-- missing, regex has nothing to match
```

**Fix:** Add `completed_at: null` to the META.yaml template in `AutoWorkCreation.hook.ts`.

### Bug 4: Field name mismatch (`item_count` vs `task_count`)

`WorkCompletionLearning.hook.ts` checks for significant work:

```typescript
currentWork.item_count > 1  // <-- field doesn't exist
```

But `AutoWorkCreation` writes `task_count`, not `item_count`. This condition is always false (undefined > 1 === false).

**Fix:** Change `item_count` to `task_count` in the interface and usage.

## Files Changed

- `Releases/v2.5/.claude/hooks/SessionSummary.hook.ts` — Fixes bugs 1 & 2
- `Releases/v2.5/.claude/hooks/WorkCompletionLearning.hook.ts` — Fixes bugs 1, 2 & 4
- `Releases/v2.5/.claude/hooks/AutoWorkCreation.hook.ts` — Fixes bug 3

## Testing

Verified locally across multiple session closes:
- META.yaml transitions from `ACTIVE` to `COMPLETED` ✓
- `completed_at` timestamp is set ✓
- Session state files are cleaned up ✓
- Work-completion learning significant-work check uses correct field ✓

## Test plan

- [ ] Start a new Claude Code session, submit a prompt (creates work directory)
- [ ] Verify META.yaml contains `completed_at: null`
- [ ] Close the session
- [ ] Verify META.yaml shows `status: "COMPLETED"` and `completed_at` has a timestamp
- [ ] Verify `current-work.json` state file is deleted
- [ ] Verify no other sessions' state is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)