### PR TITLE
docs(v3): fix broken install guide link in .claude README

### DIFF
--- a/Releases/v3.0/.claude/README.md
+++ b/Releases/v3.0/.claude/README.md
@@ -36,6 +36,6 @@ The `pai` command displays the PAI banner, announces your AI's startup catchphra
 
 ## Documentation
 
-- **[INSTALL.md](INSTALL.md)** — Detailed installation guide
+- **[PAI-Install/README.md](PAI-Install/README.md)** — Detailed installation guide
 - **[skills/PAI/SKILL.md](skills/PAI/SKILL.md)** — Full system documentation
 - **[github.com/danielmiessler/PAI](https://github.com/danielmiessler/PAI)** — Source repository


### PR DESCRIPTION
Noticed this while getting set up — .claude/README.md has a link to INSTALL.md which doesn't exist in v3.0. Looks like it was carried over from an earlier release. Updated to point to PAI-Install/README.md which is the correct v3.0 install guide.