### PR TITLE
fix(telos): remove reference to missing update-telos.ts script

### DIFF
--- a/Releases/v3.0/.claude/skills/Telos/Workflows/Update.md
+++ b/Releases/v3.0/.claude/skills/Telos/Workflows/Update.md
@@ -78,7 +78,7 @@ This is the main command you'll use. It takes three parameters:
 - Content to add (the actual text)
 - Description of the change (for the changelog)
 
-!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
+!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
 
 ## List Valid TELOS Files
 !`echo "Valid TELOS files:
@@ -140,7 +140,7 @@ Use the update-telos command with:
 
 Example:
 ```bash
-bun ~/.claude/commands/update-telos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
+bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "BOOKS.md" "- *Project Hail Mary* by Andy Weir" "Added favorite book: Project Hail Mary"
 ```
 
 ## Step 4: Confirm and Engage
@@ -286,7 +286,7 @@ The TypeScript implementation handles:
 - Content appending (preserves existing content)
 - Pacific Time timezone for consistency
 
-The script is at: `~/.claude/commands/update-telos.ts`
+The script is at: `~/.claude/skills/Telos/Tools/UpdateTelos.ts`
 
 All backups are stored in: `~/.claude/skills/PAI/USER/TELOS/Backups/`
 


### PR DESCRIPTION
## Summary

- The Telos Update workflow (`Releases/v3.0/.claude/skills/Telos/Workflows/Update.md`) references `~/.claude/commands/update-telos.ts`, but that path does not exist
- The actual implementation lives at `~/.claude/skills/Telos/Tools/UpdateTelos.ts` within the same skill directory
- Updated all three stale path references (command invocation, example, and documentation footer) to point to the correct `Tools/UpdateTelos.ts` location

Closes #752

## Test plan

- [ ] Verify the Update workflow's `bun` command invocation points to the correct `Tools/UpdateTelos.ts` path
- [ ] Confirm no remaining references to the non-existent `~/.claude/commands/update-telos.ts`
- [ ] Validate the script at `Tools/UpdateTelos.ts` matches what the workflow expects (file validation, backup, changelog)