### PR TITLE
fix: pass empty quoted strings for --tools and --setting-sources in Inference.ts

### DIFF
--- a/Releases/v2.3/.claude/skills/CORE/Tools/Inference.ts
+++ b/Releases/v2.3/.claude/skills/CORE/Tools/Inference.ts
@@ -76,9 +76,9 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
     const args = [
       '--print',
       '--model', config.model,
-      '--tools', '',  // Disable tools for faster response
+      '--tools', '""',  // Disable tools for faster response
       '--output-format', 'text',
-      '--setting-sources', '',  // Disable hooks to prevent recursion
+      '--setting-sources', '""',  // Disable hooks to prevent recursion
       '--system-prompt', options.systemPrompt,
       options.userPrompt,
     ];

--- a/Releases/v2.4/.claude/skills/CORE/Tools/Inference.ts
+++ b/Releases/v2.4/.claude/skills/CORE/Tools/Inference.ts
@@ -76,9 +76,9 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
     const args = [
       '--print',
       '--model', config.model,
-      '--tools', '',  // Disable tools for faster response
+      '--tools', '""',  // Disable tools for faster response
       '--output-format', 'text',
-      '--setting-sources', '',  // Disable hooks to prevent recursion
+      '--setting-sources', '""',  // Disable hooks to prevent recursion
       '--system-prompt', options.systemPrompt,
       options.userPrompt,
     ];

--- a/Releases/v2.5/.claude/skills/PAI/Tools/Inference.ts
+++ b/Releases/v2.5/.claude/skills/PAI/Tools/Inference.ts
@@ -76,9 +76,9 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
     const args = [
       '--print',
       '--model', config.model,
-      '--tools', '',  // Disable tools for faster response
+      '--tools', '""',  // Disable tools for faster response
       '--output-format', 'text',
-      '--setting-sources', '',  // Disable hooks to prevent recursion
+      '--setting-sources', '""',  // Disable hooks to prevent recursion
       '--system-prompt', options.systemPrompt,
       options.userPrompt,
     ];

--- a/Releases/v3.0/.claude/skills/PAI/Tools/Inference.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/Inference.ts
@@ -76,9 +76,9 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
     const args = [
       '--print',
       '--model', config.model,
-      '--tools', '',  // Disable tools for faster response
+      '--tools', '""',  // Disable tools for faster response
       '--output-format', 'text',
-      '--setting-sources', '',  // Disable hooks to prevent recursion
+      '--setting-sources', '""',  // Disable hooks to prevent recursion
       '--system-prompt', options.systemPrompt,
     ];
 


### PR DESCRIPTION
## Summary

- `--tools` and `--setting-sources` flags in `Inference.ts` receive `''` (empty string), which on some systems results in the flag getting no value at all — causing subprocess hangs and argument parsing issues
- Changed to `'""'` (literal empty double-quotes) so the flags explicitly receive an empty value across all platforms
- Applied to all release versions: v2.3, v2.4, v2.5, v3.0

## Problem

When `Bun.spawn` passes `['--tools', '']` to the `claude` CLI, some systems interpret the empty string as a missing argument rather than an explicit empty value. This can cause:
- The next flag (`--output-format`) to be consumed as the value for `--tools`
- Subprocess hangs waiting for input
- Unpredictable argument parsing behavior

## Fix

```diff
-      '--tools', '',  // Disable tools for faster response
+      '--tools', '""',  // Disable tools for faster response
       '--output-format', 'text',
-      '--setting-sources', '',  // Disable hooks to prevent recursion
+      '--setting-sources', '""',  // Disable hooks to prevent recursion
```

## Test plan

- [ ] Verify `Inference.ts` runs without subprocess hangs on macOS
- [ ] Verify `--tools` and `--setting-sources` are correctly disabled (no tools loaded, no hooks fired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)