### PR TITLE
fix: Replace Bun.stdin with process.stdin in 10 v3.0 hooks (Windows/MSYS)

### DIFF
--- a/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
+++ b/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
@@ -23,7 +23,9 @@ import {
 import type { AlgorithmCriterion, AlgorithmPhase, AlgorithmState } from './lib/algorithm-state';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { homedir } from 'os';
 import { setPhaseTab } from './lib/tab-setter';
+import { readStdinWithTimeout } from './lib/stdin';
 
 // ── Phase Detection from Voice Curls ──
 
@@ -91,7 +93,7 @@ function parseCriterion(text: string): { id: string; description: string } | nul
 
 // ── Session Activation (replaces SessionReactivator) ──
 
-const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || require('os').homedir()), '.claude');
+const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || homedir()), '.claude');
 
 function getSessionName(sid: string): string {
   try {
@@ -143,14 +145,7 @@ async function main() {
 
   let input: any;
   try {
-    const raw = await new Promise<string>((resolve) => {
-      let data = '';
-      const timer = setTimeout(() => resolve(data), 200);
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => { data += chunk; });
-      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-    });
+    const raw = await readStdinWithTimeout(200);
     if (!raw.trim()) return;
     input = JSON.parse(raw);
   } catch { return; }

--- a/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
+++ b/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
@@ -23,9 +23,9 @@ import {
 import type { AlgorithmCriterion, AlgorithmPhase, AlgorithmState } from './lib/algorithm-state';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { setPhaseTab } from './lib/tab-setter';
 import { readStdinWithTimeout } from './lib/stdin';
+import { getPaiDir } from './lib/paths';
 
 // ── Phase Detection from Voice Curls ──
 
@@ -93,7 +93,7 @@ function parseCriterion(text: string): { id: string; description: string } | nul
 
 // ── Session Activation (replaces SessionReactivator) ──
 
-const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || homedir()), '.claude');
+const BASE_DIR = getPaiDir();
 
 function getSessionName(sid: string): string {
   try {

--- a/Releases/v3.0/.claude/hooks/IntegrityCheck.hook.ts
+++ b/Releases/v3.0/.claude/hooks/IntegrityCheck.hook.ts
@@ -13,6 +13,7 @@
 import { parseTranscript } from '../skills/PAI/Tools/TranscriptParser';
 import { handleSystemIntegrity } from './handlers/SystemIntegrity';
 import { handleDocCrossRefIntegrity } from './handlers/DocCrossRefIntegrity';
+import { readStdinWithTimeout } from './lib/stdin';
 
 interface HookInput {
   session_id: string;
@@ -22,14 +23,7 @@ interface HookInput {
 
 async function readStdin(): Promise<HookInput | null> {
   try {
-    const input = await new Promise<string>((resolve) => {
-      let data = '';
-      const timer = setTimeout(() => resolve(data), 500);
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => { data += chunk; });
-      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-    });
+    const input = await readStdinWithTimeout(500);
     if (input.trim()) return JSON.parse(input) as HookInput;
   } catch {}
   return null;

--- a/Releases/v3.0/.claude/hooks/QuestionAnswered.hook.ts
+++ b/Releases/v3.0/.claude/hooks/QuestionAnswered.hook.ts
@@ -37,20 +37,14 @@
  */
 
 import { setTabState, readTabState, stripPrefix } from './lib/tab-setter';
+import { readStdinWithTimeout } from './lib/stdin';
 
 async function main() {
   try {
     // Extract session_id from stdin for correct tab targeting
     let sessionId: string | undefined;
     try {
-      const raw = await new Promise<string>((resolve) => {
-        let data = '';
-        const timer = setTimeout(() => resolve(data), 1000);
-        process.stdin.setEncoding('utf8');
-        process.stdin.on('data', chunk => { data += chunk; });
-        process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-        process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-      });
+      const raw = await readStdinWithTimeout(1000);
       if (raw.trim()) {
         const parsed = JSON.parse(raw);
         sessionId = parsed.session_id;

--- a/Releases/v3.0/.claude/hooks/QuestionAnswered.hook.ts
+++ b/Releases/v3.0/.claude/hooks/QuestionAnswered.hook.ts
@@ -43,7 +43,14 @@ async function main() {
     // Extract session_id from stdin for correct tab targeting
     let sessionId: string | undefined;
     try {
-      const raw = await Bun.stdin.text();
+      const raw = await new Promise<string>((resolve) => {
+        let data = '';
+        const timer = setTimeout(() => resolve(data), 1000);
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', chunk => { data += chunk; });
+        process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
+        process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
+      });
       if (raw.trim()) {
         const parsed = JSON.parse(raw);
         sessionId = parsed.session_id;

--- a/Releases/v3.0/.claude/hooks/SecurityValidator.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SecurityValidator.hook.ts
@@ -65,6 +65,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { parse as parseYaml } from 'yaml';
 import { paiPath } from './lib/paths';
+import { readStdinWithTimeout } from './lib/stdin';
 
 // ========================================
 // Security Event Logging
@@ -600,15 +601,8 @@ async function main(): Promise<void> {
   let input: HookInput;
 
   try {
-    // Fast stdin read with timeout (process.stdin for Windows/MSYS compat)
-    const text = await new Promise<string>((resolve) => {
-      let data = '';
-      const timer = setTimeout(() => resolve(data), 100);
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => { data += chunk; });
-      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-    });
+    // Fast stdin read with timeout (cross-platform via lib/stdin.ts)
+    const text = await readStdinWithTimeout(100);
 
     if (!text.trim()) {
       console.log(JSON.stringify({ continue: true }));

--- a/Releases/v3.0/.claude/hooks/SessionAutoName.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SessionAutoName.hook.ts
@@ -29,6 +29,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { paiPath } from './lib/paths';
 import { inference } from '../skills/PAI/Tools/Inference';
+import { readStdinWithTimeout } from './lib/stdin';
 
 interface HookInput {
   session_id: string;
@@ -204,15 +205,7 @@ function getCustomTitle(sessionId: string): string | null {
 
 async function readStdin(): Promise<HookInput | null> {
   try {
-    const input = await new Promise<string>((resolve) => {
-      let data = '';
-      const timer = setTimeout(() => resolve(data), 2000);
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => { data += chunk; });
-      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-    });
-
+    const input = await readStdinWithTimeout(2000);
     if (input.trim()) {
       return JSON.parse(input) as HookInput;
     }

--- a/Releases/v3.0/.claude/hooks/SessionAutoName.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SessionAutoName.hook.ts
@@ -204,23 +204,14 @@ function getCustomTitle(sessionId: string): string | null {
 
 async function readStdin(): Promise<HookInput | null> {
   try {
-    const decoder = new TextDecoder();
-    const reader = Bun.stdin.stream().getReader();
-    let input = '';
-
-    const timeoutPromise = new Promise<void>((resolve) => {
-      setTimeout(() => resolve(), 2000);
+    const input = await new Promise<string>((resolve) => {
+      let data = '';
+      const timer = setTimeout(() => resolve(data), 2000);
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', chunk => { data += chunk; });
+      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
+      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
     });
-
-    const readPromise = (async () => {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        input += decoder.decode(value, { stream: true });
-      }
-    })();
-
-    await Promise.race([readPromise, timeoutPromise]);
 
     if (input.trim()) {
       return JSON.parse(input) as HookInput;

--- a/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
@@ -50,12 +50,12 @@
 
 import { writeFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 import { readStdinWithTimeout } from './lib/stdin';
+import { sanitizeSessionId, getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || homedir()), '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');
@@ -130,7 +130,7 @@ async function main() {
       const input = await readStdinWithTimeout(3000);
       if (input && input.trim()) {
         const parsed = JSON.parse(input);
-        sessionId = parsed.session_id;
+        sessionId = parsed.session_id ? sanitizeSessionId(parsed.session_id) : undefined;
       }
     } catch {
       // Parse error — proceed without session_id

--- a/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
@@ -50,10 +50,12 @@
 
 import { writeFileSync, existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
+import { homedir } from 'os';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
+import { readStdinWithTimeout } from './lib/stdin';
 
-const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || require('os').homedir()), '.claude');
+const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || homedir()), '.claude');
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');
@@ -125,14 +127,7 @@ async function main() {
     // SessionEnd hooks may receive empty or slow stdin. Proceed regardless.
     let sessionId: string | undefined;
     try {
-      const input = await new Promise<string>((resolve) => {
-        let data = '';
-        const timer = setTimeout(() => resolve(data), 3000);
-        process.stdin.setEncoding('utf8');
-        process.stdin.on('data', chunk => { data += chunk; });
-        process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-        process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-      });
+      const input = await readStdinWithTimeout(3000);
       if (input && input.trim()) {
         const parsed = JSON.parse(input);
         sessionId = parsed.session_id;

--- a/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
+++ b/Releases/v3.0/.claude/hooks/SessionSummary.hook.ts
@@ -53,7 +53,7 @@ import { join } from 'path';
 import { getISOTimestamp } from './lib/time';
 import { setTabState, cleanupKittySession } from './lib/tab-setter';
 
-const BASE_DIR = process.env.PAI_DIR || join(process.env.HOME!, '.claude');
+const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || require('os').homedir()), '.claude');
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');
@@ -121,20 +121,24 @@ function clearSessionWork(sessionId?: string): void {
 
 async function main() {
   try {
-    // Read input from stdin with timeout — SessionEnd hooks may receive
-    // empty or slow stdin. Proceed regardless since state is read from disk.
+    // Read input from stdin with timeout (process.stdin for Windows/MSYS compat)
+    // SessionEnd hooks may receive empty or slow stdin. Proceed regardless.
     let sessionId: string | undefined;
     try {
-      const input = await Promise.race([
-        Bun.stdin.text(),
-        new Promise<string>((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000))
-      ]);
+      const input = await new Promise<string>((resolve) => {
+        let data = '';
+        const timer = setTimeout(() => resolve(data), 3000);
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', chunk => { data += chunk; });
+        process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
+        process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
+      });
       if (input && input.trim()) {
         const parsed = JSON.parse(input);
         sessionId = parsed.session_id;
       }
     } catch {
-      // Timeout or parse error — proceed without session_id
+      // Parse error — proceed without session_id
     }
 
     // Mark work as complete and clear state

--- a/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
+++ b/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
@@ -51,6 +51,7 @@ import { spawnSync } from 'child_process';
 
 import { getPaiDir, getSettingsPath } from './lib/paths';
 import { persistKittySession } from './lib/tab-setter';
+import { readStdinWithTimeout } from './lib/stdin';
 
 const paiDir = getPaiDir();
 const settingsPath = getSettingsPath();
@@ -71,14 +72,7 @@ const settingsPath = getSettingsPath();
     // Read session_id from stdin (Claude Code passes hook input as JSON)
     let sessionId: string | null = null;
     try {
-      const stdinText = await new Promise<string>((resolve) => {
-        let data = '';
-        const timer = setTimeout(() => resolve(data), 1000);
-        process.stdin.setEncoding('utf8');
-        process.stdin.on('data', chunk => { data += chunk; });
-        process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-        process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-      });
+      const stdinText = await readStdinWithTimeout(1000);
       if (stdinText.trim()) {
         const hookInput = JSON.parse(stdinText);
         sessionId = hookInput.session_id || null;

--- a/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
+++ b/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
@@ -71,7 +71,14 @@ const settingsPath = getSettingsPath();
     // Read session_id from stdin (Claude Code passes hook input as JSON)
     let sessionId: string | null = null;
     try {
-      const stdinText = await Bun.stdin.text();
+      const stdinText = await new Promise<string>((resolve) => {
+        let data = '';
+        const timer = setTimeout(() => resolve(data), 1000);
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', chunk => { data += chunk; });
+        process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
+        process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
+      });
       if (stdinText.trim()) {
         const hookInput = JSON.parse(stdinText);
         sessionId = hookInput.session_id || null;

--- a/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
+++ b/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
@@ -49,7 +49,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { spawnSync } from 'child_process';
 
-import { getPaiDir, getSettingsPath } from './lib/paths';
+import { getPaiDir, getSettingsPath, sanitizeSessionId } from './lib/paths';
 import { persistKittySession } from './lib/tab-setter';
 import { readStdinWithTimeout } from './lib/stdin';
 
@@ -75,7 +75,7 @@ const settingsPath = getSettingsPath();
       const stdinText = await readStdinWithTimeout(1000);
       if (stdinText.trim()) {
         const hookInput = JSON.parse(stdinText);
-        sessionId = hookInput.session_id || null;
+        sessionId = hookInput.session_id ? sanitizeSessionId(hookInput.session_id) : null;
       }
     } catch { /* stdin parse failed — proceed without session_id */ }
 

--- a/Releases/v3.0/.claude/hooks/StopOrchestrator.hook.ts
+++ b/Releases/v3.0/.claude/hooks/StopOrchestrator.hook.ts
@@ -30,6 +30,7 @@ import { handleDocCrossRefIntegrity } from './handlers/DocCrossRefIntegrity';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { readStdinWithTimeout } from './lib/stdin';
 
 interface HookInput {
   session_id: string;
@@ -51,15 +52,7 @@ function isMainSession(sessionId: string): boolean {
 
 async function readStdin(): Promise<HookInput | null> {
   try {
-    const input = await new Promise<string>((resolve) => {
-      let data = '';
-      const timer = setTimeout(() => resolve(data), 500);
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => { data += chunk; });
-      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-    });
-
+    const input = await readStdinWithTimeout(500);
     if (input.trim()) {
       return JSON.parse(input) as HookInput;
     }

--- a/Releases/v3.0/.claude/hooks/VoiceGate.hook.ts
+++ b/Releases/v3.0/.claude/hooks/VoiceGate.hook.ts
@@ -25,6 +25,7 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { readStdinWithTimeout } from './lib/stdin';
 
 interface HookInput {
   tool_name: string;
@@ -55,14 +56,7 @@ function isMainSession(sessionId: string): boolean {
 async function main() {
   let input: HookInput;
   try {
-    const raw = await new Promise<string>((resolve) => {
-      let data = '';
-      const timer = setTimeout(() => resolve(data), 200);
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => { data += chunk; });
-      process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
-      process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
-    });
+    const raw = await readStdinWithTimeout(200);
     if (!raw.trim()) {
       console.log(JSON.stringify({ continue: true }));
       return;

--- a/Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts
+++ b/Releases/v3.0/.claude/hooks/WorkCompletionLearning.hook.ts
@@ -52,12 +52,12 @@
 
 import { writeFileSync, existsSync, readFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
 import { getISOTimestamp, getPSTDate } from './lib/time';
 import { getLearningCategory } from './lib/learning-utils';
 import { readStdinWithTimeout } from './lib/stdin';
+import { sanitizeSessionId, getPaiDir } from './lib/paths';
 
-const BASE_DIR = process.env.PAI_DIR || join((process.env.HOME || process.env.USERPROFILE || homedir()), '.claude');
+const BASE_DIR = getPaiDir();
 const MEMORY_DIR = join(BASE_DIR, 'MEMORY');
 const STATE_DIR = join(MEMORY_DIR, 'STATE');
 const WORK_DIR = join(MEMORY_DIR, 'WORK');
@@ -261,7 +261,7 @@ async function main() {
       const input = await readStdinWithTimeout(3000);
       if (input && input.trim()) {
         const parsed = JSON.parse(input);
-        sessionId = parsed.session_id;
+        sessionId = parsed.session_id ? sanitizeSessionId(parsed.session_id) : undefined;
       }
     } catch {
       // Parse error — proceed without session_id

--- a/Releases/v3.0/.claude/hooks/lib/paths.ts
+++ b/Releases/v3.0/.claude/hooks/lib/paths.ts
@@ -73,3 +73,15 @@ export function getSkillsDir(): string {
 export function getMemoryDir(): string {
   return paiPath('MEMORY');
 }
+
+/**
+ * Sanitize a session_id to prevent path traversal attacks.
+ * Session IDs from Claude Code are UUIDs (hex + hyphens), but stdin input
+ * could be tampered with. Strip anything that's not alphanumeric or hyphen.
+ *
+ * Security: prevents ../../ traversal in join() calls that construct file paths.
+ * See: Gemini Code Assist security review on PR #713.
+ */
+export function sanitizeSessionId(sessionId: string): string {
+  return sessionId.replace(/[^a-zA-Z0-9\-]/g, '');
+}

--- a/Releases/v3.0/.claude/hooks/lib/stdin.ts
+++ b/Releases/v3.0/.claude/hooks/lib/stdin.ts
@@ -1,0 +1,27 @@
+/**
+ * stdin.ts — Cross-platform stdin reading utility
+ *
+ * Replaces duplicated process.stdin patterns across all hooks.
+ * Uses process.stdin (not Bun.stdin) for Windows/MSYS compatibility.
+ * See: https://github.com/danielmiessler/Personal_AI_Infrastructure/issues/385
+ */
+
+/**
+ * Read all of stdin with a timeout fallback.
+ * Returns whatever data was received before timeout, or '' on error.
+ *
+ * @param timeoutMs - Maximum time to wait for stdin (default: 500ms)
+ */
+export function readStdinWithTimeout(timeoutMs = 500): Promise<string> {
+  return new Promise<string>((resolve) => {
+    let data = '';
+    const timer = setTimeout(() => {
+      process.stdin.destroy();
+      resolve(data);
+    }, timeoutMs);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
+    process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
+  });
+}


### PR DESCRIPTION
## Summary

- **10 hooks** still used `Bun.stdin.text()` or `Bun.stdin.stream().getReader()`, which fail silently on Windows/MSYS (empty return or indefinite hang)
- All 10 now use `process.stdin` with event listeners and a timeout fallback — the same cross-platform pattern already used by the other 11 hooks
- Zero references to `Bun.stdin` remain in any v3.0 hook file

## Files Changed

| Hook | Old Pattern | Timeout |
|------|------------|---------|
| `AlgorithmTracker` | `stream().getReader()` | 200ms |
| `IntegrityCheck` | `stream().getReader()` | 500ms |
| `QuestionAnswered` | `Bun.stdin.text()` | 1s |
| `SecurityValidator` | `Promise.race` + `Bun.stdin.text()` | 100ms |
| `SessionAutoName` | `stream().getReader()` | 2s |
| `SessionSummary` | `Promise.race` + `Bun.stdin.text()` | 3s |
| `StartupGreeting` | `Bun.stdin.text()` | 1s |
| `StopOrchestrator` | `stream().getReader()` | 500ms |
| `VoiceGate` | `stream().getReader()` | 200ms |
| `WorkCompletionLearning` | `Promise.race` + `Bun.stdin.text()` | 3s |

## The Pattern

```typescript
const input = await new Promise<string>((resolve) => {
  let data = '';
  const timer = setTimeout(() => resolve(data), timeout);
  process.stdin.setEncoding('utf8');
  process.stdin.on('data', chunk => { data += chunk; });
  process.stdin.on('end', () => { clearTimeout(timer); resolve(data); });
  process.stdin.on('error', () => { clearTimeout(timer); resolve(''); });
});
```

## Test plan

- [ ] Verify `grep -r "Bun\.stdin" Releases/v3.0/.claude/hooks/` returns zero matches
- [ ] Run hooks on Windows/MSYS and confirm stdin is read correctly
- [ ] Run hooks on macOS/Linux and confirm no regression

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)