### PR TITLE
fix(telos): update UpdateTelos.ts paths for v3.0 directory structure

### DIFF
--- a/Releases/v3.0/.claude/skills/Telos/Tools/UpdateTelos.ts
+++ b/Releases/v3.0/.claude/skills/Telos/Tools/UpdateTelos.ts
@@ -19,7 +19,7 @@
  * - CHALLENGES.md - Current challenges
  * - FRAMES.md - Mental frames and perspectives
  * - GOALS.md - Life goals
- * - LESSONS.md - Lessons learned
+ * - LEARNED.md - Lessons learned
  * - MISSION.md - Life mission
  * - MODELS.md - Mental models
  * - MOVIES.md - Favorite movies
@@ -37,15 +37,16 @@
 import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { getPrincipal } from '../../../hooks/lib/identity';
+import { paiPath } from '../../../hooks/lib/paths';
 
-const TELOS_DIR = join(process.env.HOME!, '.claude', 'context', 'life', 'telos');
-const BACKUPS_DIR = join(TELOS_DIR, 'backups');
+const TELOS_DIR = paiPath('skills', 'PAI', 'USER', 'TELOS');
+const BACKUPS_DIR = join(TELOS_DIR, 'Backups');
 const UPDATES_FILE = join(TELOS_DIR, 'updates.md');
 
 // Valid TELOS files
 const VALID_FILES = [
   'BELIEFS.md', 'BOOKS.md', 'CHALLENGES.md', 'FRAMES.md', 'GOALS.md',
-  'LESSONS.md', 'MISSION.md', 'MODELS.md', 'MOVIES.md', 'NARRATIVES.md',
+  'LEARNED.md', 'MISSION.md', 'MODELS.md', 'MOVIES.md', 'NARRATIVES.md',
   'PREDICTIONS.md', 'PROBLEMS.md', 'PROJECTS.md', 'STRATEGIES.md',
   'TELOS.md', 'TRAUMAS.md', 'WISDOM.md', 'WRONG.md'
 ];


### PR DESCRIPTION
## Problem

\`UpdateTelos.ts\` references \`.claude/context/life/telos\` — a path that has never matched the actual Telos location. This causes the backup system to silently fail with file-not-found errors.

This bug exists in all releases (v2.3 through v3.0). In v3.0, Telos lives at \`skills/PAI/USER/TELOS/\` (relative to PAI_DIR).

## Changes

**File:** \`Releases/v3.0/.claude/skills/Telos/Tools/UpdateTelos.ts\`

| What | Before | After |
|------|--------|-------|
| \`TELOS_DIR\` | hardcoded \`$HOME/.claude/context/life/telos\` | \`paiPath('skills', 'PAI', 'USER', 'TELOS')\` — uses \`PAI_DIR\` env var or \`~/.claude\` |
| \`BACKUPS_DIR\` | \`backups/\` (lowercase) | \`Backups/\` (capitalized, consistent with v3.0 conventions) |
| \`VALID_FILES\` + docstring | \`LESSONS.md\` | \`LEARNED.md\` (actual filename in v3.0) |

## Why use paiPath()?

\`paths.ts\` provides \`paiPath()\` which resolves paths relative to \`PAI_DIR\` env var (with \`~/.claude\` fallback). Using it instead of \`process.env.HOME + '.claude'\` makes the script portable and consistent with the rest of the codebase.

## Why only v3.0?

Earlier releases (v2.3–v2.5) also have the broken path but fixing them would change historical releases. v3.0 is the current release users install — that's where the fix matters.

## Testing

Verified locally — \`bun UpdateTelos.ts\` correctly creates backups and appends to \`updates.md\`.