### PR TITLE
refactor: replace hardcoded skills in FormatReminder hook with dynamic config

### DIFF
--- a/Releases/v2.5/.claude/hooks/lib/identity.ts
+++ b/Releases/v2.5/.claude/hooks/lib/identity.ts
@@ -71,6 +71,7 @@ export interface Principal {
 export interface Settings {
   daidentity?: Partial<Identity>;
   principal?: Partial<Principal>;
+  skills?: string[];
   env?: Record<string, string>;
   [key: string]: unknown;
 }
@@ -169,6 +170,14 @@ export function getVoiceId(): string {
  */
 export function getSettings(): Settings {
   return loadSettings();
+}
+
+/**
+ * Get the list of personal skills from settings.json
+ */
+export function getSkills(): string[] {
+  const settings = loadSettings();
+  return Array.isArray(settings.skills) ? settings.skills : [];
 }
 
 /**


### PR DESCRIPTION
## Description
Resolves #577. This PR refactors [FormatReminder.hook.ts](cci:7://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/hooks/FormatReminder.hook.ts:0:0-0:0) to remove the hardcoded list of personal skills. 

The skills are now fetched dynamically from the user's [settings.json](cci:7://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/settings.json:0:0-0:0) configuration via [getSkills()](cci:1://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/hooks/lib/identity.ts:174:0-180:1) in [identity.ts](cci:7://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/hooks/lib/identity.ts:0:0-0:0). 

## Key Changes
- **Dynamic Config**: Added `skills` support to [identity.ts](cci:7://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/hooks/lib/identity.ts:0:0-0:0) to allow users to personalize their skill triggers without modifying source code.
- **Robust Fallback**: Maintained the original hardcoded list as a `DEFAULT_SKILLS` fallback to ensure the system remains functional for new users who haven't set up their custom skills yet.
- **Type Safety**: Updated the [Settings](cci:2://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/hooks/lib/identity.ts:70:0-76:1) interface to reflect the new configuration option.

## Verification
- Verified that [getSkills()](cci:1://file:///c:/Users/DX/Downloads/DEMAIL/Personal_AI_Infrastructure/Releases/v2.5/.claude/hooks/lib/identity.ts:174:0-180:1) correctly attempts to read from the configuration.
- Ensured the dynamic prompt generation logic correctly handles both empty and populated skill arrays.