### PR TITLE
feat: Add VoiceServer with cross-platform Linux + macOS support

### DIFF
--- a/VoiceServer/install.sh
+++ b/VoiceServer/install.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+
+# Voice Server Installation Script
+# Supports macOS (LaunchAgent) and Linux (systemd user service)
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ENV_FILE="$HOME/.env"
+OS=$(uname -s)
+
+# OS-specific paths
+if [[ "$OS" == "Darwin" ]]; then
+    SERVICE_NAME="com.pai.voice-server"
+    PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
+    LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+elif [[ "$OS" == "Linux" ]]; then
+    SERVICE_NAME="pai-voice-server"
+    SYSTEMD_DIR="$HOME/.config/systemd/user"
+    SERVICE_FILE="$SYSTEMD_DIR/${SERVICE_NAME}.service"
+    LOG_DIR="$HOME/.local/share/pai"
+    LOG_PATH="$LOG_DIR/voice-server.log"
+else
+    echo -e "${RED}X Unsupported operating system: $OS${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}=====================================================${NC}"
+echo -e "${BLUE}     PAI Voice Server Installation${NC}"
+echo -e "${BLUE}     Platform: $OS${NC}"
+echo -e "${BLUE}=====================================================${NC}"
+echo
+
+# Check for Bun
+echo -e "${YELLOW}> Checking prerequisites...${NC}"
+if ! command -v bun &> /dev/null; then
+    echo -e "${RED}X Bun is not installed${NC}"
+    echo "  Please install Bun first:"
+    echo "  curl -fsSL https://bun.sh/install | bash"
+    exit 1
+fi
+echo -e "${GREEN}OK Bun is installed ($(bun --version))${NC}"
+
+# Check for ElevenLabs configuration
+echo -e "${YELLOW}> Checking ElevenLabs configuration...${NC}"
+ELEVENLABS_CONFIGURED=false
+if [ -f "$ENV_FILE" ] && grep -q "ELEVENLABS_API_KEY=" "$ENV_FILE"; then
+    API_KEY=$(grep "ELEVENLABS_API_KEY=" "$ENV_FILE" | cut -d'=' -f2-)
+    if [ "$API_KEY" != "your_api_key_here" ] && [ -n "$API_KEY" ]; then
+        echo -e "${GREEN}OK ElevenLabs API key configured${NC}"
+        ELEVENLABS_CONFIGURED=true
+    fi
+fi
+
+if [ "$ELEVENLABS_CONFIGURED" = false ]; then
+    echo -e "${YELLOW}! ElevenLabs API key not configured${NC}"
+    echo "  To enable AI voices, add your key to ~/.env:"
+    echo "  echo 'ELEVENLABS_API_KEY=your_key_here' >> ~/.env"
+    echo "  Get a free key at: https://elevenlabs.io"
+    echo
+fi
+
+# ── macOS: LaunchAgent ──────────────────────────────────────────────────────
+if [[ "$OS" == "Darwin" ]]; then
+
+    # Check for existing installation
+    if launchctl list | grep -q "$SERVICE_NAME" 2>/dev/null; then
+        echo -e "${YELLOW}! Voice server is already installed${NC}"
+        read -p "Do you want to reinstall? (y/n): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo -e "${YELLOW}> Stopping existing service...${NC}"
+            launchctl unload "$PLIST_PATH" 2>/dev/null || true
+            echo -e "${GREEN}OK Existing service stopped${NC}"
+        else
+            echo "Installation cancelled"
+            exit 0
+        fi
+    fi
+
+    # Create LaunchAgent plist
+    echo -e "${YELLOW}> Creating LaunchAgent configuration...${NC}"
+    mkdir -p "$HOME/Library/LaunchAgents"
+
+    cat > "$PLIST_PATH" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${SERVICE_NAME}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>$(which bun)</string>
+        <string>run</string>
+        <string>${SCRIPT_DIR}/server.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${SCRIPT_DIR}</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>${LOG_PATH}</string>
+
+    <key>StandardErrorPath</key>
+    <string>${LOG_PATH}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>${HOME}</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.bun/bin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+
+    echo -e "${GREEN}OK LaunchAgent configuration created${NC}"
+
+    # Load the LaunchAgent
+    echo -e "${YELLOW}> Starting voice server service...${NC}"
+    launchctl load "$PLIST_PATH" 2>/dev/null || {
+        echo -e "${RED}X Failed to load LaunchAgent${NC}"
+        echo "  Try manually: launchctl load $PLIST_PATH"
+        exit 1
+    }
+
+# ── Linux: systemd user service ─────────────────────────────────────────────
+elif [[ "$OS" == "Linux" ]]; then
+
+    # Ensure directories exist
+    mkdir -p "$SYSTEMD_DIR"
+    mkdir -p "$LOG_DIR"
+
+    # Check for existing installation
+    if systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+        echo -e "${YELLOW}! Voice server is already running${NC}"
+        read -p "Do you want to reinstall? (y/n): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo -e "${YELLOW}> Stopping existing service...${NC}"
+            systemctl --user stop "$SERVICE_NAME" 2>/dev/null || true
+            systemctl --user disable "$SERVICE_NAME" 2>/dev/null || true
+            echo -e "${GREEN}OK Existing service stopped${NC}"
+        else
+            echo "Installation cancelled"
+            exit 0
+        fi
+    fi
+
+    # Write systemd unit file
+    echo -e "${YELLOW}> Creating systemd user service...${NC}"
+
+    cat > "$SERVICE_FILE" << EOF
+[Unit]
+Description=PAI Voice Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=$(which bun) run ${SCRIPT_DIR}/server.ts
+WorkingDirectory=${SCRIPT_DIR}
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:${LOG_PATH}
+StandardError=append:${LOG_PATH}
+Environment=HOME=${HOME}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:${HOME}/.bun/bin
+
+[Install]
+WantedBy=default.target
+EOF
+
+    echo -e "${GREEN}OK systemd unit created: $SERVICE_FILE${NC}"
+
+    # Reload systemd daemon, enable, and start
+    systemctl --user daemon-reload
+    systemctl --user enable "$SERVICE_NAME" 2>/dev/null || {
+        echo -e "${RED}X Failed to enable systemd service${NC}"
+        echo "  Try manually: systemctl --user enable $SERVICE_NAME"
+        exit 1
+    }
+
+    # Enable lingering so the service starts on boot without an active session
+    if command -v loginctl &>/dev/null; then
+        if ! loginctl enable-linger "$USER" 2>/dev/null; then
+            echo -e "${YELLOW}! Warning: loginctl enable-linger failed — service may not start on boot${NC}"
+            echo "  To fix: sudo loginctl enable-linger $USER"
+        fi
+    fi
+
+    echo -e "${YELLOW}> Starting voice server service...${NC}"
+    systemctl --user start "$SERVICE_NAME" 2>/dev/null || {
+        echo -e "${RED}X Failed to start systemd service${NC}"
+        echo "  Check logs: journalctl --user -u $SERVICE_NAME"
+        exit 1
+    }
+fi
+
+# ── Shared: verify server is responding ─────────────────────────────────────
+sleep 2
+
+echo -e "${YELLOW}> Testing voice server...${NC}"
+if curl -s -f -X GET http://localhost:8888/health > /dev/null 2>&1; then
+    echo -e "${GREEN}OK Voice server is running${NC}"
+
+    echo -e "${YELLOW}> Sending test notification...${NC}"
+    curl -s -X POST http://localhost:8888/notify \
+        -H "Content-Type: application/json" \
+        -d '{"message": "Voice server installed successfully"}' > /dev/null
+    echo -e "${GREEN}OK Test notification sent${NC}"
+else
+    echo -e "${RED}X Voice server is not responding${NC}"
+    echo "  Check logs: $LOG_PATH"
+    echo "  Try running manually: bun run $SCRIPT_DIR/server.ts"
+    exit 1
+fi
+
+# Show summary
+echo
+echo -e "${GREEN}=====================================================${NC}"
+echo -e "${GREEN}     Installation Complete!${NC}"
+echo -e "${GREEN}=====================================================${NC}"
+echo
+echo -e "${BLUE}Service Information:${NC}"
+echo "  - Service: $SERVICE_NAME"
+echo "  - Status:  Running"
+echo "  - Port:    8888"
+echo "  - Logs:    $LOG_PATH"
+echo "  - Voice:   $([ "$ELEVENLABS_CONFIGURED" = true ] && echo "ElevenLabs AI" || echo "Not configured")"
+echo
+echo -e "${BLUE}Management Commands:${NC}"
+echo "  - Status:    ./status.sh"
+echo "  - Stop:      ./stop.sh"
+echo "  - Start:     ./start.sh"
+echo "  - Restart:   ./restart.sh"
+echo "  - Uninstall: ./uninstall.sh"
+echo
+echo -e "${BLUE}Test the server:${NC}"
+echo "  curl -X POST http://localhost:8888/notify \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"message\": \"Hello from PAI\"}'"
+echo
+echo -e "${GREEN}The voice server will start automatically on login.${NC}"
+
+# macOS-only: offer menu bar indicator
+if [[ "$OS" == "Darwin" ]]; then
+    echo
+    read -p "Would you like to install a menu bar indicator? (y/n): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${YELLOW}> Installing menu bar indicator...${NC}"
+        if [ -f "$SCRIPT_DIR/menubar/install-menubar.sh" ]; then
+            chmod +x "$SCRIPT_DIR/menubar/install-menubar.sh"
+            "$SCRIPT_DIR/menubar/install-menubar.sh"
+        else
+            echo -e "${YELLOW}! Menu bar installer not found${NC}"
+        fi
+    fi
+fi

--- a/VoiceServer/menubar/install-menubar.sh
+++ b/VoiceServer/menubar/install-menubar.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Install Menu Bar Indicator for Voice Server
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MENUBAR_SCRIPT="$SCRIPT_DIR/pai-voice.5s.sh"
+
+echo -e "${BLUE}=====================================================${NC}"
+echo -e "${BLUE}     PAI Voice Menu Bar Installation${NC}"
+echo -e "${BLUE}=====================================================${NC}"
+echo
+
+# Check if SwiftBar is installed
+if [ -d "/Applications/SwiftBar.app" ]; then
+    echo -e "${GREEN}OK SwiftBar is installed${NC}"
+    MENUBAR_APP="SwiftBar"
+    PLUGIN_DIR="$HOME/Library/Application Support/SwiftBar/Plugins"
+elif [ -d "/Applications/BitBar.app" ]; then
+    echo -e "${GREEN}OK BitBar is installed${NC}"
+    MENUBAR_APP="BitBar"
+    # Check for BitBar plugin directory
+    if [ -d "$HOME/Documents/BitBarPlugins" ]; then
+        PLUGIN_DIR="$HOME/Documents/BitBarPlugins"
+    elif [ -d "$HOME/BitBar" ]; then
+        PLUGIN_DIR="$HOME/BitBar"
+    else
+        PLUGIN_DIR="$HOME/Documents/BitBarPlugins"
+        echo -e "${YELLOW}> Creating BitBar plugin directory...${NC}"
+        mkdir -p "$PLUGIN_DIR"
+    fi
+else
+    echo -e "${RED}X Neither SwiftBar nor BitBar is installed${NC}"
+    echo
+    echo "Please install SwiftBar (recommended) or BitBar first:"
+    echo
+    echo "Option 1: Install SwiftBar (Recommended)"
+    echo "  brew install --cask swiftbar"
+    echo "  Or download from: https://github.com/swiftbar/SwiftBar/releases"
+    echo
+    echo "Option 2: Install BitBar"
+    echo "  brew install --cask bitbar"
+    echo "  Or download from: https://getbitbar.com"
+    echo
+    exit 1
+fi
+
+# Make script executable
+chmod +x "$MENUBAR_SCRIPT"
+
+# Create plugin directory if it doesn't exist
+mkdir -p "$PLUGIN_DIR"
+
+# Copy or link the script
+echo -e "${YELLOW}> Installing menu bar plugin...${NC}"
+
+# Remove existing plugin if it exists
+rm -f "$PLUGIN_DIR/pai-voice.5s.sh" 2>/dev/null || true
+
+# Create symbolic link to our script
+ln -s "$MENUBAR_SCRIPT" "$PLUGIN_DIR/pai-voice.5s.sh"
+
+echo -e "${GREEN}OK Menu bar plugin installed${NC}"
+
+# Refresh SwiftBar/BitBar
+if [ "$MENUBAR_APP" = "SwiftBar" ]; then
+    echo -e "${YELLOW}> Refreshing SwiftBar...${NC}"
+    if pgrep -x "SwiftBar" > /dev/null; then
+        # SwiftBar refresh via URL scheme
+        open -g "swiftbar://refreshall"
+        echo -e "${GREEN}OK SwiftBar refreshed${NC}"
+    else
+        echo -e "${YELLOW}> Starting SwiftBar...${NC}"
+        open -a SwiftBar
+        sleep 2
+        echo -e "${GREEN}OK SwiftBar started${NC}"
+    fi
+else
+    echo -e "${YELLOW}> Refreshing BitBar...${NC}"
+    if pgrep -x "BitBar" > /dev/null; then
+        killall BitBar 2>/dev/null || true
+        sleep 1
+    fi
+    open -a BitBar
+    echo -e "${GREEN}OK BitBar started${NC}"
+fi
+
+echo
+echo -e "${GREEN}=====================================================${NC}"
+echo -e "${GREEN}     Menu Bar Installation Complete${NC}"
+echo -e "${GREEN}=====================================================${NC}"
+echo
+echo -e "${BLUE}You should now see a microphone icon in your menu bar!${NC}"
+echo
+echo "The icon shows:"
+echo "  - Colored microphone - Server is running"
+echo "  - Gray microphone - Server is stopped"
+echo
+echo "Click the icon to:"
+echo "  - Start/Stop the server"
+echo "  - View status and logs"
+echo "  - Test voice output"
+echo
+echo -e "${YELLOW}Note:${NC} If you don't see the icon, you may need to:"
+echo "  1. Open $MENUBAR_APP preferences"
+echo "  2. Set the plugin folder to: $PLUGIN_DIR"
+echo "  3. Restart $MENUBAR_APP"

--- a/VoiceServer/menubar/pai-voice.5s.sh
+++ b/VoiceServer/menubar/pai-voice.5s.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Voice Server Menu Bar Indicator
+# For BitBar/SwiftBar - updates every 5 seconds
+
+# Get the VoiceServer directory
+PAI_DIR="${PAI_DIR:-$HOME/.claude}"
+VOICE_SERVER_DIR="$PAI_DIR/VoiceServer"
+
+# Check if server is running
+if curl -s -f http://localhost:8888/health > /dev/null 2>&1; then
+    # Server is running - show green indicator with size
+    echo "🎙️ | size=18"
+    echo "---"
+    echo "Voice Server: ✅ Running"
+
+    # Check for ElevenLabs
+    if [ -f ~/.env ] && grep -q "ELEVENLABS_API_KEY=" ~/.env 2>/dev/null; then
+        API_KEY=$(grep "ELEVENLABS_API_KEY=" ~/.env | cut -d'=' -f2)
+        if [ "$API_KEY" != "your_api_key_here" ] && [ -n "$API_KEY" ]; then
+            echo "Voice: ElevenLabs AI"
+        else
+            echo "Voice: macOS Say"
+        fi
+    else
+        echo "Voice: macOS Say"
+    fi
+
+    echo "Port: 8888"
+    echo "---"
+    echo "Stop Server | bash='$VOICE_SERVER_DIR/stop.sh' terminal=false refresh=true"
+    echo "Restart Server | bash='$VOICE_SERVER_DIR/restart.sh' terminal=false refresh=true"
+else
+    # Server is not running - show gray indicator with size
+    echo "🎙️⚫ | size=18"
+    echo "---"
+    echo "Voice Server: ⚫ Stopped"
+    echo "---"
+    echo "Start Server | bash='$VOICE_SERVER_DIR/start.sh' terminal=false refresh=true"
+fi
+
+echo "---"
+echo "Check Status | bash='$VOICE_SERVER_DIR/status.sh' terminal=true"
+echo "View Logs | bash='tail -f ~/Library/Logs/pai-voice-server.log' terminal=true"
+echo "---"
+echo "Test Voice | bash='curl -X POST http://localhost:8888/notify -H \"Content-Type: application/json\" -d \"{\\\"message\\\":\\\"Testing voice server\\\"}\"' terminal=false"
+echo "---"
+echo "Open Voice Server Folder | bash='open $VOICE_SERVER_DIR'"
+echo "Uninstall | bash='$VOICE_SERVER_DIR/uninstall.sh' terminal=true"

--- a/VoiceServer/pronunciations.json
+++ b/VoiceServer/pronunciations.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "TTS pronunciation overrides. Each entry maps a display term to its phonetic TTS spelling. Uses word-boundary matching to avoid mid-word replacements. Source of truth: skills/PAI/USER/PRONUNCIATIONS.md",
+  "replacements": [
+    { "term": "Kai", "phonetic": "Kye", "note": "Rhymes with sky/pie, NOT lay/day" },
+    { "term": "PAI", "phonetic": "pie", "note": "Personal AI Infrastructure - rhymes with sky" },
+    { "term": "{PRINCIPAL.LAST_NAME}", "phonetic": "{PHONETIC}", "note": "Principal's last name - customize" },
+    { "term": "ISC", "phonetic": "I S C", "note": "Ideal State Criteria - spell out" }
+  ]
+}

--- a/VoiceServer/restart.sh
+++ b/VoiceServer/restart.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Restart the Voice Server
+# Supports macOS (LaunchAgent) and Linux (systemd user service)
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OS=$(uname -s)
+
+# Colors
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo -e "${YELLOW}> Restarting Voice Server...${NC}"
+
+if [[ "$OS" == "Darwin" ]]; then
+    # macOS: stop then start (launchctl has no single restart command)
+    "$SCRIPT_DIR/stop.sh"
+    sleep 1
+    "$SCRIPT_DIR/start.sh"
+    echo -e "${GREEN}OK Voice server restarted${NC}"
+
+elif [[ "$OS" == "Linux" ]]; then
+    SERVICE_NAME="pai-voice-server"
+    if systemctl --user is-enabled --quiet "$SERVICE_NAME" 2>/dev/null; then
+        # systemd: single atomic restart
+        systemctl --user restart "$SERVICE_NAME"
+        sleep 2
+        HEALTH=$(curl -s http://localhost:8888/health 2>/dev/null)
+        if [ -n "$HEALTH" ]; then
+            echo -e "${GREEN}OK Voice server restarted${NC}"
+        else
+            echo -e "${YELLOW}! Restarted but not responding yet — check: journalctl --user -u $SERVICE_NAME${NC}"
+        fi
+    else
+        # Service not installed, fall back to stop/start
+        "$SCRIPT_DIR/stop.sh"
+        sleep 1
+        "$SCRIPT_DIR/start.sh"
+        echo -e "${GREEN}OK Voice server restarted${NC}"
+    fi
+
+else
+    echo -e "${RED}X Unsupported operating system: $OS${NC}"
+    exit 1
+fi

--- a/VoiceServer/server.ts
+++ b/VoiceServer/server.ts
@@ -1,0 +1,727 @@
+#!/usr/bin/env bun
+/**
+ * Voice Server - Personal AI Voice notification server using ElevenLabs TTS
+ *
+ * Architecture: Pure pass-through. All voice config comes from settings.json.
+ * The server has zero hardcoded voice parameters.
+ *
+ * Config resolution (3-tier):
+ *   1. Caller sends voice_settings in request body → use directly (pass-through)
+ *   2. Caller sends voice_id → look up in settings.json daidentity.voices → use those settings
+ *   3. Neither → use settings.json daidentity.voices.main as default
+ *
+ * Pronunciation preprocessing: loads pronunciations.json and applies
+ * word-boundary replacements before sending text to ElevenLabs TTS.
+ */
+
+import { serve } from "bun";
+import { spawn } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import { existsSync, readFileSync } from "fs";
+
+// Load .env from user home directory
+const envPath = join(homedir(), '.env');
+if (existsSync(envPath)) {
+  const envContent = await Bun.file(envPath).text();
+  envContent.split('\n').forEach(line => {
+    const [key, value] = line.split('=');
+    if (key && value && !key.startsWith('#')) {
+      process.env[key.trim()] = value.trim();
+    }
+  });
+}
+
+const PORT = parseInt(process.env.PORT || "8888");
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+
+if (!ELEVENLABS_API_KEY) {
+  console.error('⚠️  ELEVENLABS_API_KEY not found in ~/.env');
+  console.error('Add: ELEVENLABS_API_KEY=your_key_here');
+}
+
+// ==========================================================================
+// Pronunciation System
+// ==========================================================================
+
+interface PronunciationEntry {
+  term: string;
+  phonetic: string;
+  note?: string;
+}
+
+interface PronunciationConfig {
+  replacements: PronunciationEntry[];
+}
+
+// Compiled pronunciation rules (loaded once at startup)
+interface CompiledRule {
+  regex: RegExp;
+  phonetic: string;
+}
+
+let pronunciationRules: CompiledRule[] = [];
+
+// Load and compile pronunciation rules from pronunciations.json
+function loadPronunciations(): void {
+  const pronPath = join(import.meta.dir, 'pronunciations.json');
+  try {
+    if (!existsSync(pronPath)) {
+      console.warn('⚠️  No pronunciations.json found — TTS will use default pronunciations');
+      return;
+    }
+    const content = readFileSync(pronPath, 'utf-8');
+    const config: PronunciationConfig = JSON.parse(content);
+
+    pronunciationRules = config.replacements.map(entry => ({
+      // Word-boundary matching: \b ensures "Kai" matches but "Kaiser" doesn't
+      regex: new RegExp(`\\b${escapeRegex(entry.term)}\\b`, 'g'),
+      phonetic: entry.phonetic,
+    }));
+
+    console.log(`📖 Loaded ${pronunciationRules.length} pronunciation rules`);
+    for (const entry of config.replacements) {
+      console.log(`   ${entry.term} → ${entry.phonetic} (${entry.note || ''})`);
+    }
+  } catch (error) {
+    console.error('⚠️  Failed to load pronunciations.json:', error);
+  }
+}
+
+// Escape special regex characters in a literal string
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Apply all pronunciation replacements to text before TTS
+function applyPronunciations(text: string): string {
+  let result = text;
+  for (const rule of pronunciationRules) {
+    result = result.replace(rule.regex, rule.phonetic);
+  }
+  return result;
+}
+
+// Load pronunciations at startup
+loadPronunciations();
+
+// ==========================================================================
+// Voice Configuration — Single Source of Truth: settings.json
+// ==========================================================================
+
+// ElevenLabs voice_settings fields (sent to their API)
+interface ElevenLabsVoiceSettings {
+  stability: number;
+  similarity_boost: number;
+  style?: number;
+  speed?: number;
+  use_speaker_boost?: boolean;
+}
+
+// A voice entry from settings.json daidentity.voices.*
+interface VoiceEntry {
+  voiceId: string;
+  voiceName?: string;
+  stability: number;
+  similarity_boost: number;
+  style: number;
+  speed: number;
+  use_speaker_boost: boolean;
+  volume: number;
+}
+
+// Loaded config from settings.json
+interface LoadedVoiceConfig {
+  defaultVoiceId: string;
+  voices: Record<string, VoiceEntry>;     // keyed by name ("main", "algorithm")
+  voicesByVoiceId: Record<string, VoiceEntry>;  // keyed by voiceId for lookup
+  desktopNotifications: boolean;  // whether to show macOS notification banners
+}
+
+// Last-resort defaults if settings.json is entirely missing or unparseable
+const FALLBACK_VOICE_SETTINGS: ElevenLabsVoiceSettings = {
+  stability: 0.5,
+  similarity_boost: 0.75,
+  style: 0.0,
+  speed: 1.0,
+  use_speaker_boost: true,
+};
+const FALLBACK_VOLUME = 1.0;
+
+// Load voice configuration from settings.json (cached at startup)
+function loadVoiceConfig(): LoadedVoiceConfig {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+
+  try {
+    if (!existsSync(settingsPath)) {
+      console.warn('⚠️  settings.json not found — using fallback voice defaults');
+      return { defaultVoiceId: '', voices: {}, voicesByVoiceId: {}, desktopNotifications: true };
+    }
+
+    const content = readFileSync(settingsPath, 'utf-8');
+    const settings = JSON.parse(content);
+    const daidentity = settings.daidentity || {};
+    const voicesSection = daidentity.voices || {};
+    const desktopNotifications = settings.notifications?.desktop?.enabled !== false;
+
+    // Build lookup maps
+    const voices: Record<string, VoiceEntry> = {};
+    const voicesByVoiceId: Record<string, VoiceEntry> = {};
+
+    for (const [name, config] of Object.entries(voicesSection)) {
+      const entry = config as any;
+      if (entry.voiceId) {
+        const voiceEntry: VoiceEntry = {
+          voiceId: entry.voiceId,
+          voiceName: entry.voiceName,
+          stability: entry.stability ?? 0.5,
+          similarity_boost: entry.similarity_boost ?? entry.similarityBoost ?? 0.75,
+          style: entry.style ?? 0.0,
+          speed: entry.speed ?? 1.0,
+          use_speaker_boost: entry.use_speaker_boost ?? entry.useSpeakerBoost ?? true,
+          volume: entry.volume ?? 1.0,
+        };
+        voices[name] = voiceEntry;
+        voicesByVoiceId[entry.voiceId] = voiceEntry;
+      }
+    }
+
+    // Default voice ID from settings
+    const defaultVoiceId = voices.main?.voiceId || daidentity.mainDAVoiceID || '';
+
+    const voiceNames = Object.keys(voices);
+    console.log(`✅ Loaded ${voiceNames.length} voice config(s) from settings.json: ${voiceNames.join(', ')}`);
+    for (const [name, entry] of Object.entries(voices)) {
+      console.log(`   ${name}: ${entry.voiceName || entry.voiceId} (speed: ${entry.speed}, stability: ${entry.stability})`);
+    }
+
+    return { defaultVoiceId, voices, voicesByVoiceId, desktopNotifications };
+  } catch (error) {
+    console.error('⚠️  Failed to load settings.json voice config:', error);
+    return { defaultVoiceId: '', voices: {}, voicesByVoiceId: {}, desktopNotifications: true };
+  }
+}
+
+// Load config at startup
+const voiceConfig = loadVoiceConfig();
+const DEFAULT_VOICE_ID = voiceConfig.defaultVoiceId || process.env.ELEVENLABS_VOICE_ID || "{YOUR_ELEVENLABS_VOICE_ID}";
+
+// Look up a voice entry by voice ID
+function lookupVoiceByVoiceId(voiceId: string): VoiceEntry | null {
+  return voiceConfig.voicesByVoiceId[voiceId] || null;
+}
+
+// Get ElevenLabs voice settings for a voice entry
+function voiceEntryToSettings(entry: VoiceEntry): ElevenLabsVoiceSettings {
+  return {
+    stability: entry.stability,
+    similarity_boost: entry.similarity_boost,
+    style: entry.style,
+    speed: entry.speed,
+    use_speaker_boost: entry.use_speaker_boost,
+  };
+}
+
+// Emotional markers for dynamic voice adjustment (overlay-only — modifies stability + similarity_boost)
+interface EmotionalOverlay {
+  stability: number;
+  similarity_boost: number;
+}
+
+// 13 Emotional Presets - Expanded Prosody System
+// These OVERLAY onto resolved voice settings, not replace them
+const EMOTIONAL_PRESETS: Record<string, EmotionalOverlay> = {
+  // High Energy / Positive
+  'excited': { stability: 0.7, similarity_boost: 0.9 },
+  'celebration': { stability: 0.65, similarity_boost: 0.85 },
+  'insight': { stability: 0.55, similarity_boost: 0.8 },
+  'creative': { stability: 0.5, similarity_boost: 0.75 },
+
+  // Success / Achievement
+  'success': { stability: 0.6, similarity_boost: 0.8 },
+  'progress': { stability: 0.55, similarity_boost: 0.75 },
+
+  // Analysis / Investigation
+  'investigating': { stability: 0.6, similarity_boost: 0.85 },
+  'debugging': { stability: 0.55, similarity_boost: 0.8 },
+  'learning': { stability: 0.5, similarity_boost: 0.75 },
+
+  // Thoughtful / Careful
+  'pondering': { stability: 0.65, similarity_boost: 0.8 },
+  'focused': { stability: 0.7, similarity_boost: 0.85 },
+  'caution': { stability: 0.4, similarity_boost: 0.6 },
+
+  // Urgent / Critical
+  'urgent': { stability: 0.3, similarity_boost: 0.9 },
+};
+
+// Escape special characters for AppleScript
+function escapeForAppleScript(input: string): string {
+  return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// Extract emotional marker from message
+function extractEmotionalMarker(message: string): { cleaned: string; emotion?: string } {
+  const emojiToEmotion: Record<string, string> = {
+    '\u{1F4A5}': 'excited',
+    '\u{1F389}': 'celebration',
+    '\u{1F4A1}': 'insight',
+    '\u{1F3A8}': 'creative',
+    '\u{2728}': 'success',
+    '\u{1F4C8}': 'progress',
+    '\u{1F50D}': 'investigating',
+    '\u{1F41B}': 'debugging',
+    '\u{1F4DA}': 'learning',
+    '\u{1F914}': 'pondering',
+    '\u{1F3AF}': 'focused',
+    '\u{26A0}\u{FE0F}': 'caution',
+    '\u{1F6A8}': 'urgent'
+  };
+
+  const emotionMatch = message.match(/\[(\u{1F4A5}|\u{1F389}|\u{1F4A1}|\u{1F3A8}|\u{2728}|\u{1F4C8}|\u{1F50D}|\u{1F41B}|\u{1F4DA}|\u{1F914}|\u{1F3AF}|\u{26A0}\u{FE0F}|\u{1F6A8})\s+(\w+)\]/u);
+  if (emotionMatch) {
+    const emoji = emotionMatch[1];
+    const emotionName = emotionMatch[2].toLowerCase();
+
+    if (emojiToEmotion[emoji] === emotionName) {
+      return {
+        cleaned: message.replace(emotionMatch[0], '').trim(),
+        emotion: emotionName
+      };
+    }
+  }
+
+  return { cleaned: message };
+}
+
+// Sanitize input for TTS and notifications
+function sanitizeForSpeech(input: string): string {
+  const cleaned = input
+    .replace(/<script/gi, '')
+    .replace(/\.\.\//g, '')
+    .replace(/[;&|><`$\\]/g, '')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/#{1,6}\s+/g, '')
+    .trim()
+    .substring(0, 500);
+
+  return cleaned;
+}
+
+// Validate user input
+function validateInput(input: any): { valid: boolean; error?: string; sanitized?: string } {
+  if (!input || typeof input !== 'string') {
+    return { valid: false, error: 'Invalid input type' };
+  }
+
+  if (input.length > 500) {
+    return { valid: false, error: 'Message too long (max 500 characters)' };
+  }
+
+  const sanitized = sanitizeForSpeech(input);
+
+  if (!sanitized || sanitized.length === 0) {
+    return { valid: false, error: 'Message contains no valid content after sanitization' };
+  }
+
+  return { valid: true, sanitized };
+}
+
+// Generate speech using ElevenLabs API — pure pass-through of voice_settings
+async function generateSpeech(
+  text: string,
+  voiceId: string,
+  voiceSettings: ElevenLabsVoiceSettings
+): Promise<ArrayBuffer> {
+  if (!ELEVENLABS_API_KEY) {
+    throw new Error('ElevenLabs API key not configured');
+  }
+
+  // Apply pronunciation replacements before sending to TTS
+  const pronouncedText = applyPronunciations(text);
+  if (pronouncedText !== text) {
+    console.log(`📖 Pronunciation: "${text}" → "${pronouncedText}"`);
+  }
+
+  const url = `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'audio/mpeg',
+      'Content-Type': 'application/json',
+      'xi-api-key': ELEVENLABS_API_KEY,
+    },
+    body: JSON.stringify({
+      text: pronouncedText,
+      model_id: 'eleven_turbo_v2_5',
+      voice_settings: voiceSettings,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`ElevenLabs API error: ${response.status} - ${errorText}`);
+  }
+
+  return await response.arrayBuffer();
+}
+
+// Play audio using afplay (macOS) or ffplay (Linux)
+async function playAudio(audioBuffer: ArrayBuffer, volume: number = FALLBACK_VOLUME): Promise<void> {
+  const tempFile = `/tmp/voice-${Date.now()}.mp3`;
+
+  await Bun.write(tempFile, audioBuffer);
+
+  return new Promise((resolve, reject) => {
+    const isLinux = process.platform === 'linux';
+    const [cmd, args] = isLinux
+      ? ['/usr/bin/ffplay', ['-nodisp', '-autoexit', '-v', 'quiet', '-af', `volume=${volume}`, tempFile]]
+      : ['/usr/bin/afplay', ['-v', volume.toString(), tempFile]];
+    const proc = spawn(cmd, args);
+
+    proc.on('error', (error) => {
+      console.error('Error playing audio:', error);
+      reject(error);
+    });
+
+    proc.on('exit', (code) => {
+      spawn('/bin/rm', [tempFile]);
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`afplay exited with code ${code}`));
+      }
+    });
+  });
+}
+
+// Spawn a process safely
+function spawnSafe(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args);
+
+    proc.on('error', (error) => {
+      console.error(`Error spawning ${command}:`, error);
+      reject(error);
+    });
+
+    proc.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+// ==========================================================================
+// Core: Send notification with 3-tier voice settings resolution
+// ==========================================================================
+
+/**
+ * Send macOS notification with voice.
+ *
+ * Voice settings resolution (3-tier):
+ *   1. callerVoiceSettings provided → use directly (pass-through)
+ *   2. voiceId provided → look up in settings.json → use those settings
+ *   3. Neither → use settings.json voices.main defaults
+ *
+ * Emotional presets overlay stability + similarity_boost onto resolved settings.
+ * Volume is resolved separately: caller → voice entry → main → 1.0 fallback.
+ */
+async function sendNotification(
+  title: string,
+  message: string,
+  voiceEnabled = true,
+  voiceId: string | null = null,
+  callerVoiceSettings?: Partial<ElevenLabsVoiceSettings> | null,
+  callerVolume?: number | null,
+): Promise<{ voicePlayed: boolean; voiceError?: string }> {
+  const titleValidation = validateInput(title);
+  const messageValidation = validateInput(message);
+
+  if (!titleValidation.valid) {
+    throw new Error(`Invalid title: ${titleValidation.error}`);
+  }
+
+  if (!messageValidation.valid) {
+    throw new Error(`Invalid message: ${messageValidation.error}`);
+  }
+
+  const safeTitle = titleValidation.sanitized!;
+  let safeMessage = messageValidation.sanitized!;
+
+  const { cleaned, emotion } = extractEmotionalMarker(safeMessage);
+  safeMessage = cleaned;
+
+  // Generate and play voice using ElevenLabs
+  let voicePlayed = false;
+  let voiceError: string | undefined;
+
+  if (voiceEnabled && ELEVENLABS_API_KEY) {
+    try {
+      const voice = voiceId || DEFAULT_VOICE_ID;
+      let effectiveVoiceId = voice;
+
+      // 3-tier voice settings resolution
+      let resolvedSettings: ElevenLabsVoiceSettings;
+      let resolvedVolume: number;
+
+      if (callerVoiceSettings && Object.keys(callerVoiceSettings).length > 0) {
+        // Tier 1: Caller provided explicit voice_settings → pass through
+        resolvedSettings = {
+          stability: callerVoiceSettings.stability ?? FALLBACK_VOICE_SETTINGS.stability,
+          similarity_boost: callerVoiceSettings.similarity_boost ?? FALLBACK_VOICE_SETTINGS.similarity_boost,
+          style: callerVoiceSettings.style ?? FALLBACK_VOICE_SETTINGS.style,
+          speed: callerVoiceSettings.speed ?? FALLBACK_VOICE_SETTINGS.speed,
+          use_speaker_boost: callerVoiceSettings.use_speaker_boost ?? FALLBACK_VOICE_SETTINGS.use_speaker_boost,
+        };
+        resolvedVolume = callerVolume ?? FALLBACK_VOLUME;
+        console.log(`🔗 Voice settings: pass-through from caller`);
+      } else {
+        // Tier 2/3: Look up by voiceId, fall back to main
+        const exactMatch = lookupVoiceByVoiceId(voice);
+        const voiceEntry = exactMatch || voiceConfig.voices.main;
+        if (voiceEntry) {
+          resolvedSettings = voiceEntryToSettings(voiceEntry);
+          resolvedVolume = callerVolume ?? voiceEntry.volume ?? FALLBACK_VOLUME;
+          // If the requested voice isn't in config, swap to main's voiceId for the API call
+          if (!exactMatch && voiceConfig.voices.main) {
+            console.log(`⚠️  Voice "${voice}" not in config → falling back to main (${voiceConfig.voices.main.voiceId})`);
+            effectiveVoiceId = voiceConfig.voices.main.voiceId;
+          }
+          console.log(`📋 Voice settings: from settings.json (${voiceEntry.voiceName || effectiveVoiceId})`);
+        } else {
+          resolvedSettings = { ...FALLBACK_VOICE_SETTINGS };
+          resolvedVolume = callerVolume ?? FALLBACK_VOLUME;
+          console.log(`⚠️  Voice settings: fallback defaults (no config found for ${voice})`);
+        }
+      }
+
+      // Emotional preset overlay — modifies stability + similarity_boost only
+      if (emotion && EMOTIONAL_PRESETS[emotion]) {
+        resolvedSettings = {
+          ...resolvedSettings,
+          stability: EMOTIONAL_PRESETS[emotion].stability,
+          similarity_boost: EMOTIONAL_PRESETS[emotion].similarity_boost,
+        };
+        console.log(`🎭 Emotion overlay: ${emotion}`);
+      }
+
+      console.log(`🎙️  Generating speech (voice: ${effectiveVoiceId}, speed: ${resolvedSettings.speed}, stability: ${resolvedSettings.stability}, boost: ${resolvedSettings.similarity_boost}, style: ${resolvedSettings.style}, volume: ${resolvedVolume})`);
+
+      const audioBuffer = await generateSpeech(safeMessage, effectiveVoiceId, resolvedSettings);
+      await playAudio(audioBuffer, resolvedVolume);
+      voicePlayed = true;
+    } catch (error: any) {
+      console.error("Failed to generate/play speech:", error);
+      voiceError = error.message || "TTS generation failed";
+    }
+  }
+
+  // Display macOS notification (macOS only — skip on Linux)
+  if (voiceConfig.desktopNotifications && process.platform === 'darwin') {
+    try {
+      const escapedTitle = escapeForAppleScript(safeTitle);
+      const escapedMessage = escapeForAppleScript(safeMessage);
+      const script = `display notification "${escapedMessage}" with title "${escapedTitle}" sound name ""`;
+      await spawnSafe('/usr/bin/osascript', ['-e', script]);
+    } catch (error) {
+      console.error("Notification display error:", error);
+    }
+  }
+
+  return { voicePlayed, voiceError };
+}
+
+// Rate limiting
+const requestCounts = new Map<string, { count: number; resetTime: number }>();
+const RATE_LIMIT = 10;
+const RATE_WINDOW = 60000;
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const record = requestCounts.get(ip);
+
+  if (!record || now > record.resetTime) {
+    requestCounts.set(ip, { count: 1, resetTime: now + RATE_WINDOW });
+    return true;
+  }
+
+  if (record.count >= RATE_LIMIT) {
+    return false;
+  }
+
+  record.count++;
+  return true;
+}
+
+// Start HTTP server
+const server = serve({
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    const clientIp = req.headers.get('x-forwarded-for') || 'localhost';
+
+    const corsHeaders = {
+      "Access-Control-Allow-Origin": "http://localhost",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type"
+    };
+
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders, status: 204 });
+    }
+
+    if (!checkRateLimit(clientIp)) {
+      return new Response(
+        JSON.stringify({ status: "error", message: "Rate limit exceeded" }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 429
+        }
+      );
+    }
+
+    if (url.pathname === "/notify" && req.method === "POST") {
+      try {
+        const data = await req.json();
+        const title = data.title || "PAI Notification";
+        const message = data.message || "Task completed";
+        const voiceEnabled = data.voice_enabled !== false;
+        const voiceId = data.voice_id || data.voice_name || null;
+        const voiceSettings = data.voice_settings || null;
+        const volume = data.volume ?? null;
+
+        if (voiceId && typeof voiceId !== 'string') {
+          throw new Error('Invalid voice_id');
+        }
+
+        console.log(`📨 Notification: "${title}" - "${message}" (voice: ${voiceEnabled}, voiceId: ${voiceId || DEFAULT_VOICE_ID})`);
+
+        const result = await sendNotification(title, message, voiceEnabled, voiceId, voiceSettings, volume);
+
+        if (voiceEnabled && !result.voicePlayed && result.voiceError) {
+          return new Response(
+            JSON.stringify({ status: "error", message: `TTS failed: ${result.voiceError}`, notification_sent: true }),
+            {
+              headers: { ...corsHeaders, "Content-Type": "application/json" },
+              status: 502
+            }
+          );
+        }
+
+        return new Response(
+          JSON.stringify({ status: "success", message: "Notification sent" }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: 200
+          }
+        );
+      } catch (error: any) {
+        console.error("Notification error:", error);
+        return new Response(
+          JSON.stringify({ status: "error", message: error.message || "Internal server error" }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: error.message?.includes('Invalid') ? 400 : 500
+          }
+        );
+      }
+    }
+
+    // /notify/personality — compatibility shim for callers using the old Qwen3-TTS endpoint
+    // Personality fields are Qwen3-specific; for ElevenLabs, we just speak with default voice
+    if (url.pathname === "/notify/personality" && req.method === "POST") {
+      try {
+        const data = await req.json();
+        const message = data.message || "Notification";
+
+        console.log(`🎭 Personality notification: "${message}"`);
+
+        await sendNotification("PAI Notification", message, true, null);
+
+        return new Response(
+          JSON.stringify({ status: "success", message: "Personality notification sent" }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: 200
+          }
+        );
+      } catch (error: any) {
+        console.error("Personality notification error:", error);
+        return new Response(
+          JSON.stringify({ status: "error", message: error.message || "Internal server error" }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: error.message?.includes('Invalid') ? 400 : 500
+          }
+        );
+      }
+    }
+
+    if (url.pathname === "/pai" && req.method === "POST") {
+      try {
+        const data = await req.json();
+        const title = data.title || "PAI Assistant";
+        const message = data.message || "Task completed";
+
+        console.log(`🤖 PAI notification: "${title}" - "${message}"`);
+
+        await sendNotification(title, message, true, null);
+
+        return new Response(
+          JSON.stringify({ status: "success", message: "PAI notification sent" }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: 200
+          }
+        );
+      } catch (error: any) {
+        console.error("PAI notification error:", error);
+        return new Response(
+          JSON.stringify({ status: "error", message: error.message || "Internal server error" }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: error.message?.includes('Invalid') ? 400 : 500
+          }
+        );
+      }
+    }
+
+    if (url.pathname === "/health") {
+      return new Response(
+        JSON.stringify({
+          status: "healthy",
+          port: PORT,
+          voice_system: "ElevenLabs",
+          default_voice_id: DEFAULT_VOICE_ID,
+          api_key_configured: !!ELEVENLABS_API_KEY,
+          pronunciation_rules: pronunciationRules.length,
+          configured_voices: Object.keys(voiceConfig.voices),
+        }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 200
+        }
+      );
+    }
+
+    return new Response("Voice Server - POST to /notify, /notify/personality, or /pai", {
+      headers: corsHeaders,
+      status: 200
+    });
+  },
+});
+
+console.log(`🚀 Voice Server running on port ${PORT}`);
+console.log(`🎙️  Using ElevenLabs TTS (default voice: ${DEFAULT_VOICE_ID})`);
+console.log(`📡 POST to http://localhost:${PORT}/notify`);
+console.log(`🔒 Security: CORS restricted to localhost, rate limiting enabled`);
+console.log(`🔑 API Key: ${ELEVENLABS_API_KEY ? '✅ Configured' : '❌ Missing'}`);
+console.log(`📖 Pronunciations: ${pronunciationRules.length} rules loaded`);

--- a/VoiceServer/start.sh
+++ b/VoiceServer/start.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Start the Voice Server
+# Supports macOS (LaunchAgent) and Linux (systemd user service)
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OS=$(uname -s)
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}> Starting Voice Server...${NC}"
+
+if [[ "$OS" == "Darwin" ]]; then
+    SERVICE_NAME="com.pai.voice-server"
+    PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
+
+    if [ ! -f "$PLIST_PATH" ]; then
+        echo -e "${RED}X Service not installed${NC}"
+        echo "  Run ./install.sh first to install the service"
+        exit 1
+    fi
+
+    if launchctl list | grep -q "$SERVICE_NAME" 2>/dev/null; then
+        echo -e "${YELLOW}! Voice server is already running${NC}"
+        echo "  To restart, use: ./restart.sh"
+        exit 0
+    fi
+
+    launchctl load "$PLIST_PATH" 2>/dev/null
+
+elif [[ "$OS" == "Linux" ]]; then
+    SERVICE_NAME="pai-voice-server"
+    SERVICE_FILE="$HOME/.config/systemd/user/${SERVICE_NAME}.service"
+
+    if [ ! -f "$SERVICE_FILE" ]; then
+        echo -e "${RED}X Service not installed${NC}"
+        echo "  Run ./install.sh first to install the service"
+        exit 1
+    fi
+
+    if systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+        echo -e "${YELLOW}! Voice server is already running${NC}"
+        echo "  To restart, use: ./restart.sh"
+        exit 0
+    fi
+
+    systemctl --user start "$SERVICE_NAME"
+
+else
+    echo -e "${RED}X Unsupported operating system: $OS${NC}"
+    exit 1
+fi
+
+# Verify server is responding
+sleep 2
+if curl -s -f -X GET http://localhost:8888/health > /dev/null 2>&1; then
+    echo -e "${GREEN}OK Voice server started successfully (port 8888)${NC}"
+else
+    echo -e "${YELLOW}! Server started but not responding yet${NC}"
+    if [[ "$OS" == "Darwin" ]]; then
+        echo "  Check logs: tail -f ~/Library/Logs/pai-voice-server.log"
+    else
+        echo "  Check logs: journalctl --user -u pai-voice-server -f"
+    fi
+fi

--- a/VoiceServer/status.sh
+++ b/VoiceServer/status.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Check status of Voice Server
+# Supports macOS (LaunchAgent) and Linux (systemd user service)
+
+OS=$(uname -s)
+ENV_FILE="$HOME/.env"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}=====================================================${NC}"
+echo -e "${BLUE}     PAI Voice Server Status${NC}"
+echo -e "${BLUE}     Platform: $OS${NC}"
+echo -e "${BLUE}=====================================================${NC}"
+echo
+
+# ── Service status ───────────────────────────────────────────────────────────
+echo -e "${BLUE}Service Status:${NC}"
+
+if [[ "$OS" == "Darwin" ]]; then
+    SERVICE_NAME="com.pai.voice-server"
+    LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+
+    if launchctl list | grep -q "$SERVICE_NAME" 2>/dev/null; then
+        PID=$(launchctl list | grep "$SERVICE_NAME" | awk '{print $1}')
+        if [ "$PID" != "-" ]; then
+            echo -e "  ${GREEN}OK LaunchAgent loaded (PID: $PID)${NC}"
+        else
+            echo -e "  ${YELLOW}! LaunchAgent loaded but not running${NC}"
+        fi
+    else
+        echo -e "  ${RED}X LaunchAgent not loaded — run ./install.sh${NC}"
+    fi
+
+elif [[ "$OS" == "Linux" ]]; then
+    SERVICE_NAME="pai-voice-server"
+    LOG_PATH="$HOME/.local/share/pai/voice-server.log"
+
+    if systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+        PID=$(systemctl --user show -p MainPID --value "$SERVICE_NAME" 2>/dev/null)
+        echo -e "  ${GREEN}OK systemd service active (PID: $PID)${NC}"
+    elif systemctl --user is-enabled --quiet "$SERVICE_NAME" 2>/dev/null; then
+        echo -e "  ${YELLOW}! Service installed but not running — try: ./start.sh${NC}"
+    else
+        echo -e "  ${RED}X Service not installed — run ./install.sh${NC}"
+    fi
+
+else
+    echo -e "  ${RED}X Unsupported operating system: $OS${NC}"
+    exit 1
+fi
+
+# ── HTTP health check ────────────────────────────────────────────────────────
+echo
+echo -e "${BLUE}Server Status:${NC}"
+HEALTH=$(curl -s http://localhost:8888/health 2>/dev/null)
+if [ -n "$HEALTH" ]; then
+    echo -e "  ${GREEN}OK Responding on port 8888${NC}"
+    echo "  Health: $HEALTH"
+else
+    echo -e "  ${RED}X Not responding on port 8888${NC}"
+fi
+
+# ── Port check ───────────────────────────────────────────────────────────────
+echo
+echo -e "${BLUE}Port Status:${NC}"
+PORT_IN_USE=false
+if command -v lsof &>/dev/null && lsof -i :8888 > /dev/null 2>&1; then
+    PORT_IN_USE=true
+    PROCESS=$(lsof -i :8888 | grep LISTEN | head -1)
+    echo -e "  ${GREEN}OK Port 8888 is in use${NC}"
+    echo "$PROCESS" | awk '{print "  Process: " $1 " (PID: " $2 ")"}'
+elif command -v ss &>/dev/null && ss -tlnp 2>/dev/null | grep -q ':8888'; then
+    PORT_IN_USE=true
+    echo -e "  ${GREEN}OK Port 8888 is in use${NC}"
+    ss -tlnp 2>/dev/null | grep ':8888'
+fi
+if [ "$PORT_IN_USE" = false ]; then
+    echo -e "  ${YELLOW}! Port 8888 is not in use${NC}"
+fi
+
+# ── Voice configuration ──────────────────────────────────────────────────────
+echo
+echo -e "${BLUE}Voice Configuration:${NC}"
+if [ -f "$ENV_FILE" ] && grep -q "ELEVENLABS_API_KEY=" "$ENV_FILE"; then
+    API_KEY=$(grep "ELEVENLABS_API_KEY=" "$ENV_FILE" | cut -d'=' -f2-)
+    if [ "$API_KEY" != "your_api_key_here" ] && [ -n "$API_KEY" ]; then
+        echo -e "  ${GREEN}OK ElevenLabs API configured${NC}"
+    else
+        echo -e "  ${YELLOW}! ElevenLabs API key placeholder — update ~/.env${NC}"
+    fi
+else
+    echo -e "  ${YELLOW}! No ElevenLabs configuration found in ~/.env${NC}"
+fi
+
+# ── Recent logs ──────────────────────────────────────────────────────────────
+echo
+echo -e "${BLUE}Recent Logs:${NC}"
+if [ -f "$LOG_PATH" ]; then
+    echo "  Log file: $LOG_PATH"
+    echo "  Last 5 lines:"
+    tail -5 "$LOG_PATH" | while IFS= read -r line; do
+        echo "    $line"
+    done
+elif [[ "$OS" == "Linux" ]]; then
+    echo "  No log file yet — journalctl logs:"
+    journalctl --user -u "$SERVICE_NAME" -n 5 --no-pager 2>/dev/null | while IFS= read -r line; do
+        echo "    $line"
+    done
+else
+    echo -e "  ${YELLOW}! No log file found${NC}"
+fi
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+echo
+echo -e "${BLUE}Available Commands:${NC}"
+echo "  - Start:     ./start.sh"
+echo "  - Stop:      ./stop.sh"
+echo "  - Restart:   ./restart.sh"
+echo "  - Uninstall: ./uninstall.sh"
+echo "  - Logs:      tail -f $LOG_PATH"
+echo "  - Test:      curl -X POST http://localhost:8888/notify -H 'Content-Type: application/json' -d '{\"message\":\"Test\"}'"

--- a/VoiceServer/stop.sh
+++ b/VoiceServer/stop.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Stop the Voice Server
+# Supports macOS (LaunchAgent) and Linux (systemd user service)
+
+OS=$(uname -s)
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}> Stopping Voice Server...${NC}"
+
+if [[ "$OS" == "Darwin" ]]; then
+    SERVICE_NAME="com.pai.voice-server"
+    PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
+
+    if launchctl list | grep -q "$SERVICE_NAME" 2>/dev/null; then
+        launchctl unload "$PLIST_PATH" 2>/dev/null
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}OK Voice server stopped${NC}"
+        else
+            echo -e "${RED}X Failed to stop voice server${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}! Voice server is not running${NC}"
+    fi
+
+elif [[ "$OS" == "Linux" ]]; then
+    SERVICE_NAME="pai-voice-server"
+
+    if systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+        systemctl --user stop "$SERVICE_NAME"
+        echo -e "${GREEN}OK Voice server stopped${NC}"
+    else
+        echo -e "${YELLOW}! Voice server is not running${NC}"
+    fi
+
+else
+    echo -e "${RED}X Unsupported operating system: $OS${NC}"
+    exit 1
+fi
+
+# Clean up any remaining PAI voice server process on port 8888
+_pai_pids_on_8888() {
+    local pids=""
+    if command -v lsof &>/dev/null; then
+        pids=$(lsof -ti :8888 2>/dev/null)
+    elif command -v ss &>/dev/null; then
+        pids=$(ss -tlnp 2>/dev/null | grep ':8888' | grep -o 'pid=[0-9]*' | cut -d= -f2)
+    fi
+    # Only return PIDs whose cmdline includes bun or server.ts (scoped to PAI)
+    local pai_pids=""
+    for pid in $pids; do
+        if [ -r "/proc/$pid/cmdline" ]; then
+            if grep -qa 'bun\|server\.ts' "/proc/$pid/cmdline" 2>/dev/null; then
+                pai_pids="$pai_pids $pid"
+            fi
+        elif ps -p "$pid" -o args= 2>/dev/null | grep -q 'bun\|server\.ts'; then
+            pai_pids="$pai_pids $pid"
+        fi
+    done
+    echo "$pai_pids"
+}
+
+REMAINING=$(_pai_pids_on_8888)
+if [ -n "$REMAINING" ]; then
+    echo -e "${YELLOW}> Cleaning up remaining PAI process on port 8888...${NC}"
+    # Graceful shutdown: SIGTERM first, then SIGKILL if still alive after 3s
+    echo "$REMAINING" | xargs kill -TERM 2>/dev/null || true
+    sleep 3
+    STILL_ALIVE=$(_pai_pids_on_8888)
+    if [ -n "$STILL_ALIVE" ]; then
+        echo "$STILL_ALIVE" | xargs kill -KILL 2>/dev/null || true
+    fi
+    echo -e "${GREEN}OK Port 8888 cleared${NC}"
+fi

--- a/VoiceServer/uninstall.sh
+++ b/VoiceServer/uninstall.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Uninstall Voice Server
+# Supports macOS (LaunchAgent) and Linux (systemd user service)
+
+OS=$(uname -s)
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}=====================================================${NC}"
+echo -e "${BLUE}     PAI Voice Server Uninstall${NC}"
+echo -e "${BLUE}     Platform: $OS${NC}"
+echo -e "${BLUE}=====================================================${NC}"
+echo
+
+echo -e "${YELLOW}This will:${NC}"
+echo "  - Stop the voice server"
+if [[ "$OS" == "Darwin" ]]; then
+    echo "  - Remove the LaunchAgent (~/Library/LaunchAgents/com.pai.voice-server.plist)"
+elif [[ "$OS" == "Linux" ]]; then
+    echo "  - Disable and remove the systemd user service"
+fi
+echo "  - Keep your server files and configuration"
+echo
+read -p "Are you sure you want to uninstall? (y/n): " -n 1 -r
+echo
+echo
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Uninstall cancelled"
+    exit 0
+fi
+
+if [[ "$OS" == "Darwin" ]]; then
+    SERVICE_NAME="com.pai.voice-server"
+    PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
+    LOG_PATH="$HOME/Library/Logs/pai-voice-server.log"
+
+    echo -e "${YELLOW}> Stopping voice server...${NC}"
+    if launchctl list | grep -q "$SERVICE_NAME" 2>/dev/null; then
+        launchctl unload "$PLIST_PATH" 2>/dev/null
+        echo -e "${GREEN}OK Voice server stopped${NC}"
+    else
+        echo -e "${YELLOW}  Service was not running${NC}"
+    fi
+
+    echo -e "${YELLOW}> Removing LaunchAgent...${NC}"
+    if [ -f "$PLIST_PATH" ]; then
+        rm "$PLIST_PATH"
+        echo -e "${GREEN}OK LaunchAgent removed${NC}"
+    else
+        echo -e "${YELLOW}  LaunchAgent file not found${NC}"
+    fi
+
+elif [[ "$OS" == "Linux" ]]; then
+    SERVICE_NAME="pai-voice-server"
+    SERVICE_FILE="$HOME/.config/systemd/user/${SERVICE_NAME}.service"
+    LOG_PATH="$HOME/.local/share/pai/voice-server.log"
+
+    echo -e "${YELLOW}> Stopping voice server...${NC}"
+    if systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+        systemctl --user stop "$SERVICE_NAME"
+        echo -e "${GREEN}OK Voice server stopped${NC}"
+    else
+        echo -e "${YELLOW}  Service was not running${NC}"
+    fi
+
+    echo -e "${YELLOW}> Disabling and removing systemd service...${NC}"
+    systemctl --user disable "$SERVICE_NAME" 2>/dev/null || true
+    if [ -f "$SERVICE_FILE" ]; then
+        rm "$SERVICE_FILE"
+        systemctl --user daemon-reload
+        echo -e "${GREEN}OK systemd service removed${NC}"
+    else
+        echo -e "${YELLOW}  Service file not found${NC}"
+    fi
+
+else
+    echo -e "${RED}X Unsupported operating system: $OS${NC}"
+    exit 1
+fi
+
+# Clean up any remaining PAI voice server process on port 8888
+_pai_pids_on_8888() {
+    local pids=""
+    if command -v lsof &>/dev/null; then
+        pids=$(lsof -ti :8888 2>/dev/null)
+    elif command -v ss &>/dev/null; then
+        pids=$(ss -tlnp 2>/dev/null | grep ':8888' | grep -o 'pid=[0-9]*' | cut -d= -f2)
+    fi
+    local pai_pids=""
+    for pid in $pids; do
+        if [ -r "/proc/$pid/cmdline" ]; then
+            if grep -qa 'bun\|server\.ts' "/proc/$pid/cmdline" 2>/dev/null; then
+                pai_pids="$pai_pids $pid"
+            fi
+        elif ps -p "$pid" -o args= 2>/dev/null | grep -q 'bun\|server\.ts'; then
+            pai_pids="$pai_pids $pid"
+        fi
+    done
+    echo "$pai_pids"
+}
+
+REMAINING=$(_pai_pids_on_8888)
+if [ -n "$REMAINING" ]; then
+    echo -e "${YELLOW}> Cleaning up remaining PAI process on port 8888...${NC}"
+    echo "$REMAINING" | xargs kill -TERM 2>/dev/null || true
+    sleep 3
+    STILL_ALIVE=$(_pai_pids_on_8888)
+    if [ -n "$STILL_ALIVE" ]; then
+        echo "$STILL_ALIVE" | xargs kill -KILL 2>/dev/null || true
+    fi
+    echo -e "${GREEN}OK Port 8888 cleared${NC}"
+fi
+
+# Offer to remove log file
+echo
+read -p "Do you want to remove log files? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [ -f "$LOG_PATH" ]; then
+        rm "$LOG_PATH"
+        echo -e "${GREEN}OK Log file removed${NC}"
+    fi
+fi
+
+echo
+echo -e "${GREEN}=====================================================${NC}"
+echo -e "${GREEN}     Uninstall Complete${NC}"
+echo -e "${GREEN}=====================================================${NC}"
+echo
+echo -e "${BLUE}Notes:${NC}"
+echo "  - Your server files are still in: $(dirname "${BASH_SOURCE[0]}")"
+echo "  - Your ~/.env configuration is preserved"
+echo "  - To reinstall, run: ./install.sh"
+echo
+echo "To completely remove all files:"
+echo "  rm -rf $(dirname "${BASH_SOURCE[0]}")"

--- a/VoiceServer/voices.json
+++ b/VoiceServer/voices.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "./voices-schema.json",
+  "default_rate": 175,
+  "default_volume": 0.8,
+  "voices": {
+    "default": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Default (Male)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.50,
+      "similarity_boost": 0.75,
+      "description": "Default male voice - balanced and professional",
+      "type": "Premium"
+    },
+    "assistant": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Assistant (Male)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.50,
+      "similarity_boost": 0.75,
+      "description": "Primary assistant voice - warm and helpful",
+      "type": "Premium"
+    },
+    "researcher": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Researcher (Female)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.65,
+      "similarity_boost": 0.9,
+      "description": "Research agent voice - analytical and authoritative",
+      "type": "Premium"
+    },
+    "engineer": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Engineer (Male)",
+      "rate_multiplier": 1.3,
+      "rate_wpm": 228,
+      "stability": 0.7,
+      "similarity_boost": 0.85,
+      "description": "Engineering voice - measured and precise",
+      "type": "Premium"
+    },
+    "architect": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Architect (Female)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.7,
+      "similarity_boost": 0.85,
+      "description": "Architecture voice - strategic and sophisticated",
+      "type": "Premium"
+    },
+    "designer": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Designer (Female)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.62,
+      "similarity_boost": 0.85,
+      "description": "Design voice - creative and discerning",
+      "type": "Premium"
+    },
+    "analyst": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Analyst (Neutral)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.65,
+      "similarity_boost": 0.85,
+      "description": "Analyst voice - thorough and balanced",
+      "type": "Premium"
+    },
+    "writer": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Writer (Female)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.6,
+      "similarity_boost": 0.8,
+      "description": "Writer voice - articulate and warm",
+      "type": "Premium"
+    },
+    "security": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Security (Male)",
+      "rate_multiplier": 1.35,
+      "rate_wpm": 236,
+      "stability": 0.32,
+      "similarity_boost": 0.88,
+      "description": "Security voice - alert and focused",
+      "type": "Enhanced"
+    },
+    "intern": {
+      "voice_id": "YOUR_VOICE_ID_HERE",
+      "voice_name": "Intern (Neutral)",
+      "rate_multiplier": 1.4,
+      "rate_wpm": 245,
+      "stability": 0.42,
+      "similarity_boost": 0.72,
+      "description": "Intern voice - enthusiastic and eager",
+      "type": "Premium"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the VoiceServer component with full support for both macOS and Linux. All 6 management scripts auto-detect the OS via `uname -s` — no manual configuration needed.

- **macOS**: `launchctl` / `~/Library/LaunchAgents` (existing pattern preserved unchanged)
- **Linux**: `systemctl --user` / `~/.config/systemd/user/pai-voice-server.service`

## Platform Details

| | macOS | Linux |
|--|-------|-------|
| Service manager | launchctl / LaunchAgent plist | systemd user service |
| Log path | `~/Library/Logs/pai-voice-server.log` | `~/.local/share/pai/voice-server.log` |
| Auto-start on boot | RunAtLoad plist key | `loginctl enable-linger` |
| Root required | No | No |

## Scripts included

`install.sh` · `start.sh` · `stop.sh` · `restart.sh` · `status.sh` · `uninstall.sh`

## Implementation notes

- Port cleanup is scoped to PAI `bun`/`server.ts` processes only — never kills unrelated processes on port 8888
- Graceful shutdown: SIGTERM with 3s grace period before SIGKILL fallback
- API key parsing uses `cut -d'=' -f2-` to correctly handle base64 keys containing `=`
- `ss` port check uses portable `grep -o` instead of `grep -oP` (works on Alpine/RHEL/older systems)
- `loginctl enable-linger` failure produces a visible warning with fix instructions instead of silently swallowing
- Single `curl` call in `status.sh` (response cached, not fetched twice)

## Test Plan

- [ ] Linux: `./install.sh` creates `~/.config/systemd/user/pai-voice-server.service`
- [ ] Linux: `systemctl --user status pai-voice-server` shows active after install
- [ ] Linux: Service survives reboot (with `loginctl enable-linger`)
- [ ] Linux: `./stop.sh`, `./start.sh`, `./restart.sh`, `./status.sh`, `./uninstall.sh` all work correctly
- [ ] macOS: All existing LaunchAgent behavior unchanged
- [ ] Both: `curl http://localhost:8888/health` returns healthy response after install

**Tested on:** Ubuntu 24.04 LTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)