### PR TITLE
Merge duplicate first-principles rules in SYSTEM AISTEERINGRULES

### DIFF
--- a/Releases/v3.0/.claude/skills/PAI/AISTEERINGRULES.md
+++ b/Releases/v3.0/.claude/skills/PAI/AISTEERINGRULES.md
@@ -2,10 +2,10 @@
 
 Universal behavioral rules for PAI. Mandatory. Personal customizations in `USER/AISTEERINGRULES.md` extend and override these.
 
-## First principles and elegant problem-solving
-**Statement:** Don't just randomly add bolt-on solutions for things when the user complains about something. Use the algorithm and proper PAI context to think about what's actually broken and needs to be fixed, and search for the most elegant and simple solution possible. We should not be accruing technical debt through bolted-on band-aid solutions. 
-**Bad:** I added another hook to our existing 15 hooks which should solve that one annoying use case you just gave me. 
-**Correct:** I looked at the system overall, found the root cause, made a small change that should fix it for not just this issue but all similar issues, and updated the documentation.
+## First Principles, Simplicity, and Elegant Problem-Solving
+**Statement:** Most problems are symptoms. Think root cause. Don't randomly add bolt-on solutions — search for the most elegant and simple fix. Simplify > add. Order: Understand → Simplify → Reduce → Add (last resort). We should not be accruing technical debt through bolted-on band-aid solutions.
+**Bad:** Page slow → add caching, monitoring. Actual issue: bad SQL. Or: add another hook to existing 15 hooks to solve one annoying use case.
+**Correct:** Profile → find root cause → fix query or make a small change that fixes this issue and all similar issues. No new components. Update documentation.
 
 ## Build ISC From Every Request
 **Statement:** Decompose every request into Ideal State Criteria before acting. Read entire request, session context, PAI context. Turn each component (including negatives) into verifiable criteria.
@@ -71,12 +71,6 @@ Universal behavioral rules for PAI. Mandatory. Personal customizations in `USER/
 **Statement:** For clarifying questions, use AskUserQuestion with structured options.
 **Bad:** Write prose questions: "1. A or B? 2. X or Y?"
 **Correct:** Use tool with choices. User selects quickly.
-
-## First Principles and Simplicity
-**Statement:** Most problems are symptoms. Think root cause. Simplify > add.
-**Bad:** Page slow → add caching, monitoring. Actual issue: bad SQL.
-**Correct:** Profile → fix query. No new components.
-**Order:** Understand → Simplify → Reduce → Add (last resort).
 
 ## Use PAI Inference Tool
 **Statement:** For AI inference, use `Tools/Inference.ts` (fast/standard/smart), not direct API.


### PR DESCRIPTION
## Summary

- The SYSTEM `AISTEERINGRULES.md` file contains two rules that both target first-principles thinking:
  1. **"First principles and elegant problem-solving"** (line 5) — focuses on avoiding bolt-on solutions
  2. **"First Principles and Simplicity"** (line 75) — focuses on root-cause thinking with the "Understand → Simplify → Reduce → Add" order
- These are merged into a single rule that preserves all unique guidance from both
- Net result: one fewer instruction competing for model attention in the always-loaded steering rules

## Motivation

PAI's steering rules are loaded on every request. Duplicate rules waste tokens and create ambiguity about which rule governs first-principles behavior. Since both rules target the same concept with complementary examples, merging them into one comprehensive rule reduces instruction count without losing any behavioral guidance.

## Test plan

- [x] Verify merged rule preserves the "Understand → Simplify → Reduce → Add" order from the second rule
- [x] Verify merged rule preserves the anti-bolt-on/technical-debt guidance from the first rule
- [x] Verify both Bad/Correct examples are represented in the merged version
- [x] Verify no other rules reference either original by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)