### PR TITLE
fix(v4.0.1): Fix broken UpdateTelos paths and add bootstrap support

### DIFF
--- a/Releases/v4.0.1/.claude/skills/Telos/Workflows/Update.md
+++ b/Releases/v4.0.1/.claude/skills/Telos/Workflows/Update.md
@@ -78,7 +78,7 @@ This is the main command you'll use. It takes three parameters:
 - Content to add (the actual text)
 - Description of the change (for the changelog)
 
-!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/commands/update-telos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
+!`FILE="$1"; CONTENT="$2"; DESCRIPTION="$3"; bun ~/.claude/skills/Telos/Tools/UpdateTelos.ts "$FILE" "$CONTENT" "$DESCRIPTION"`
 
 ## List Valid TELOS Files
 !`echo "Valid TELOS files:


### PR DESCRIPTION
## Summary

- **UpdateTelos.ts** hardcodes `~/.claude/context/life/telos/` as the TELOS directory, but this path doesn't exist. Every other file in the system (SKILL.md, Update.md workflow, CONTEXT_ROUTING.md, DashboardTemplate, PAIUpgrade skill) references `~/.claude/PAI/USER/TELOS/`. The script is completely non-functional.
- **Update.md** workflow calls `~/.claude/commands/update-telos.ts` which also doesn't exist. The actual script lives at `skills/Telos/Tools/UpdateTelos.ts`.
- The script errors out if a TELOS file doesn't already exist, making initial population impossible through the intended workflow.

## Changes

| Fix | File | Line |
|-----|------|------|
| TELOS_DIR path: `context/life/telos` -> `PAI/USER/TELOS` | `UpdateTelos.ts` | 41 |
| Backups dir casing: `backups` -> `Backups` | `UpdateTelos.ts` | 42 |
| Script path: `commands/update-telos.ts` -> `skills/Telos/Tools/UpdateTelos.ts` | `Update.md` | 81 |
| Auto-create TELOS + Backups dirs if missing | `UpdateTelos.ts` | 107-108 |
| Bootstrap new files with header instead of erroring | `UpdateTelos.ts` | 128-143 |
| Auto-create `updates.md` changelog if missing | `UpdateTelos.ts` | 159-161 |

## Test plan

- [ ] Run `bun skills/Telos/Tools/UpdateTelos.ts BOOKS.md "- Test Book" "Test entry"` on a fresh install (no pre-existing TELOS files)
- [ ] Verify file created at `~/.claude/PAI/USER/TELOS/BOOKS.md` with header
- [ ] Verify `updates.md` and `Backups/` directory auto-created
- [ ] Run again to verify append + backup works on existing file
- [ ] Verify backup appears in `Backups/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)