### PR TITLE
fix: GenerateSkillIndex.ts — follow symlinked skill directories

### DIFF
--- a/Releases/v3.0/.claude/skills/PAI/Tools/GenerateSkillIndex.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/GenerateSkillIndex.ts
@@ -10,7 +10,7 @@
  * Output: ~/.claude/skills/skill-index.json
  */
 
-import { readdir, readFile, writeFile } from 'fs/promises';
+import { readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 
@@ -52,7 +52,10 @@ async function findSkillFiles(dir: string): Promise<string[]> {
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
 
-      if (entry.isDirectory()) {
+      // Follow symlinks: Bun's readdir reports symlinks as isDirectory=false
+      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && (await stat(fullPath)).isDirectory());
+
+      if (isDir) {
         // Skip hidden directories and node_modules
         if (entry.name.startsWith('.') || entry.name === 'node_modules') {
           continue;


### PR DESCRIPTION
## Summary

- `GenerateSkillIndex.ts` uses `readdir({ withFileTypes: true })` to scan the skills directory, but Bun's `Dirent.isDirectory()` returns `false` for symlinks (even when the target is a directory)
- This causes symlinked skill directories to be silently skipped during index generation
- Adds a `isSymbolicLink() + stat()` fallback so symlinked directories containing `SKILL.md` are discovered alongside regular directories

## Context

This affects users who symlink custom skills into the skills directory — for example, the ["Move out, Link Back" pattern](https://github.com/ecielam/pai-personal-data) where personal/custom skills live outside the PAI repo and are symlinked in.

Without this fix, symlinked skills are invisible to the index generator despite Claude Code's native skill discovery following symlinks correctly.

## Test plan

- [ ] Verify symlinked skill directories are discovered by `GenerateSkillIndex.ts`
- [ ] Verify regular (non-symlinked) skill directories still work
- [ ] Verify broken symlinks don't cause crashes (stat will throw, caught by existing try/catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)