### PR TITLE
fix(statusline): read timezone from settings.json instead of hardcoding

### DIFF
--- a/Releases/v3.0/.claude/statusline-command.sh
+++ b/Releases/v3.0/.claude/statusline-command.sh
@@ -69,6 +69,10 @@ DA_NAME="${DA_NAME:-Assistant}"
 PAI_VERSION=$(jq -r '.pai.version // "—"' "$SETTINGS_FILE" 2>/dev/null)
 PAI_VERSION="${PAI_VERSION:-—}"
 
+# Get user timezone from settings (for reset time display)
+USER_TZ=$(jq -r '.principal.timezone // empty' "$SETTINGS_FILE" 2>/dev/null)
+USER_TZ="${USER_TZ:-UTC}"
+
 # Get Algorithm version from LATEST file (single source of truth)
 ALGO_LATEST_FILE="$PAI_DIR/skills/PAI/Components/Algorithm/LATEST"
 if [ -f "$ALGO_LATEST_FILE" ]; then
@@ -648,9 +652,9 @@ try:
         dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
     else:
         dt = datetime.fromisoformat(ts + '+00:00')
-    # Convert to Pacific
+    # Convert to user timezone from settings.json
     from zoneinfo import ZoneInfo
-    local_dt = dt.astimezone(ZoneInfo('America/Los_Angeles'))
+    local_dt = dt.astimezone(ZoneInfo('$USER_TZ'))
     if '$fmt' == 'weekly':
         day = local_dt.strftime('%a')
         hour = local_dt.strftime('%H:%M')
@@ -920,7 +924,7 @@ def time_until(ts):
 def clock_time(ts, fmt):
     dt = parse_ts(ts)
     if not dt: return ''
-    local_dt = dt.astimezone(ZoneInfo('America/Los_Angeles'))
+    local_dt = dt.astimezone(ZoneInfo('$USER_TZ'))
     if fmt == 'weekly':
         return local_dt.strftime('%a %H:%M')
     return local_dt.strftime('%H:%M')


### PR DESCRIPTION
## Summary

- Replaces hardcoded `America/Los_Angeles` timezone in `statusline-command.sh` with dynamic read from `settings.json` (`principal.timezone`)
- Falls back to UTC if no timezone is configured
- Affects both `reset_clock_time()` (line ~653) and inline `clock_time()` (line ~923)

The comment on line 596 already says "Uses TZ from settings.json" — this PR makes the code match the comment.

Closes #734

## Test plan

- [ ] Verify reset times display in configured timezone (e.g., `Europe/Berlin`)
- [ ] Verify fallback to UTC when `principal.timezone` is not set
- [ ] Verify no regression in `time_until` calculations (those use UTC diff, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)