### PR TITLE
fix(installer): resolve tilde in plansDirectory during upgrade

### DIFF
--- a/Releases/v3.0/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v3.0/.claude/PAI-Install/engine/actions.ts
@@ -446,6 +446,10 @@ export async function runConfiguration(
       if (!existing.permissions) existing.permissions = config.permissions;
       if (!existing.contextFiles) existing.contextFiles = config.contextFiles;
       if (!existing.plansDirectory) existing.plansDirectory = config.plansDirectory;
+      // Fix tilde paths that Node/Bun fs APIs can't resolve (v3.0.0 shipped with ~/)
+      if (existing.plansDirectory?.startsWith('~')) {
+        existing.plansDirectory = existing.plansDirectory.replace(/^~/, homedir());
+      }
       // Never touch: hooks, statusLine, spinnerVerbs, contextFiles (if present)
       writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
     } catch {


### PR DESCRIPTION
## Summary

- Adds retroactive tilde path sanitization in the installer's settings merge step
- Expands `~` to `homedir()` when `plansDirectory` starts with `~`
- Fixes the issue for existing v3.0 installs that still have `"~/.claude/Plans/"` baked in

The template was already fixed to `"Plans/"` in 16ccbe0, but the installer's merge logic only sets `plansDirectory` when it's missing — so users who installed before the fix keep the buggy value through upgrades. This patch catches it retroactively.

Closes #699

## Context

We found 5 stray literal `~` directory trees in our own installation across project folders. One contained an orphaned plan file. The fix is 4 lines using the already-imported `homedir` from `os`.

## Test plan

- [ ] Fresh install: verify `plansDirectory` is set to `"Plans/"` (no change)
- [ ] Upgrade from buggy v3.0: verify `"~/.claude/Plans/"` gets resolved to absolute path
- [ ] Verify plan files are created in the correct location after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)