### PR TITLE
fix: remove 29 dead references from CONTEXT_ROUTING.md

### DIFF
--- a/Releases/v4.0.0/.claude/PAI/CONTEXT_ROUTING.md
+++ b/Releases/v4.0.0/.claude/PAI/CONTEXT_ROUTING.md
@@ -13,62 +13,19 @@ Load context on-demand by reading the file at the path listed. Only load what th
 | Hook system | `PAI/THEHOOKSYSTEM.md` |
 | Agent system | `PAI/PAIAGENTSYSTEM.md` |
 | Delegation system | `PAI/THEDELEGATIONSYSTEM.md` |
-| Security system | `PAI/PAISECURITYSYSTEM/` |
 | Notification system | `PAI/THENOTIFICATIONSYSTEM.md` |
-| Browser automation | `PAI/BROWSERAUTOMATION.md` |
 | CLI architecture | `PAI/CLIFIRSTARCHITECTURE.md` |
 | Tools reference | `PAI/TOOLS.md` |
 | Actions & pipelines | `PAI/ACTIONS.md`, `PAI/PIPELINES.md` |
 | Flows | `PAI/FLOWS.md` |
-| Deployment | `PAI/DEPLOYMENT.md` |
 | Behavioral rules | `PAI/AISTEERINGRULES.md` |
 | PRD format spec | `PAI/PRDFORMAT.md` |
 
-## {PRINCIPAL.NAME} — Identity & Voice
+## {PRINCIPAL.NAME} — Personal Context
 
 | Topic | Path |
 |-------|------|
-| About {PRINCIPAL.NAME} | `PAI/USER/ABOUTME.md` |
-| Career & resume | `PAI/USER/RESUME.md` |
-| Contacts | `PAI/USER/CONTACTS.md` |
-| Personal rules | `PAI/USER/AISTEERINGRULES.md` |
-| Opinions | `PAI/USER/OPINIONS.md` |
-| Definitions | `PAI/USER/DEFINITIONS.md` |
-| Core content themes | `PAI/USER/CORECONTENT.md` |
-| Productivity system | `PAI/USER/PRODUCTIVITY.md` |
-| Writing style | `PAI/USER/WRITINGSTYLE.md` |
-| Rhetorical style | `PAI/USER/RHETORICALSTYLE.md` |
-
-## {PRINCIPAL.NAME} — Life Goals (Telos)
-
-| Topic | Path |
-|-------|------|
-| Telos overview | `PAI/USER/TELOS/README.md` |
-| Mission | `PAI/USER/TELOS/MISSION.md` |
-| Goals | `PAI/USER/TELOS/GOALS.md` |
-| Challenges | `PAI/USER/TELOS/CHALLENGES.md` |
-| Beliefs | `PAI/USER/TELOS/BELIEFS.md` |
-| Predictions | `PAI/USER/TELOS/PREDICTIONS.md` |
-| Wisdom | `PAI/USER/TELOS/WISDOM.md` |
-| Favorite books | `PAI/USER/TELOS/BOOKS.md` |
-| Favorite movies | `PAI/USER/TELOS/MOVIES.md` |
-| Favorite authors | `PAI/USER/TELOS/AUTHORS.md` |
-
-## {DAIDENTITY.NAME} (DA Identity)
-
-| Topic | Path |
-|-------|------|
-| {DAIDENTITY.NAME} identity & rules | `PAI/USER/DAIDENTITY.md` |
-| {DAIDENTITY.NAME} writing style | `PAI/USER/DAWRITINGSTYLE.md` |
-| Our relationship | `PAI/USER/OUR_STORY.md` |
-
-## {PRINCIPAL.NAME} — Work
-
-| Topic | Path |
-|-------|------|
-| Feed system | `PAI/USER/FEED.md` |
-| Projects | `PAI/USER/PROJECTS/PROJECTS.md` |
-| Business context | `PAI/USER/BUSINESS/` |
-| Health data | `PAI/USER/HEALTH/` |
-| Financial context | `PAI/USER/FINANCES/` |
 | All USER context index | `PAI/USER/README.md` |
+| Projects | `PAI/USER/PROJECTS/README.md` |
+| Business context | `PAI/USER/BUSINESS/README.md` |
+| Telos (life goals) | `PAI/USER/TELOS/README.md` |

--- a/Releases/v4.0.1/.claude/PAI/CONTEXT_ROUTING.md
+++ b/Releases/v4.0.1/.claude/PAI/CONTEXT_ROUTING.md
@@ -13,62 +13,19 @@ Load context on-demand by reading the file at the path listed. Only load what th
 | Hook system | `PAI/THEHOOKSYSTEM.md` |
 | Agent system | `PAI/PAIAGENTSYSTEM.md` |
 | Delegation system | `PAI/THEDELEGATIONSYSTEM.md` |
-| Security system | `PAI/PAISECURITYSYSTEM/` |
 | Notification system | `PAI/THENOTIFICATIONSYSTEM.md` |
-| Browser automation | `PAI/BROWSERAUTOMATION.md` |
 | CLI architecture | `PAI/CLIFIRSTARCHITECTURE.md` |
 | Tools reference | `PAI/TOOLS.md` |
 | Actions & pipelines | `PAI/ACTIONS.md`, `PAI/PIPELINES.md` |
 | Flows | `PAI/FLOWS.md` |
-| Deployment | `PAI/DEPLOYMENT.md` |
 | Behavioral rules | `PAI/AISTEERINGRULES.md` |
 | PRD format spec | `PAI/PRDFORMAT.md` |
 
-## {PRINCIPAL.NAME} — Identity & Voice
+## {PRINCIPAL.NAME} — Personal Context
 
 | Topic | Path |
 |-------|------|
-| About {PRINCIPAL.NAME} | `PAI/USER/ABOUTME.md` |
-| Career & resume | `PAI/USER/RESUME.md` |
-| Contacts | `PAI/USER/CONTACTS.md` |
-| Personal rules | `PAI/USER/AISTEERINGRULES.md` |
-| Opinions | `PAI/USER/OPINIONS.md` |
-| Definitions | `PAI/USER/DEFINITIONS.md` |
-| Core content themes | `PAI/USER/CORECONTENT.md` |
-| Productivity system | `PAI/USER/PRODUCTIVITY.md` |
-| Writing style | `PAI/USER/WRITINGSTYLE.md` |
-| Rhetorical style | `PAI/USER/RHETORICALSTYLE.md` |
-
-## {PRINCIPAL.NAME} — Life Goals (Telos)
-
-| Topic | Path |
-|-------|------|
-| Telos overview | `PAI/USER/TELOS/README.md` |
-| Mission | `PAI/USER/TELOS/MISSION.md` |
-| Goals | `PAI/USER/TELOS/GOALS.md` |
-| Challenges | `PAI/USER/TELOS/CHALLENGES.md` |
-| Beliefs | `PAI/USER/TELOS/BELIEFS.md` |
-| Predictions | `PAI/USER/TELOS/PREDICTIONS.md` |
-| Wisdom | `PAI/USER/TELOS/WISDOM.md` |
-| Favorite books | `PAI/USER/TELOS/BOOKS.md` |
-| Favorite movies | `PAI/USER/TELOS/MOVIES.md` |
-| Favorite authors | `PAI/USER/TELOS/AUTHORS.md` |
-
-## {DAIDENTITY.NAME} (DA Identity)
-
-| Topic | Path |
-|-------|------|
-| {DAIDENTITY.NAME} identity & rules | `PAI/USER/DAIDENTITY.md` |
-| {DAIDENTITY.NAME} writing style | `PAI/USER/DAWRITINGSTYLE.md` |
-| Our relationship | `PAI/USER/OUR_STORY.md` |
-
-## {PRINCIPAL.NAME} — Work
-
-| Topic | Path |
-|-------|------|
-| Feed system | `PAI/USER/FEED.md` |
-| Projects | `PAI/USER/PROJECTS/PROJECTS.md` |
-| Business context | `PAI/USER/BUSINESS/` |
-| Health data | `PAI/USER/HEALTH/` |
-| Financial context | `PAI/USER/FINANCES/` |
 | All USER context index | `PAI/USER/README.md` |
+| Projects | `PAI/USER/PROJECTS/README.md` |
+| Business context | `PAI/USER/BUSINESS/README.md` |
+| Telos (life goals) | `PAI/USER/TELOS/README.md` |


### PR DESCRIPTION
## Summary

- Removes 29 dead file/directory references from `CONTEXT_ROUTING.md` in v4.0.0 and v4.0.1
- Consolidates 4 USER sections into one pointing at the README.md indexes that actually ship with the release

## Problem

`CONTEXT_ROUTING.md` references 29 files/directories that don't exist in the v4.0.0+ releases:

| Category | Dead references | Examples |
|----------|----------------|----------|
| System docs | 3 | `PAISECURITYSYSTEM/`, `BROWSERAUTOMATION.md`, `DEPLOYMENT.md` |
| USER identity | 10 | `ABOUTME.md`, `RESUME.md`, `CONTACTS.md`, etc. |
| TELOS files | 9 | `MISSION.md`, `GOALS.md`, `BELIEFS.md`, etc. (only `README.md` ships) |
| DA identity | 3 | `DAIDENTITY.md`, `DAWRITINGSTYLE.md`, `OUR_STORY.md` |
| Work section | 4 | `FEED.md`, `HEALTH/`, `FINANCES/`, `PROJECTS.md` |

Each dead reference wastes context tokens during AI context loading — the AI reads the path, attempts to load it, gets a file-not-found error, and moves on. With 29 dead links out of 46 total (63%), a significant portion of the routing table is noise.

## Fix

- Remove all references to non-existent files/directories
- Consolidate the 4 USER sections (Identity, Telos, DA Identity, Work) into a single "Personal Context" section
- Point to the README.md indexes that actually ship (`USER/README.md`, `PROJECTS/README.md`, `BUSINESS/README.md`, `TELOS/README.md`)
- Applied to both v4.0.0 and v4.0.1 releases

## Verification

Validated every remaining path exists in both releases:
```
OK: PAI/README.md
OK: PAI/PAISYSTEMARCHITECTURE.md
...all 18 paths verified OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)