### PR TITLE
feat(algorithm): configurable phase voice notification text

### DIFF
--- a/Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.8.0.md
+++ b/Releases/v3.0/.claude/skills/PAI/Components/Algorithm/v1.8.0.md
@@ -14,7 +14,7 @@
 🗒️ TASK: [8 word description]
 
 [VERBATIM - Execute exactly as written, do not modify(Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the PAI Algorithm Observe phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.OBSERVE}"}'`
 
 ━━━ 👁️ OBSERVE ━━━ 1/7
 
@@ -160,7 +160,7 @@ For each extracted constraint [EX-N], state which ISC criterion covers it:
 **⚡ GATE IS NOW OPEN — All tools are available from THINK onward.**
 
 [VERBATIM - Execute exactly as written, do not modify (Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the Think phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.THINK}"}'`
 
 ━━━ 🧠 THINK ━━━ 2/7
 🚫 **STOP. This phase is SEPARATE. Never combine with adjacent phases. Never use combined numbering (e.g., "4-5/7").**
@@ -198,7 +198,7 @@ For each [CRITICAL] ISC criterion and anti-criterion:
 [Verification method categories: CLI (commands), Test (test runner), Static (type check/lint), Browser (screenshot), Grep (pattern match), Read (file inspection), Custom (human judgment — interactive only)]
 
 [VERBATIM - Execute exactly as written, do not modify(Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the Plan phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.PLAN}"}'`
 
 ━━━ 📋 PLAN ━━━ 3/7
 🚫 **STOP. This phase is SEPARATE. Never combine with adjacent phases. Never use combined numbering (e.g., "4-5/7").**
@@ -284,7 +284,7 @@ ELSE:
 [Finalize approach and declare execution strategy]
 
 [VERBATIM - Execute exactly as written, do not modify(Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the Build phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.BUILD}"}'`
 
 ━━━ 🔨 BUILD ━━━ 4/7
 🚫 **STOP. This phase is SEPARATE. Never combine with adjacent phases. Never use combined numbering (e.g., "4-5/7").**
@@ -313,7 +313,7 @@ After creating each artifact, immediately check all [CRITICAL] anti-criteria aga
 📝 **ISC MUTATIONS:** [ADDED: ... | MODIFIED: ... | REMOVED: ... | None]
 
 [VERBATIM - Execute exactly as written, do not modify(Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the Execute phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.EXECUTE}"}'`
 
 ━━━ ⚡ EXECUTE ━━━ 5/7
 🚫 **STOP. This phase is SEPARATE. Never combine with adjacent phases. Never use combined numbering (e.g., "4-5/7").**
@@ -326,7 +326,7 @@ After creating each artifact, immediately check all [CRITICAL] anti-criteria aga
 📝 **ISC MUTATIONS:** [ADDED: ... | MODIFIED: ... | REMOVED: ... | None]
 
 [VERBATIM - Execute exactly as written, do not modify(Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the Verify phase."}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.VERIFY}"}'`
 
 ━━━ ✅ VERIFY ━━━ 6/7 (THE CULMINATION)
 🚫 **STOP. This phase is SEPARATE. Never combine with adjacent phases. Never use combined numbering (e.g., "4-5/7").**
@@ -375,7 +375,7 @@ For EACH criterion in the list:
 [INVOKE TaskList to show final verification state - NO manual tables]
 
 [VERBATIM - Execute exactly as written, do not modify(Background agents ignore)]
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "Entering the Learn phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"{DAIDENTITY.ALGORITHMVOICEID}","message": "{VOICE.NOTIFY.LEARN}"}'`
 
 ━━━ 📚 LEARN ━━━ 7/7
 ⏱️ FINAL TIME: [Total: Xs | Budget: Ys | WITHIN / OVER by Zs]

--- a/Releases/v3.0/.claude/skills/PAI/Tools/RebuildPAI.ts
+++ b/Releases/v3.0/.claude/skills/PAI/Tools/RebuildPAI.ts
@@ -32,6 +32,14 @@ function loadVariables(): Record<string, string> {
       "{PRINCIPAL.NAME}": settings.principal?.name || "User",
       "{PRINCIPAL.TIMEZONE}": settings.principal?.timezone || "UTC",
       "{DAIDENTITY.ALGORITHMVOICEID}": settings.daidentity?.voices?.algorithm?.voiceId || "",
+      // Phase notification texts (user-configurable, short defaults)
+      "{VOICE.NOTIFY.OBSERVE}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.observe || "Observe",
+      "{VOICE.NOTIFY.THINK}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.think || "Think",
+      "{VOICE.NOTIFY.PLAN}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.plan || "Plan",
+      "{VOICE.NOTIFY.BUILD}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.build || "Build",
+      "{VOICE.NOTIFY.EXECUTE}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.execute || "Execute",
+      "{VOICE.NOTIFY.VERIFY}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.verify || "Verify",
+      "{VOICE.NOTIFY.LEARN}": settings.daidentity?.voices?.algorithm?.phaseNotifications?.learn || "Learn",
     };
   } catch {
     console.warn("⚠️ Could not read settings.json, using defaults");
@@ -42,6 +50,13 @@ function loadVariables(): Record<string, string> {
       "{PRINCIPAL.NAME}": "User",
       "{PRINCIPAL.TIMEZONE}": "UTC",
       "{DAIDENTITY.ALGORITHMVOICEID}": "",
+      "{VOICE.NOTIFY.OBSERVE}": "Observe",
+      "{VOICE.NOTIFY.THINK}": "Think",
+      "{VOICE.NOTIFY.PLAN}": "Plan",
+      "{VOICE.NOTIFY.BUILD}": "Build",
+      "{VOICE.NOTIFY.EXECUTE}": "Execute",
+      "{VOICE.NOTIFY.VERIFY}": "Verify",
+      "{VOICE.NOTIFY.LEARN}": "Learn",
     };
   }
 }


### PR DESCRIPTION
## Summary

- Phase voice notifications are currently hardcoded in the Algorithm template ("Entering the PAI Algorithm Observe phase", "Entering the Think phase", etc.)
- Users who want shorter or different notification text must edit SYSTEM files, which get overwritten on update
- This PR makes the text user-configurable via `settings.json` with short defaults

## Changes

- **Algorithm/v1.8.0.md**: Replace 7 hardcoded message strings with `{VOICE.NOTIFY.*}` template placeholders
- **RebuildPAI.ts**: Add 7 new variables to `loadVariables()` reading from `settings.json` → `daidentity.voices.algorithm.phaseNotifications`, with single-word fallback defaults ("Observe", "Think", "Plan", "Build", "Execute", "Verify", "Learn")

## Configuration

Users can customize in `settings.json`:

```json
"daidentity": {
  "voices": {
    "algorithm": {
      "phaseNotifications": {
        "observe": "Observing now",
        "think": "Thinking",
        "plan": "Planning",
        "build": "Building",
        "execute": "Executing",
        "verify": "Verifying",
        "learn": "Learning"
      }
    }
  }
}
```

Then run `bun ~/.claude/skills/PAI/Tools/RebuildPAI.ts` to regenerate SKILL.md.

If no `phaseNotifications` is configured, defaults are short single words — a nice improvement over the current verbose text regardless of customization.

## Test plan

- [ ] Run `bun RebuildPAI.ts` — verify all 7 `{VOICE.NOTIFY.*}` variables resolve
- [ ] Check generated SKILL.md curl commands contain the configured (or default) text
- [ ] Remove `phaseNotifications` from settings.json — verify defaults ("Observe", etc.) are used
- [ ] Add custom text — verify it appears in SKILL.md after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)