### PR TITLE
fix: WorldThreatModelHarness use PAI_DIR for model storage path

### DIFF
--- a/Releases/v3.0/.claude/skills/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v3.0/.claude/skills/WorldThreatModelHarness/SKILL.md
@@ -39,7 +39,7 @@ All workflows support three execution tiers:
 
 ## World Model Storage
 
-Models are stored at: `~/.claude/MEMORY/RESEARCH/WorldModels/`
+Models are stored at: `$PAI_DIR/MEMORY/RESEARCH/WorldModels/`
 
 | File | Horizon |
 |------|---------|


### PR DESCRIPTION
## Summary

- The `WorldThreatModelHarness/SKILL.md` storage path was hardcoded to `~/.claude/MEMORY/RESEARCH/WorldModels/`
- Correct path is `$PAI_DIR/MEMORY/RESEARCH/WorldModels/`

## Test plan

- [ ] Verify `$PAI_DIR` resolves correctly in your PAI installation (`echo $PAI_DIR`)
- [ ] Run WorldThreatModelHarness to confirm models are created at the correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)