### PR TITLE
fix: Stop creating noise learning files for neutral (5/10) sentiment ratings

### DIFF
--- a/Releases/v3.0/.claude/hooks/RatingCapture.hook.ts
+++ b/Releases/v3.0/.claude/hooks/RatingCapture.hook.ts
@@ -294,7 +294,8 @@ function captureLowRatingLearning(
   detailedContext: string,
   source: 'explicit' | 'implicit'
 ): void {
-  if (rating >= 6) return;
+  if (rating >= 5) return;  // 5 = neutral (no sentiment), only capture actual negatives (<=4)
+  if (!detailedContext?.trim()) return;  // Skip if no meaningful context to learn from
 
   const { year, month, day, hours, minutes, seconds } = getPSTComponents();
   const yearMonth = `${year}-${month}`;
@@ -370,7 +371,7 @@ async function main() {
       writeRating(entry);
       triggerTrending();
 
-      if (explicitResult.rating < 6) {
+      if (explicitResult.rating < 5) {
         // Get last response for context
         let responseContext = '';
         try {
@@ -455,7 +456,7 @@ async function main() {
       writeRating(entry);
       triggerTrending();
 
-      if (sentiment.rating < 6) {
+      if (sentiment.rating < 5) {
         captureLowRatingLearning(
           sentiment.rating,
           sentiment.summary,


### PR DESCRIPTION
## Summary
- Rating 5 means "no sentiment detected" (neutral), but the `< 6` threshold was treating it as a low rating, creating learning files with empty context for the majority of all messages
- Changed threshold from `< 6` to `< 5` across all 3 locations so only genuinely negative ratings (1-4) trigger learning file creation
- Added early return when `detailedContext` is empty as a second safety net

## The Bug
The sentiment analysis prompt correctly returns rating 5 for neutral technical messages and an empty `detailed_context`. But `captureLowRatingLearning` fires for any rating `< 6`, so every neutral message creates a file containing only "No context available" tagged as an "improvement opportunity." In practice this was generating many context-less files per day, with no perceived learning value.

## Changes (1 file, +4/-3)
`Releases/v3.0/.claude/hooks/RatingCapture.hook.ts`:
- `captureLowRatingLearning`: threshold `>= 6` → `>= 5` + empty context guard
- Explicit rating caller: `< 6` → `< 5`
- Implicit sentiment caller: `< 6` → `< 5`

## Test plan
- [ ] Verify neutral messages (rating 5) no longer create learning files
- [ ] Verify genuinely negative messages (rating 1-4) still create learning files with context
- [ ] Verify failure capture (rating <= 3) path is unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)