### PR TITLE
fix: SessionEnd hooks never execute + session-scoped state files (v3.0)

### DIFF
--- a/Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -57,15 +57,27 @@ import { getLearningCategory } from './lib/learning-utils';
 
 const MEMORY_DIR = join(process.env.HOME!, '.claude', 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
-const CURRENT_WORK_FILE = join(STATE_DIR, 'current-work.json');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');
 const LEARNING_DIR = join(MEMORY_DIR, 'LEARNING');
 
+// Session-scoped state file lookup with legacy fallback
+function findStateFile(sessionId?: string): string | null {
+  if (sessionId) {
+    const scoped = join(STATE_DIR, `current-work-${sessionId}.json`);
+    if (existsSync(scoped)) return scoped;
+  }
+  const legacy = join(STATE_DIR, 'current-work.json');
+  if (existsSync(legacy)) return legacy;
+  return null;
+}
+
 interface CurrentWork {
   session_id: string;
-  work_dir: string;
+  session_dir: string;
+  current_task: string;
+  task_title: string;
+  task_count: number;
   created_at: string;
-  item_count: number;
 }
 
 interface WorkMeta {
@@ -239,28 +251,45 @@ ${idealContent || 'Not specified'}
 
 async function main() {
   try {
-    // Read input from stdin (required for hook pattern)
-    const input = await Bun.stdin.text();
-    if (!input || input.trim() === '') {
-      process.exit(0);
+    // Read input from stdin with timeout — SessionEnd hooks may receive
+    // empty or slow stdin. Proceed regardless since state is read from disk.
+    let sessionId: string | undefined;
+    try {
+      const input = await Promise.race([
+        Bun.stdin.text(),
+        new Promise<string>((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000))
+      ]);
+      if (input && input.trim()) {
+        const parsed = JSON.parse(input);
+        sessionId = parsed.session_id;
+      }
+    } catch {
+      // Timeout or parse error — proceed without session_id
     }
 
-    // Check if there's an active work session
-    if (!existsSync(CURRENT_WORK_FILE)) {
+    // Check if there's an active work session (session-scoped with legacy fallback)
+    const stateFile = findStateFile(sessionId);
+    if (!stateFile) {
       console.error('[WorkCompletionLearning] No active work session');
       process.exit(0);
     }
 
     // Read current work state
-    const currentWork: CurrentWork = JSON.parse(readFileSync(CURRENT_WORK_FILE, 'utf-8'));
+    const currentWork: CurrentWork = JSON.parse(readFileSync(stateFile, 'utf-8'));
 
-    if (!currentWork.work_dir) {
+    // Guard: don't process another session's state
+    if (sessionId && currentWork.session_id !== sessionId) {
+      console.error('[WorkCompletionLearning] State file belongs to different session, skipping');
+      process.exit(0);
+    }
+
+    if (!currentWork.session_dir) {
       console.error('[WorkCompletionLearning] No work directory in current session');
       process.exit(0);
     }
 
     // Read work directory metadata
-    const workPath = join(WORK_DIR, currentWork.work_dir);
+    const workPath = join(WORK_DIR, currentWork.session_dir);
     const metaPath = join(workPath, 'META.yaml');
 
     if (!existsSync(metaPath)) {
@@ -301,7 +330,7 @@ async function main() {
     // Check if this was significant work (has files changed or was manually created)
     const hasSignificantWork = (
       (workMeta.lineage?.files_changed?.length || 0) > 0 ||
-      currentWork.item_count > 1 ||
+      currentWork.task_count > 1 ||
       workMeta.source === 'MANUAL'
     );
 


### PR DESCRIPTION
## Summary

> **Rebased from closed PRs #648 and #649** which targeted v2.5 paths. Per maintainer feedback, this PR targets the equivalent v3.0 hooks. All four bugs are identical in v3.0.

The `SessionSummary` and `WorkCompletionLearning` hooks (both triggered at `SessionEnd`) have never worked. Four independent bugs prevent them from executing their core logic. As a result:

- Work directories are never marked `COMPLETED` (all stay `ACTIVE` forever)
- `completed_at` timestamps are never set
- Work-completion learnings are never captured
- Session state files are never cleaned up

Additionally, parallel sessions overwrite each other's state via a shared singleton file.

## The Bugs

### Bug 1: Stdin handling causes silent exit

Both `SessionSummary.hook.ts` and `WorkCompletionLearning.hook.ts` read stdin and bail if it's empty:

```typescript
const input = await Bun.stdin.text();
if (!input || input.trim() === '') {
  process.exit(0);  // <-- exits here every time
}
```

`SessionEnd` hooks may receive empty or slow stdin. The hooks exit before doing any work.

**Fix:** Use `Promise.race` with a 3-second timeout. Proceed regardless of stdin availability — these hooks read state from disk files, not stdin. (Note: `AutoWorkCreation.hook.ts` already uses this pattern via `readStdinWithTimeout`.)

### Bug 2: Field name mismatch (`work_dir` vs `session_dir`)

`AutoWorkCreation.hook.ts` writes state files with `session_dir`, but both `SessionSummary` and `WorkCompletionLearning` declare their `CurrentWork` interface with `work_dir` — always `undefined`.

**Fix:** Align interfaces to use `session_dir` (matching what `AutoWorkCreation` writes). Also updated `current_task`, `task_title`, `task_count` fields to match the v3.0 `CurrentWork` shape.

### Bug 3: Missing `completed_at` field in META.yaml template

`SessionSummary` tries to regex-replace `completed_at: null`, but `AutoWorkCreation` creates META.yaml without that field. The regex has nothing to match.

**Fix:** Added `completed_at: null` to the META.yaml template in `AutoWorkCreation.hook.ts`.

### Bug 4: Field name mismatch (`item_count` vs `task_count`)

`WorkCompletionLearning` checks `currentWork.item_count > 1` but `AutoWorkCreation` writes `task_count`. The condition is always false (`undefined > 1 === false`).

**Fix:** Changed `item_count` to `task_count`.

## Session-Scoped State Files (from #649)

When multiple Claude Code sessions run in parallel, they share a single `current-work.json` — last writer wins. This PR introduces session-scoped state files (`current-work-{session_id}.json`) so each session tracks independently.

- **Write path** (`AutoWorkCreation`): Creates `current-work-{session_id}.json`
- **Read path** (`SessionSummary`, `WorkCompletionLearning`): Looks up scoped file first, falls back to legacy `current-work.json`
- **Session guard**: Both SessionEnd hooks verify `session_id` matches before processing, preventing cross-session interference
- **Backwards compatible**: Falls back to legacy singleton if no scoped file exists

## Files Changed

- `Releases/v3.0/.claude/hooks/SessionSummary.hook.ts` — Fixes bugs 1, 2 + session-scoped reads
- `Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts` — Fixes bugs 1, 2, 4 + session-scoped reads
- `Releases/v3.0/.claude/hooks/AutoWorkCreation.hook.ts` — Fixes bug 3 + session-scoped writes

## Testing

Verified locally across multiple session closes:
- META.yaml transitions from `ACTIVE` to `COMPLETED`
- `completed_at` timestamp is set
- Session state files are cleaned up
- Work-completion learning significant-work check uses correct field
- Parallel sessions don't interfere with each other

## Test plan

- [ ] Start a new Claude Code session, submit a prompt (creates work directory)
- [ ] Verify META.yaml contains `completed_at: null`
- [ ] Close the session
- [ ] Verify META.yaml shows `status: "COMPLETED"` and `completed_at` has a timestamp
- [ ] Verify session-scoped `current-work-{id}.json` state file is deleted
- [ ] Start two parallel sessions, verify each gets its own state file
- [ ] Close one session, verify the other's state is untouched

Generated with [Claude Code](https://claude.com/claude-code)