### PR TITLE
feat(voice): fall back to macOS say when ElevenLabs unavailable

### DIFF
--- a/Releases/v4.0.3/.claude/VoiceServer/server.ts
+++ b/Releases/v4.0.3/.claude/VoiceServer/server.ts
@@ -506,9 +506,28 @@ async function sendNotification(
       const audioBuffer = await generateSpeech(safeMessage, voice, resolvedSettings);
       await playAudio(audioBuffer, resolvedVolume);
       voicePlayed = true;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : "TTS generation failed";
       console.error("Failed to generate/play speech:", error);
-      voiceError = error.message || "TTS generation failed";
+      voiceError = msg;
+    }
+  }
+
+  // Fallback: macOS native voice when ElevenLabs is unavailable or failed
+  // Uses /usr/bin/say (available on all macOS versions). Pronunciation rules
+  // from pronunciations.json are applied so custom terms sound correct.
+  // TODO: Linux equivalent — see issue #855 and PR #872 for cross-platform audio
+  if (voiceEnabled && !voicePlayed) {
+    try {
+      const pronouncedText = applyPronunciations(safeMessage);
+      console.log(`🗣️  Falling back to macOS say`);
+      await spawnSafe('/usr/bin/say', [pronouncedText]);
+      voicePlayed = true;
+      voiceError = undefined;
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : "macOS say failed";
+      console.error("macOS say fallback failed:", error);
+      if (!voiceError) voiceError = msg;
     }
   }
 


### PR DESCRIPTION
## Summary

When `ELEVENLABS_API_KEY` is missing or the ElevenLabs API call fails, VoiceServer now falls back to the macOS native `say` command instead of silently skipping voice output. This gives new users immediate voice feedback without requiring ElevenLabs setup.

## Problem

VoiceServer silently skips all TTS when `ELEVENLABS_API_KEY` is missing. New users who haven't configured ElevenLabs get zero voice feedback with no indication why — the server returns HTTP 200, making the failure invisible.

## Solution

After the ElevenLabs TTS path is skipped (no API key) or fails (API error), fall back to `/usr/bin/say`:

- Reuses existing `applyPronunciations()` so custom pronunciation rules apply to native voice too
- Reuses existing `spawnSafe()` helper (array-form spawn, no shell injection)
- Only triggers when ElevenLabs path didn't play (no double-speak)
- Fails gracefully — logs error, doesn't crash server
- Uses `error: unknown` with `instanceof` type guard (also upgrades the adjacent ElevenLabs catch block)

**macOS-only** — `say` is present on all macOS versions. Linux equivalent is out of scope for this PR (see #855, #872 for cross-platform audio work).

## Test plan

- [ ] Start server with no `ELEVENLABS_API_KEY` → send notification → hear macOS `say` voice
- [ ] Set invalid `ELEVENLABS_API_KEY` → send notification → ElevenLabs fails → fallback to `say`
- [ ] Both paths fail (e.g., Linux) → notification still displays, no voice, error logged
- [ ] Custom pronunciations from `pronunciations.json` apply to `say` output

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: additive fallback path, existing behavior unchanged when ElevenLabs key is configured.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)