### PR TITLE
fix(statusline): fix f-string syntax error silently breaking reset time display

### DIFF
--- a/Releases/v3.0/.claude/statusline-command.sh
+++ b/Releases/v3.0/.claude/statusline-command.sh
@@ -929,8 +929,8 @@ r5h = '$usage_5h_reset'
 r7d = '$usage_7d_reset'
 print(f\"reset_5h='{time_until(r5h)}'\")
 print(f\"reset_7d='{time_until(r7d)}'\")
-print(f\"clock_5h='{clock_time(r5h, \"hourly\")}'\")
-print(f\"clock_7d='{clock_time(r7d, \"weekly\")}'\")
+print(f\"clock_5h='{clock_time(r5h, 'hourly')}'\")
+print(f\"clock_7d='{clock_time(r7d, 'weekly')}'\")
 " 2>/dev/null)"
     reset_5h="${reset_5h:-—}"
     reset_7d="${reset_7d:-—}"


### PR DESCRIPTION
## Summary

- Fixes a Python f-string `SyntaxError` in the batch usage reset time eval that silently breaks all four reset-time variables (`reset_5h`, `reset_7d`, `clock_5h`, `clock_7d`) for **all users with valid OAuth tokens**
- The error is swallowed by `2>/dev/null`, so users see `↻—` instead of a real reset time with no indication anything is wrong

Closes #779

## Root Cause

```python
# Before — SyntaxError: double quotes inside double-quoted f-string (Python < 3.12)
print(f"clock_5h='{clock_time(r5h, "hourly")}'")
print(f"clock_7d='{clock_time(r7d, "weekly")}'")
```

Because the entire `python3 -c "..."` invocation is wrapped in `2>/dev/null`, the `SyntaxError` is silently discarded. The `eval` receives no output, all variables stay empty, and the statusline falls back to `—` for every reset time.

## Fix

```python
# After — single quotes inside double-quoted f-string, valid Python 3.6+
print(f"clock_5h='{clock_time(r5h, 'hourly')}'")
print(f"clock_7d='{clock_time(r7d, 'weekly')}'")
```

Single-quoted string literals inside a `f"..."` f-string are valid since Python 3.6. No behavior change — just fixes the silent crash.

## Test Plan

- [ ] Confirm `reset_5h` and `reset_7d` are populated after the eval (e.g. `4h32m`, `2d23h`)
- [ ] Confirm statusline usage line shows `↻4h32m` instead of `↻—`
- [ ] Verify no regression when OAuth token is absent (falls back to `—` as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)