### PR TITLE
fix: surface PAI Tools into session context + self-heal skill-index.json

### DIFF
--- a/Releases/v3.0/.claude/hooks/LoadContext.hook.ts
+++ b/Releases/v3.0/.claude/hooks/LoadContext.hook.ts
@@ -539,7 +539,7 @@ async function main() {
     if (!existsSync(skillIndexPath)) {
       console.error('🔍 skill-index.json missing — regenerating...');
       try {
-        execSync('bun ~/.claude/skills/PAI/Tools/GenerateSkillIndex.ts', {
+        execSync(`bun "${join(paiDir, 'skills/PAI/Tools/GenerateSkillIndex.ts')}"`, {
           cwd: paiDir,
           stdio: 'pipe',
           timeout: 5000

--- a/Releases/v3.0/.claude/skills/PAI/Components/35-tools-inventory.md
+++ b/Releases/v3.0/.claude/skills/PAI/Components/35-tools-inventory.md
@@ -27,7 +27,7 @@ Core TypeScript utilities in `skills/PAI/Tools/`. Run with `bun ~/.claude/skills
 |------|---------|
 | `GetTranscript.ts` | Fetch YouTube video transcripts |
 | `ExtractTranscript.ts` | Extract and clean audio transcripts |
-| `Transcribe-bun.lock` | Lock file for audio transcription dependencies |
+| `TranscriptParser.ts` | Parse and structure raw transcript text into segments |
 | `PreviewMarkdown.ts` | Render markdown to terminal preview |
 | `Banner.ts` / `BannerNeofetch.ts` | Generate PAI startup banner variants |
 


### PR DESCRIPTION
Fixes #785

## Summary

- **Add `35-tools-inventory.md`** — Quick reference for ~20 core PAI Tools grouped by category, auto-slotted into SKILL.md by RebuildPAI.ts
- **Add self-healing guard in LoadContext.hook.ts** — Regenerates missing `skill-index.json` via `GenerateSkillIndex.ts` at session start, following the same pattern as the existing SKILL.md rebuild guard

## Test plan

- [ ] `grep "PAI Tools Quick Reference" ~/.claude/skills/PAI/SKILL.md` — found between components 30 and 40
- [ ] `wc -c ~/.claude/skills/PAI/SKILL.md` — ~84KB (was ~82KB, +1.7%)
- [ ] Delete `skill-index.json`, start new Claude Code session — "regenerating..." in stderr, file recreated
- [ ] Normal session start with `skill-index.json` present — no "regenerating" message, no perceptible overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)