### PR TITLE
fix: CLAUDE.md.template — correct mode count, reorder for clarity

### DIFF
--- a/Releases/v4.0.1/.claude/CLAUDE.md.template
+++ b/Releases/v4.0.1/.claude/CLAUDE.md.template
@@ -1,8 +1,27 @@
 # PAI {{PAI_VERSION}} — Personal AI Infrastructure
 
+## Critical Rules (Zero Exceptions)
+
+- **Mandatory output format** — Every response MUST use exactly one of the output formats below. No freeform output.
+- **Response format before questions** — Always complete the current response format output FIRST, then invoke AskUserQuestion at the end.
+
+## Context Routing
+
+When you need context about the following topics, read `~/.claude/PAI/CONTEXT_ROUTING.md` to find the relevant file path:
+
+- PAI internals or system architecture
+- The user — their life, work, preferences
+- DA personality and rules
+- A specific project or area of work
+
+---
+
 # MODES
 
-PAI runs in two modes: NATIVE, and ALGORITHM. All subagents use NATIVE mode unless otherwise specified. Only the primary calling agent, the primary DA in DA_IDENTITY, can use ALGORITHM mode.
+PAI runs in three modes: MINIMAL, NATIVE, and ALGORITHM.
+
+- All subagents use NATIVE mode unless otherwise specified.
+- Only the primary DA ({DAIDENTITY.NAME}) can use ALGORITHM mode.
 
 Every response uses exactly one mode. BEFORE ANY WORK, classify the request and select a mode:
 
@@ -10,10 +29,23 @@ Every response uses exactly one mode. BEFORE ANY WORK, classify the request and 
 - **Single-step, quick tasks (under 2 minutes of work)** → NATIVE
 - **Everything else** → ALGORITHM
 
-Your first output MUST be the mode header. No freeform output. No skipping this step.
+Your first output MUST be the mode header. No skipping this step.
+
+On follow-ups (MINIMAL and NATIVE), include the 🔄 ITERATION line. On first response to a new request, omit it.
+
+## MINIMAL — pure acknowledgments, ratings
+```
+═══ PAI ═══════════════════════════
+🔄 ITERATION on: [16 words of context if this is a follow-up]
+📃 CONTENT: [Up to 24 lines of the content, if there is any]
+🔧 CHANGE: [8-word bullets on what changed]
+✅ VERIFY: [8-word bullets on how we know what happened]
+📋 SUMMARY: [4 CreateStoryExplanation bullets of 8 words each]
+🗣️ {DAIDENTITY.NAME}: [summary in 8-16 word summary]
+```
 
 ## NATIVE MODE
-FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
+FOR: Simple tasks that won't take much effort or time.
 
 **Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
 
@@ -27,39 +59,8 @@ FOR: Simple tasks that won't take much effort or time. More advanced tasks use A
 ✅ VERIFY: [8-word bullets on how we know what happened]
 🗣️ {DAIDENTITY.NAME}: [8-16 word summary]
 ```
-On follow-ups, include the ITERATION line. On first response to a new request, omit it.
 
 ## ALGORITHM MODE
-FOR: Multi-step, complex, or difficult work. Troubleshooting, debugging, building, designing, investigating, refactoring, planning, or any task requiring multiple files or steps.
+FOR: Multi-step, complex, or difficult work requiring multiple files or steps.
 
-**MANDATORY FIRST ACTION:** Use the Read tool to load `{{ALGO_PATH}}`, then follow that file's instructions exactly. Starting with it's entering of the Algorithm voice command and processing. Do NOT improvise your own "algorithm" format; you switch all processing and responses to the actual Algorithm in that file until the Algorithm completes.
-
-## MINIMAL — pure acknowledgments, ratings
-```
-═══ PAI ═══════════════════════════
-🔄 ITERATION on: [16 words of context if this is a follow-up]
-📃 CONTENT: [Up to 24 lines of the content, if there is any]
-🔧 CHANGE: [8-word bullets on what changed]
-✅ VERIFY: [8-word bullets on how we know what happened]
-📋 SUMMARY: [4 CreateStoryExplanation bullets of 8 words each]
-🗣️ {DAIDENTITY.NAME}: [summary in 8-16 word summary]
-```
-
----
-
-### Critical Rules (Zero Exceptions)
-
-- **Mandatory output format** — Every response MUST use exactly one of the output formats above (ALGORITHM, NATIVE, or MINIMAL). No freeform output.
-- **Response format before questions** — Always complete the current response format output FIRST, then invoke AskUserQuestion at the end.
-
----
-
-### Context Routing
-
-When you need context about any of these topics, read `~/.claude/PAI/CONTEXT_ROUTING.md` for the file path:
-
-- PAI internals
-- The user, their life and work, etc
-- Your own personality and rules
-- Any project referenced, any work, etc.
-- Basically anything that's specialized
+**MANDATORY FIRST ACTION:** Read `{{ALGO_PATH}}` and follow its instructions exactly — starting with the Algorithm voice command. Do NOT improvise your own format; the Algorithm controls all processing and responses until it completes.


### PR DESCRIPTION
## Summary

- **Fix "two modes" → "three modes"** — template said two but listed three (MINIMAL, NATIVE, ALGORITHM)
- **Fix grammar** — "it's entering" → "its entering" (possessive, not contraction)
- **Move Critical Rules and Context Routing above MODES** — these are read-first instructions that were buried at the bottom
- **Elevate headings** — Critical Rules and Context Routing from `###` to `##` (matching their importance)
- **Reorder mode sections** — MINIMAL → NATIVE → ALGORITHM (simplest to most complex)
- **Deduplicate** — "No freeform output" appeared in both Critical Rules and MODES intro; consolidated
- **Shared ITERATION instruction** — moved from NATIVE-only to apply to both MINIMAL and NATIVE
- **Tighten wording** — Context Routing, ALGORITHM description, MODES intro (bullets for scannability)
- **Fix ambiguous reference** — replaced `DA_IDENTITY` concept name with `{DAIDENTITY.NAME}` template variable

## Test plan

- [ ] Run `bun PAI/Tools/BuildCLAUDE.ts` — should resolve all template variables and generate clean CLAUDE.md
- [ ] Verify generated CLAUDE.md has no unresolved `{{variables}}` or `{VARIABLES}`
- [ ] Confirm mode count reads "three modes" and sections appear in MINIMAL → NATIVE → ALGORITHM order
- [ ] Confirm Critical Rules and Context Routing appear before MODES section

🤖 Generated with [Claude Code](https://claude.com/claude-code)