### PR TITLE
fix(SECUpdates): use direct WebFetch instead of agent spawning for source fetching

### DIFF
--- a/Releases/v3.0/.claude/skills/SECUpdates/SKILL.md
+++ b/Releases/v3.0/.claude/skills/SECUpdates/SKILL.md
@@ -173,15 +173,18 @@ cat ~/.claude/skills/SECUpdates/State/last-check.json
 
 ### Step 2: Fetch Sources (Parallel)
 
-Launch parallel agents to fetch each source:
+Fetch all sources using direct parallel WebFetch calls (do NOT spawn agents via the Task tool — WebFetch is instant, agents add 10s+ overhead per source and can silently stall):
 
-| Agent | Source | Method |
-|-------|--------|--------|
-| Agent 1 | tldrsec.com | WebFetch latest newsletter |
-| Agent 2 | no.security | WebFetch recent posts |
-| Agent 3 | krebsonsecurity.com | WebFetch recent articles |
-| Agent 4 | thehackernews.com | WebFetch headlines |
-| Agent 5 | schneier.com | WebFetch recent posts |
+| Source | Method |
+|--------|--------|
+| tldrsec.com | WebFetch latest newsletter |
+| no.security | WebFetch recent posts |
+| krebsonsecurity.com | WebFetch recent articles |
+| thehackernews.com | WebFetch headlines |
+| schneier.com | WebFetch recent posts |
+| risky.biz | WebFetch recent episodes/news |
+
+**Implementation note:** Call WebFetch directly in batches of 2-3. Do not spawn agents via the Task tool for fetching — WebFetch returns in seconds while agent spawning adds 10-15 seconds per source and can hang indefinitely without visible output.
 
 ### Step 3: Parse & Categorize
 

--- a/Releases/v3.0/.claude/skills/SECUpdates/Workflows/Update.md
+++ b/Releases/v3.0/.claude/skills/SECUpdates/Workflows/Update.md
@@ -14,7 +14,9 @@ Determine the last check timestamp to filter for new content only.
 
 ### 2. Fetch Sources (Parallel)
 
-Launch parallel WebFetch requests to all sources:
+Fetch all sources using direct parallel WebFetch calls in batches of 2-3:
+
+> **Important:** Use the WebFetch tool directly — do NOT spawn agents via the Task tool for source fetching. Agent spawning adds 10-15 seconds of overhead per source and can silently hang, while direct WebFetch calls complete in 2-5 seconds each.
 
 ```
 Source 1: https://tldrsec.com


### PR DESCRIPTION
## Summary
- Replace "Launch parallel agents" guidance in SKILL.md with direct WebFetch calls
- Add explicit anti-agent note to Update.md workflow
- Add risky.biz to SKILL.md source table (was in sources list but missing from Step 2)

## Problem
The SECUpdates SKILL.md Step 2 says "Launch parallel agents to fetch each source" with an "Agent 1/2/3..." table. This causes Claude to spawn Task agents for what should be direct WebFetch calls. Agent spawning adds 10-15 seconds overhead per source (permission prompts, context building, subprocess startup) and can silently hang — we observed a 17-minute stall with zero visible output.

## Fix
Replace agent language with direct WebFetch guidance and add an explicit implementation note. WebFetch is a direct tool call that returns in 2-5 seconds. Fetching 6 sources via direct WebFetch in two batches of 3 completes in under 15 seconds total vs. potentially unbounded with agents.

## Test plan
- [x] Ran SECUpdates with direct WebFetch: 6 sources, 32 items, ~15 seconds total
- [x] Confirmed no silent stalls
- [x] Output matches expected format from SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)