### PR TITLE
feat(council): Add file-first output and recovery mode

### DIFF
--- a/Releases/v3.0/.claude/skills/Council/SKILL.md
+++ b/Releases/v3.0/.claude/skills/Council/SKILL.md
@@ -93,7 +93,7 @@ Running the **WorkflowName** workflow in the **Council** skill to ACTION...
 -> DEBATE with Security agent added
 
 "Council recovery: Resume session 20260202-143052-a1b2c3d4"
--> RECOVERY workflow -> Continue from checkpoint
+-> RECOVERY workflow (partial rerun) -> Continue from checkpoint
 ```
 
 ## Integration

--- a/Releases/v3.0/.claude/skills/Council/Workflows/Debate.md
+++ b/Releases/v3.0/.claude/skills/Council/Workflows/Debate.md
@@ -99,7 +99,9 @@ Your perspective focuses on: [agent's domain]
 **Write Round 1 to file:**
 ```bash
 # Write combined Round 1 output to session directory
-echo "[Round 1 content]" > ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-1.md
+cat <<'EOF' > ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-1.md
+[Round 1 content]
+EOF
 ```
 
 ### Step 3: Round 2 - Responses & Challenges
@@ -129,7 +131,9 @@ The value is in genuine intellectual friction—engage with their actual argumen
 
 **Write Round 2 to file:**
 ```bash
-echo "[Round 2 content]" > ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-2.md
+cat <<'EOF' > ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-2.md
+[Round 2 content]
+EOF
 ```
 
 **Output:**
@@ -175,7 +179,9 @@ Be honest about remaining disagreements—forced consensus is worse than acknowl
 
 **Write Round 3 to file:**
 ```bash
-echo "[Round 3 content]" > ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-3.md
+cat <<'EOF' > ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-3.md
+[Round 3 content]
+EOF
 ```
 
 **Output:**
@@ -219,7 +225,7 @@ After all rounds complete, synthesize the debate:
 After synthesis, archive the complete session:
 
 ```bash
-TOPIC_SLUG=$(echo "[topic]" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | cut -c1-50)
+TOPIC_SLUG=$(echo "[topic]" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | tr -s '-' | sed 's/^-//;s/-$//' | cut -c1-50)
 TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
 MONTH=$(date +%Y-%m)
 mkdir -p ~/.claude/MEMORY/RESEARCH/$MONTH
@@ -233,7 +239,10 @@ cat ~/.claude/MEMORY/STATE/council-sessions/$SESSION_ID/round-1.md \
 
 If the council is interrupted (rate limit, timeout):
 1. Session state is preserved in `~/.claude/MEMORY/STATE/council-sessions/{SESSION_ID}/`
-2. Use Recovery workflow to resume: `"Council recovery: Resume session {SESSION_ID}"`
+2. Use the Recovery workflow to resume with one of:
+   - `"Council recovery: Resume session {SESSION_ID}"` (defaults to partial rerun)
+   - `"Council recovery (partial): Resume session {SESSION_ID}"`
+   - `"Council recovery (full rerun): {topic}"`
 3. See `Workflows/Recovery.md` for details
 
 ## Custom Council Members

--- a/Releases/v3.0/.claude/skills/Council/Workflows/Recovery.md
+++ b/Releases/v3.0/.claude/skills/Council/Workflows/Recovery.md
@@ -21,7 +21,7 @@ Running the **Recovery** workflow in the **Council** skill to resume interrupted
 
 ## Prerequisites
 
-- Session ID or session directory path
+- Session ID (the workflow resolves this to a session directory under `~/.claude/MEMORY/STATE/council-sessions/`)
 - Prior round outputs (partial or complete)
 - Knowledge of which agents completed / which didn't
 
@@ -49,11 +49,19 @@ Keep completed agent outputs, only rerun missing agents.
 
 **Invoke:** `"Council recovery (partial): Resume session {session-id}"`
 
+### Short Form (Alias)
+
+`"Council recovery: Resume session {session-id}"` — defaults to partial rerun.
+
 ## Execution
 
 ### Step 1: Load Session State
 
-**Session ID validation:** Before using a session ID in file paths, validate it matches the expected format `YYYYMMDD-HHMMSS-[hex]` (e.g., `20260202-235539-a1b2c3d4`). Reject IDs containing path traversal characters (`/`, `\`, `..`).
+**Session ID and path handling:** The session root is a fixed base directory: `~/.claude/MEMORY/STATE/council-sessions/`.
+- Only accept **session IDs**, not arbitrary directory paths.
+- Validate the ID matches the expected format `YYYYMMDD-HHMMSS-[hex]` (e.g., `20260202-235539-a1b2c3d4`).
+- Reject IDs containing path traversal characters (`/`, `\`, `..`).
+- Always resolve the session directory as `{session-root}/{session-id}/` — never allow user-provided absolute paths.
 
 Read the session directory:
 ```


### PR DESCRIPTION
## Summary

Adds resilient session state to Council debates, rebased from #567 to v3.0 paths.

- **File-First Output** — Each round is written to `~/.claude/MEMORY/STATE/council-sessions/{session-id}/` as it completes, surviving context compaction and rate limits
- **Recovery Workflow** — New `Workflows/Recovery.md` supports full and partial rerun modes for interrupted sessions
- **Session Archival** — Completed debates archived to `~/.claude/MEMORY/RESEARCH/`

### What's NOT included (intentionally)

Per maintainer feedback on #567, this PR focuses on infrastructure resilience only. The following from #567 are excluded as separate concerns:

- Adaptive rounds (separate behavioral change)
- Model tiering (separate cost optimization)
- Patchlist mode (filed as separate PR)
- Config.md (not needed without the above)
- Version bump / changelog (left to maintainers)

## Files Changed

| File | Change |
|------|--------|
| `Releases/v3.0/.claude/skills/Council/SKILL.md` | Added recovery routing, resilience philosophy, recovery example |
| `Releases/v3.0/.claude/skills/Council/Workflows/Debate.md` | Added session init (Step 0), file writes per round, archival step, interruption handling |
| `Releases/v3.0/.claude/skills/Council/Workflows/Recovery.md` | **New** — Full and partial rerun modes with session ID validation |

## Test plan

- [ ] Run a council debate and verify files written to `~/.claude/MEMORY/STATE/council-sessions/`
- [ ] Interrupt a session mid-round, then use Recovery workflow to resume
- [ ] Verify archived output appears in `~/.claude/MEMORY/RESEARCH/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)