### PR TITLE
fix: replace tilde paths with $HOME in v3.0 markdown instructions

### DIFF
--- a/Releases/v3.0/.claude/skills/Agents/AgentProfileSystem.md
+++ b/Releases/v3.0/.claude/skills/Agents/AgentProfileSystem.md
@@ -181,7 +181,7 @@ bun run ~/.claude/skills/Agents/Tools/LoadAgentContext.ts Architect "Design new 
 
 To add a new agent type:
 
-1. Create `[AgentType]Context.md` in `~/.claude/skills/Agents/`
+1. Create `[AgentType]Context.md` in `$HOME/.claude/skills/Agents/`
 2. Follow the context file format above
 3. Reference relevant Skills (don't duplicate content)
 4. Specify model preference (opus/sonnet/haiku)

--- a/Releases/v3.0/.claude/skills/Evals/Workflows/CompareModels.md
+++ b/Releases/v3.0/.claude/skills/Evals/Workflows/CompareModels.md
@@ -46,7 +46,7 @@ models:
 
 ### Step 3: Create Model Comparison Config
 
-Create `~/.claude/skills/Evals/UseCases/<name>/model-comparisons/<comparison-name>.yaml`:
+Create `$HOME/.claude/skills/Evals/UseCases/<name>/model-comparisons/<comparison-name>.yaml`:
 
 ```yaml
 model_comparison:

--- a/Releases/v3.0/.claude/skills/Evals/Workflows/ComparePrompts.md
+++ b/Releases/v3.0/.claude/skills/Evals/Workflows/ComparePrompts.md
@@ -76,7 +76,7 @@ ls ~/.claude/skills/Evals/UseCases/<name>/prompts/
 
 ### Step 3: Create Comparison Config
 
-Create `~/.claude/skills/Evals/UseCases/<name>/comparisons/<comparison-name>.yaml`:
+Create `$HOME/.claude/skills/Evals/UseCases/<name>/comparisons/<comparison-name>.yaml`:
 
 ```yaml
 comparison:

--- a/Releases/v3.0/.claude/skills/Evals/Workflows/CreateJudge.md
+++ b/Releases/v3.0/.claude/skills/Evals/Workflows/CreateJudge.md
@@ -33,7 +33,7 @@ Ask the user:
 
 ### Step 2: Create Judge Config
 
-Create `~/.claude/skills/Evals/UseCases/<name>/judge-config.yaml`:
+Create `$HOME/.claude/skills/Evals/UseCases/<name>/judge-config.yaml`:
 
 ```yaml
 judge:

--- a/Releases/v3.0/.claude/skills/Evals/Workflows/CreateUseCase.md
+++ b/Releases/v3.0/.claude/skills/Evals/Workflows/CreateUseCase.md
@@ -39,7 +39,7 @@ mkdir -p ~/.claude/skills/Evals/UseCases/<name>/{test-cases,golden-outputs,promp
 
 ### Step 3: Create Config File
 
-Create `~/.claude/skills/Evals/UseCases/<name>/config.yaml`:
+Create `$HOME/.claude/skills/Evals/UseCases/<name>/config.yaml`:
 
 ```yaml
 name: <use_case_name>
@@ -97,7 +97,7 @@ models:
 
 ### Step 4: Create Initial Prompt Version
 
-Create `~/.claude/skills/Evals/UseCases/<name>/prompts/v1.0.0.md`:
+Create `$HOME/.claude/skills/Evals/UseCases/<name>/prompts/v1.0.0.md`:
 
 ```markdown
 # <Task Name> Prompt v1.0.0
@@ -121,7 +121,7 @@ Create `~/.claude/skills/Evals/UseCases/<name>/prompts/v1.0.0.md`:
 
 ### Step 5: Create Test Cases
 
-Create test cases in `~/.claude/skills/Evals/UseCases/<name>/test-cases/`:
+Create test cases in `$HOME/.claude/skills/Evals/UseCases/<name>/test-cases/`:
 
 Each test case is a YAML file:
 
@@ -173,7 +173,7 @@ Golden outputs serve as:
 
 ### Step 7: Create README
 
-Create `~/.claude/skills/Evals/UseCases/<name>/README.md`:
+Create `$HOME/.claude/skills/Evals/UseCases/<name>/README.md`:
 
 ```markdown
 # <Use Case Name>

--- a/Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.6.0.md
+++ b/Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.6.0.md
@@ -284,7 +284,8 @@ ELSE:
   → All criteria in one PRD
 
 📄 **PRD CREATION:**
-[Create PRD file at ~/.claude/MEMORY/WORK/{session-slug}/PRD-{YYYYMMDD}-{slug}.md]
+⚠️ **PATH RULE: Write/Edit tools do NOT shell-expand `~`. ALWAYS resolve to absolute home path (e.g., `/home/user/.claude/` or `/Users/name/.claude/`) before writing files. Using literal `~` creates a rogue `~` directory in the CWD.**
+[Create PRD file at $HOME/.claude/MEMORY/WORK/{session-slug}/PRD-{YYYYMMDD}-{slug}.md — where $HOME is the absolute home directory path, NEVER literal `~`]
 [Write IDEAL STATE CRITERIA section matching TaskCreate entries]
 [Write CONTEXT section for loop mode self-containment]
 [If continuing work: Read existing PRD, rebuild working memory from ISC section]
@@ -661,7 +662,7 @@ Each entry: date, decision, rationale, alternatives considered.}
 | `parent` | string\|null | Parent PRD ID if this is a child PRD |
 | `children` | array | Child PRD IDs if decomposed |
 
-**Location:** Project `.prd/` directory if inside a project with `.git/`, else `~/.claude/MEMORY/WORK/{session-slug}/`
+**Location:** Project `.prd/` directory if inside a project with `.git/`, else `$HOME/.claude/MEMORY/WORK/{session-slug}/` (resolve `$HOME` to absolute path — NEVER use literal `~`)
 **Slug:** Task description lowercased, special chars stripped, spaces to hyphens, max 40 chars.
 
 ### Per-Phase PRD Behavior

--- a/Releases/v3.0/.claude/skills/PAI/SKILL.md
+++ b/Releases/v3.0/.claude/skills/PAI/SKILL.md
@@ -323,7 +323,8 @@ ELSE:
   → All criteria in one PRD
 
 📄 **PRD CREATION:**
-[Create PRD file at ~/.claude/MEMORY/WORK/{session-slug}/PRD-{YYYYMMDD}-{slug}.md]
+⚠️ **PATH RULE: Write/Edit tools do NOT shell-expand `~`. ALWAYS resolve to absolute home path (e.g., `/home/user/.claude/` or `/Users/name/.claude/`) before writing files. Using literal `~` creates a rogue `~` directory in the CWD.**
+[Create PRD file at $HOME/.claude/MEMORY/WORK/{session-slug}/PRD-{YYYYMMDD}-{slug}.md — where $HOME is the absolute home directory path, NEVER literal `~`]
 [Write IDEAL STATE CRITERIA section matching TaskCreate entries]
 [Write CONTEXT section for loop mode self-containment]
 [If continuing work: Read existing PRD, rebuild working memory from ISC section]
@@ -700,7 +701,7 @@ Each entry: date, decision, rationale, alternatives considered.}
 | `parent` | string\|null | Parent PRD ID if this is a child PRD |
 | `children` | array | Child PRD IDs if decomposed |
 
-**Location:** Project `.prd/` directory if inside a project with `.git/`, else `~/.claude/MEMORY/WORK/{session-slug}/`
+**Location:** Project `.prd/` directory if inside a project with `.git/`, else `$HOME/.claude/MEMORY/WORK/{session-slug}/` (resolve `$HOME` to absolute path — NEVER use literal `~`)
 **Slug:** Task description lowercased, special chars stripped, spaces to hyphens, max 40 chars.
 
 ### Per-Phase PRD Behavior

--- a/Releases/v3.0/.claude/skills/PAI/THEHOOKSYSTEM.md
+++ b/Releases/v3.0/.claude/skills/PAI/THEHOOKSYSTEM.md
@@ -160,7 +160,7 @@ Claude Code supports the following hook events:
 - Explicit path: Pattern match first (no inference needed), writes to `ratings.jsonl`
 - Implicit path: Haiku inference for sentiment if no explicit match
 - Low ratings (<6) auto-capture as learning opportunities
-- Writes to `~/.claude/MEMORY/SIGNALS/ratings.jsonl`
+- Writes to `$HOME/.claude/MEMORY/SIGNALS/ratings.jsonl` (resolved via `paths.ts` at runtime)
 - Uses shared libraries: `hooks/lib/learning-utils.ts`, `hooks/lib/time.ts`
 - **Inference:** `import { inference } from '../skills/PAI/Tools/Inference'` → `inference({ level: 'fast', expectJson: true })`
 

--- a/Releases/v3.0/.claude/skills/Research/Workflows/ExtractAlpha.md
+++ b/Releases/v3.0/.claude/skills/Research/Workflows/ExtractAlpha.md
@@ -379,10 +379,10 @@ When this skill activates, PAI should:
 
 1. **Load content** via appropriate method (fabric -y, WebFetch, Read, or paste)
 2. **Get current work directory** - Read `~/.claude/MEMORY/STATE/current-work.json` for `work_dir`
-3. **Create scratch workspace** - Work in `~/.claude/MEMORY/WORK/{work_dir}/scratch/`
+3. **Create scratch workspace** - Work in `$HOME/.claude/MEMORY/WORK/{work_dir}/scratch/` (resolve `$HOME` to absolute path — NEVER use literal `~`)
 4. **Engage deep thinking mode** - Deep extended thinking through all 10 dimensions
 5. **Extract insights** - Extract 24-30 highest-alpha ideas focusing on low-probability brilliant insights
-6. **Save to history** - Final outputs to `~/.claude/History/research/YYYY-MM-DD_description/`
+6. **Save to history** - Final outputs to `$HOME/.claude/History/research/YYYY-MM-DD_description/`
 7. **Verify capture** - Ensure hooks captured or manually save all files
 8. **Output simple list** - Unformatted markdown, Paul Graham style, 8-12 words each
 9. **Prioritize surprise** - Novel ideas over obvious takeaways

--- a/Releases/v3.0/.claude/skills/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v3.0/.claude/skills/WorldThreatModelHarness/SKILL.md
@@ -39,7 +39,7 @@ All workflows support three execution tiers:
 
 ## World Model Storage
 
-Models are stored at: `~/.claude/MEMORY/RESEARCH/WorldModels/`
+Models are stored at: `$HOME/.claude/MEMORY/RESEARCH/WorldModels/` (resolve `$HOME` to absolute path — NEVER use literal `~`)
 
 | File | Horizon |
 |------|---------|

--- a/Releases/v3.0/.claude/skills/WorldThreatModelHarness/Workflows/UpdateModels.md
+++ b/Releases/v3.0/.claude/skills/WorldThreatModelHarness/Workflows/UpdateModels.md
@@ -79,11 +79,11 @@ For each model, following `ModelTemplate.md`:
 4. Include specific data points, named entities, cited reasoning
 5. Write Wildcards section with probability estimates
 
-Save to: `~/.claude/MEMORY/RESEARCH/WorldModels/{horizon}.md`
+Save to: `$HOME/.claude/MEMORY/RESEARCH/WorldModels/{horizon}.md` (resolve `$HOME` to absolute path — NEVER use literal `~`)
 
 ### Step 5: Update INDEX
 
-Write/update `~/.claude/MEMORY/RESEARCH/WorldModels/INDEX.md`:
+Write/update `$HOME/.claude/MEMORY/RESEARCH/WorldModels/INDEX.md` (resolve `$HOME` to absolute path — NEVER use literal `~`):
 
 ```markdown
 # World Threat Models — Index


### PR DESCRIPTION
## Summary

Claude Code's `Write`/`Edit` tools use `fs.writeFile()` internally — they do **not** shell-expand `~`. When the AI follows markdown instructions containing `~/.claude/...` paths and passes them to `Write`/`Edit` tools, a literal directory named `~` is created in the current working directory instead of writing to the user's home directory.

This PR fixes **11 files** across v3.0 where Write-facing markdown instructions used `~/.claude/` shorthand, replacing them with `$HOME/.claude/` (with resolution notes where appropriate).

**Root cause:** The PAI system has two path systems:
- **TypeScript tools** (`paths.ts`, hooks) — use `homedir()` + `join()` → **correct**, unaffected
- **Markdown instructions** — use `~/.claude/` shorthand that the AI passes verbatim to `Write`/`Edit` → **broken on all platforms**

This is platform-agnostic — affects Linux, macOS, and WSL equally since `Write`/`Edit` are API-level file operations, not shell commands.

## Files Changed (11 files, 20 insertions, 18 deletions)

| File | Lines | Change |
|------|-------|--------|
| `PAI/Components/Algorithm/v1.6.0.md` | 287, 664 | PRD creation path + PATH RULE warning |
| `PAI/SKILL.md` | 326, 703 | Same (built version of Algorithm) |
| `WorldThreatModelHarness/Workflows/UpdateModels.md` | 82, 86 | Save/write model paths |
| `WorldThreatModelHarness/SKILL.md` | 42 | Model storage reference |
| `Evals/Workflows/CreateUseCase.md` | 42, 100, 124, 176 | 4× Create file instructions |
| `Evals/Workflows/CreateJudge.md` | 36 | Create judge config |
| `Evals/Workflows/CompareModels.md` | 49 | Create comparison config |
| `Evals/Workflows/ComparePrompts.md` | 79 | Create comparison config |
| `Research/Workflows/ExtractAlpha.md` | 382, 385 | Scratch workspace + history paths |
| `Agents/AgentProfileSystem.md` | 184 | Agent profile creation |
| `PAI/THEHOOKSYSTEM.md` | 163 | Ratings write path |

## What Was NOT Changed

- **Shell commands** (`mkdir -p ~/.claude/...` in bash blocks) — shell correctly expands `~`
- **Read-only references** (`Read ~/.claude/...`) — Read tool handles `~` correctly
- **TypeScript code** — already uses `homedir()` + `join()` via `paths.ts`
- **User-facing documentation** — `~` is fine in human-readable contexts

## Testing

```bash
# Verify no Write-facing tilde paths remain in v3.0 skills:
cd Releases/v3.0/.claude/skills
grep -rn '~/.claude/' --include='*.md' | grep -iE '(create|write|save|work in)' | grep -v '```bash' | grep -v 'mkdir'
# Should return 0 results
```

## Related

- Relates to #699 (tilde path expansion in `plansDirectory` setting)
- #699 addresses the installer/settings.json side; this PR addresses the AI-facing markdown instruction side

🤖 Generated with [Claude Code](https://claude.com/claude-code)