### PR TITLE
fix(statusline): read timezone from settings.json instead of hardcoding

### DIFF
--- a/Releases/v3.0/.claude/statusline-command.sh
+++ b/Releases/v3.0/.claude/statusline-command.sh
@@ -69,6 +69,10 @@ DA_NAME="${DA_NAME:-Assistant}"
 PAI_VERSION=$(jq -r '.pai.version // "—"' "$SETTINGS_FILE" 2>/dev/null)
 PAI_VERSION="${PAI_VERSION:-—}"
 
+# Get principal timezone from settings (fallback to America/Los_Angeles for backwards compat)
+TZ_NAME=$(jq -r '.principal.timezone // "America/Los_Angeles"' "$SETTINGS_FILE" 2>/dev/null)
+TZ_NAME="${TZ_NAME:-America/Los_Angeles}"
+
 # Get Algorithm version from LATEST file (single source of truth)
 ALGO_LATEST_FILE="$PAI_DIR/skills/PAI/Components/Algorithm/LATEST"
 if [ -f "$ALGO_LATEST_FILE" ]; then
@@ -650,7 +654,7 @@ try:
         dt = datetime.fromisoformat(ts + '+00:00')
     # Convert to Pacific
     from zoneinfo import ZoneInfo
-    local_dt = dt.astimezone(ZoneInfo('America/Los_Angeles'))
+    local_dt = dt.astimezone(ZoneInfo('$TZ_NAME'))
     if '$fmt' == 'weekly':
         day = local_dt.strftime('%a')
         hour = local_dt.strftime('%H:%M')
@@ -920,7 +924,7 @@ def time_until(ts):
 def clock_time(ts, fmt):
     dt = parse_ts(ts)
     if not dt: return ''
-    local_dt = dt.astimezone(ZoneInfo('America/Los_Angeles'))
+    local_dt = dt.astimezone(ZoneInfo('$TZ_NAME'))
     if fmt == 'weekly':
         return local_dt.strftime('%a %H:%M')
     return local_dt.strftime('%H:%M')


### PR DESCRIPTION
## Summary

Reads `principal.timezone` from `settings.json` (with fallback to `America/Los_Angeles`) and passes it to the two Python timezone conversion blocks in the statusline script.

## Problem

The statusline script hardcodes `ZoneInfo('America/Los_Angeles')` in two places, causing reset times and clock displays to show Pacific time regardless of user's configured timezone.

## Fix

- Read `TZ_NAME` from `settings.json → principal.timezone` at startup
- Pass it into both Python `clock_time` / `format_reset_time` blocks
- Fallback to `America/Los_Angeles` if not configured (backwards compatible)

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)