### PR TITLE
feat(algorithm): add Designer Intent check to THINK pressure test

### DIFF
--- a/Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.8.0.md
+++ b/Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.8.0.md
@@ -177,6 +177,7 @@ For each extracted constraint [EX-N], state which ISC criterion covers it:
 - [CAPABILITY] What capability would sharpen the Ideal State Criteria right now?
 - [CONSTRAINT COVERAGE (v1.3.0)] Re-examine extracted constraints [EX-N]. Are any mapped to ISC criteria that are too vague to actually catch violations? Would a concrete violation of EX-{N} pass through ISC-C{M} undetected?
 - [SELF-INTERROGATION (v1.3.0)] "Am I about to build something that violates my own criteria? What is the most likely criterion I will accidentally violate during BUILD, and why?" Name it explicitly.
+- [DESIGNER INTENT (v1.8.1)] For each proposed change to existing design, state in one sentence why the original designer likely made that choice. If you cannot articulate a plausible reason, you do not understand the design well enough to change it.
 - [UPDATE] Based on above: add, modify, or remove criteria. If no changes, state why they hold.
 
 🔍 **VERIFICATION REHEARSAL (v1.3.0 — Extended+ effort level ONLY. Skip at Standard and below.):**


### PR DESCRIPTION
## Summary

- Adds a `[DESIGNER INTENT]` bullet to THINK's PRESSURE TEST section (~30 words)
- Before proposing changes to existing design, the assistant must articulate why the original designer likely made that choice
- If a plausible reason cannot be stated, the design is not understood well enough to change

## Motivation

The Algorithm's OBSERVE self-interrogation asks "did I capture what the user wants?" and THINK's pressure test challenges assumptions — but neither checks whether the assistant understands **why existing systems are designed the way they are** before proposing changes.

This creates a blind spot: when the task involves modifying, optimizing, or refactoring existing work, the Algorithm can propose changes that break intentional design decisions.

**Real example:** While analyzing the Algorithm itself for context optimization, the assistant identified the Quality Gate block appearing 3 times and proposed removing the "duplicates" — missing that the inline copies serve as positional reinforcement (LLMs attend more strongly to instructions near the point of application). The user caught it; the Algorithm didn't.

This is Chesterton's Fence applied to the Algorithm: don't remove a fence until you understand why it was built.

## Changes

One line added to `Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.8.0.md`:

```
- [DESIGNER INTENT (v1.8.1)] For each proposed change to existing design,
  state in one sentence why the original designer likely made that choice.
  If you cannot articulate a plausible reason, you do not understand the
  design well enough to change it.
```

Positioned after `[SELF-INTERROGATION]` and before `[UPDATE]` in the pressure test sequence.

## Design decisions

- **~30 words** — minimal context cost for significant safety improvement
- **Triggers only for modification tasks** — no overhead on greenfield work
- **Complements existing checks** — ASSUMPTION challenges beliefs, PRE-MORTEM imagines failures, DESIGNER INTENT prevents misunderstanding existing design
- **Tagged v1.8.1** — follows existing versioning convention (v1.3.0 tags on CONSTRAINT COVERAGE and SELF-INTERROGATION)

## Test plan

- [ ] Verify the bullet renders correctly in the Algorithm output during THINK phase
- [ ] Confirm it triggers on modification/refactoring tasks
- [ ] Confirm it does not add overhead on greenfield/new-build tasks
- [ ] Verify it catches the QG deduplication scenario described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)