### PR TITLE
feat: Add PAI_SKIP_WORK_CREATION env var for headless sessions

### DIFF
--- a/Releases/v3.0/.claude/hooks/AutoWorkCreation.hook.ts
+++ b/Releases/v3.0/.claude/hooks/AutoWorkCreation.hook.ts
@@ -279,6 +279,13 @@ async function main() {
       process.exit(0);
     }
 
+    // Allow headless/automated sessions to opt out of WORK directory creation.
+    // Useful for cron jobs, CI pipelines, or any non-interactive session where
+    // the session's own logging is the record-of-truth.
+    if (process.env.PAI_SKIP_WORK_CREATION === '1') {
+      process.exit(0);
+    }
+
     if (!existsSync(WORK_DIR)) mkdirSync(WORK_DIR, { recursive: true });
 
     let currentWork = readCurrentWork(sessionId);


### PR DESCRIPTION
## Summary

Adds a `PAI_SKIP_WORK_CREATION=1` environment variable check to `AutoWorkCreation.hook.ts` that lets automated sessions skip WORK directory creation entirely.

**Motivation:** When running PAI sessions from cron jobs, CI pipelines, or background workers, each invocation creates a `MEMORY/WORK/` directory with META.yaml and PRD stubs that never get used — the session's own logging (cron logs, CI artifacts) is the record-of-truth. Over time this creates significant directory clutter.

**Usage:** Set `PAI_SKIP_WORK_CREATION=1` in the environment before launching `claude -p`. The hook exits cleanly before creating any WORK artifacts.

## Test plan

- [ ] Run a session with `PAI_SKIP_WORK_CREATION=1` — confirm no WORK directory created
- [ ] Run a session without the env var — confirm normal WORK directory creation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)