### PR TITLE
fix(DocCrossRefIntegrity): use fast/haiku inference tier as documented

### DIFF
--- a/Releases/v3.0/.claude/hooks/handlers/DocCrossRefIntegrity.ts
+++ b/Releases/v3.0/.claude/hooks/handlers/DocCrossRefIntegrity.ts
@@ -566,9 +566,9 @@ async function runInferenceAnalysis(
     const result = await inference({
       systemPrompt: INFERENCE_SYSTEM_PROMPT,
       userPrompt: `Analyze these source file changes and documentation sections for factual inaccuracies:\n\n${context}`,
-      level: 'standard',
+      level: 'fast',
       expectJson: true,
-      timeout: 15000, // Sonnet needs more time but produces better quality
+      timeout: 15000,
     });
 
     const elapsed = Date.now() - startTime;


### PR DESCRIPTION
## Summary

- `runInferenceAnalysis()` in `DocCrossRefIntegrity.ts` has a docstring that explicitly states it uses the **fast tier (Haiku, ~500ms)**, but the implementation calls `inference({ level: 'standard' })` (Sonnet) with a comment noting Sonnet's slower speed
- This PR fixes the implementation to match the documented intent by changing `level: 'standard'` → `level: 'fast'`
- The 15s timeout is retained (fast/Haiku tier default is also 15s, so this is a safe ceiling)

## Change

```diff
- level: 'standard',
+ level: 'fast',
  expectJson: true,
- timeout: 15000, // Sonnet needs more time but produces better quality
+ timeout: 15000,
```

## Test plan

- [ ] Verify `DocCrossRefIntegrity` hook runs successfully after a session with modified system files
- [ ] Confirm inference completes faster (Haiku vs Sonnet latency)
- [ ] Confirm JSON output shape is unchanged (fast tier still returns parseable edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)