### PR TITLE
fix(hooks): StartupGreeting exit(1) blocks hook chain on banner failure

### DIFF
--- a/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
+++ b/Releases/v3.0/.claude/hooks/StartupGreeting.hook.ts
@@ -121,6 +121,6 @@ const settingsPath = getSettingsPath();
     process.exit(0);
   } catch (error) {
     console.error('StartupGreeting: Failed to display banner', error);
-    process.exit(1);
+    process.exit(0);
   }
 })();


### PR DESCRIPTION
## Summary
- Change `process.exit(1)` to `process.exit(0)` in StartupGreeting.hook.ts catch block
- Banner display failure is cosmetic — should never block subsequent SessionStart hooks (LoadContext, CheckVersion) from running
- One-line fix

## Details
When `StartupGreeting.hook.ts` fails to render the ASCII banner (e.g., terminal encoding issues, missing font data), the catch block exits with code 1. Since Claude Code runs SessionStart hooks sequentially, a non-zero exit can prevent the rest of the hook chain from executing — meaning `LoadContext` and `CheckVersion` never run, leaving the session without its context.

The banner is nice-to-have, not critical infrastructure.

Closes #768

## Test plan
- [ ] Normal startup: banner renders, exit(0) — no change in behavior
- [ ] Simulated failure (e.g., corrupt banner data): catch fires, exit(0), subsequent hooks still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)