### PR TITLE
fix(hooks): use shared getVoiceId() instead of hardcoded ElevenLabs Adam voice

### DIFF
--- a/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
+++ b/Releases/v3.0/.claude/hooks/AlgorithmTracker.hook.ts
@@ -24,6 +24,7 @@ import type { AlgorithmCriterion, AlgorithmPhase, AlgorithmState } from './lib/a
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { setPhaseTab } from './lib/tab-setter';
+import { getVoiceId } from './lib/identity';
 
 // ── Phase Detection from Voice Curls ──
 
@@ -192,7 +193,7 @@ async function main() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               message: `Re-entering algorithm. Rework iteration ${reworkNum}.`,
-              voice_id: process.env.PAI_VOICE_ID || 'pNInz6obpgDQGcFmaJgB',
+              voice_id: getVoiceId(),
             }),
           }).catch(() => {});
         } catch {}

--- a/Releases/v3.0/.claude/hooks/handlers/DocCrossRefIntegrity.ts
+++ b/Releases/v3.0/.claude/hooks/handlers/DocCrossRefIntegrity.ts
@@ -36,6 +36,7 @@ import { join, basename, dirname } from 'path';
 import { paiPath, getPaiDir } from '../lib/paths';
 import { inference } from '../../skills/PAI/Tools/Inference';
 import type { ParsedTranscript } from '../../skills/PAI/Tools/TranscriptParser';
+import { getVoiceId } from '../lib/identity';
 
 // ============================================================================
 // Types
@@ -363,7 +364,7 @@ async function notifyVoice(message: string): Promise<void> {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       signal: controller.signal,
-      body: JSON.stringify({ message, voice_id: process.env.PAI_VOICE_ID || 'pNInz6obpgDQGcFmaJgB' }),
+      body: JSON.stringify({ message, voice_id: getVoiceId() }),
     });
     clearTimeout(timeout);
   } catch {


### PR DESCRIPTION
## Summary
- Replace hardcoded ElevenLabs "Adam" voice ID (`pNInz6obpgDQGcFmaJgB`) with the shared `getVoiceId()` utility from `hooks/lib/identity.ts`
- Affects `AlgorithmTracker.hook.ts` (line 195) and `handlers/DocCrossRefIntegrity.ts` (line 366)
- Anyone not using the default ElevenLabs Adam voice currently gets incorrect voice notifications from these two hooks

## Details
The shared `getVoiceId()` utility already exists in `hooks/lib/identity.ts` and reads from `settings.json` with a proper fallback chain. This change simply uses it consistently instead of duplicating the fallback logic with a hardcoded ID.

The `process.env.PAI_VOICE_ID` env var pattern was also not documented anywhere as a configuration mechanism — `settings.json` is the single source of truth for voice configuration.

Closes #766

## Test plan
- [ ] Verify voice notifications still work with default ElevenLabs setup
- [ ] Verify voice notifications work with custom voice provider (e.g., Kokoro on localhost:8888)
- [ ] Confirm `getVoiceId()` reads from `settings.json → daidentity.voiceId` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)