### PR TITLE
fix(statusline): remove broken context percentage fallback after /clear

### DIFF
--- a/Releases/v3.0/.claude/statusline-command.sh
+++ b/Releases/v3.0/.claude/statusline-command.sh
@@ -99,12 +99,11 @@ context_remaining=${context_remaining:-100}
 total_input=${total_input:-0}
 total_output=${total_output:-0}
 
-# If used_percentage is 0 but we have token data, calculate manually
-# This handles cases where statusLine is called before percentage is populated
-if [ "$context_pct" = "0" ] && [ "$total_input" -gt 0 ]; then
-    total_tokens=$((total_input + total_output))
-    context_pct=$((total_tokens * 100 / context_max))
-fi
+# NOTE: Removed fallback that calculated context_pct from total_input + total_output
+# when used_percentage was 0. total_input/output_tokens are CUMULATIVE session totals
+# (like an odometer) — they can far exceed context_window_size. After /clear,
+# used_percentage is null (jq defaults to 0) but totals retain pre-clear values,
+# producing e.g. 531K/200K = 265% capped to 100%. See issue for full analysis.
 
 # Get Claude Code version
 if [ -n "$cc_version_json" ] && [ "$cc_version_json" != "unknown" ]; then


### PR DESCRIPTION
## Summary

- Removes the fallback calculation in `statusline-command.sh` that incorrectly computes context percentage from cumulative session totals
- After `/clear`, CONTEXT now correctly shows ~0% instead of 100%

## Root Cause

The fallback (lines 102-107) fires when `used_percentage` is null (jq defaults to 0) and `total_input_tokens > 0`. It divides cumulative session totals by `context_window_size` — but cumulative totals are an odometer, not a speedometer. After `/clear`, they retain pre-clear values (e.g. 531K tokens) while the actual context is empty: `531K/200K = 265%` → capped at 100%.

The fallback is wrong in all cases because cumulative totals never represent current context window contents. Full analysis in #805.

## Change

Replaced the 6-line fallback block with a 5-line comment explaining why it was removed, so future maintainers don't reintroduce it.

## Test plan

- [ ] Run `/clear` — CONTEXT bar should show 0%, not 100%
- [ ] Normal mid-session — CONTEXT bar unchanged (uses `used_percentage` directly)
- [ ] Long session where `total_input_tokens` exceeds `context_window_size` — no incorrect percentage

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)