### PR TITLE
fix: unify PRD frontmatter schema on phase:/progress:

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
@@ -58,15 +58,14 @@ const VOICE_ID = "fTtv3eikoepIosk8dTZ5";
 interface PRDFrontmatter {
   prd: boolean;
   id: string;
-  status: string;
+  phase: string;
   mode: string;
   effort_level: string;
   iteration: number;
   maxIterations: number;
   loopStatus: string | null;
-  last_phase: string | null;
   failing_criteria: string[];
-  verification_summary: string;
+  progress: string;
   [key: string]: unknown;
 }
 
@@ -324,15 +323,14 @@ function readPRD(path: string): { frontmatter: PRDFrontmatter; content: string; 
     frontmatter: {
       prd: fm.prd === true,
       id: (fm.id as string) || "unknown",
-      status: (fm.status as string) || "DRAFT",
+      phase: (fm.phase as string) || (fm.status as string) || "observe",
       mode: (fm.mode as string) || "interactive",
       effort_level: (fm.effort_level as string) || (fm.sla_tier as string) || "Standard",
       iteration: (fm.iteration as number) || 0,
       maxIterations: (fm.maxIterations as number) || 128,
       loopStatus: (fm.loopStatus as string) || null,
-      last_phase: (fm.last_phase as string) || null,
       failing_criteria: Array.isArray(fm.failing_criteria) ? fm.failing_criteria as string[] : [],
-      verification_summary: (fm.verification_summary as string) || "0/0",
+      progress: (fm.progress as string) || (fm.verification_summary as string) || "0/0",
       ...fm,
     },
     content,
@@ -486,8 +484,8 @@ function buildIterationPrompt(prdPath: string, iteration: number, maxIterations:
     const { frontmatter, content } = readPRD(prdPath);
     mode = frontmatter.mode || "loop";
     effortLevel = frontmatter.effort_level || "Standard";
-    lastPhase = frontmatter.last_phase || "unknown";
-    verificationSummary = frontmatter.verification_summary || "0/0";
+    lastPhase = frontmatter.phase || "unknown";
+    verificationSummary = frontmatter.progress || "0/0";
 
     const criteria = countCriteria(content);
     if (criteria.failingIds.length > 0) {
@@ -531,7 +529,7 @@ Instructions:
    - Check off criteria that now pass: \`- [ ]\` → \`- [x]\`
    - Uncheck any criteria that regressed: \`- [x]\` → \`- [ ]\`
    - Update the STATUS table with current progress
-   - Update frontmatter: verification_summary, failing_criteria, last_phase, updated
+   - Update frontmatter: progress, failing_criteria, phase, updated
    - Append a CHANGELOG entry for this iteration:
      ### Iteration {N} — {date}
      - **Phase reached:** VERIFY
@@ -720,11 +718,11 @@ async function runParallelIteration(
 
   // Update frontmatter with consolidated results
   updateFrontmatter(prdPath, {
-    verification_summary: `"${postCriteria.passing}/${postCriteria.total}"`,
+    progress: `"${postCriteria.passing}/${postCriteria.total}"`,
     failing_criteria: postCriteria.failingIds.length > 0
       ? `[${postCriteria.failingIds.join(", ")}]`
       : "[]",
-    last_phase: "VERIFY",
+    phase: "verify",
     updated: new Date().toISOString().split("T")[0],
   });
 
@@ -769,7 +767,7 @@ function buildInteractivePrompt(prdPath: string): string {
   try {
     const { frontmatter, content } = readPRD(prdPath);
     title = extractPRDTitle(content);
-    verificationSummary = frontmatter.verification_summary || "0/0";
+    verificationSummary = frontmatter.progress || "0/0";
 
     const criteria = countCriteria(content);
     if (criteria.failingIds.length > 0) {
@@ -1091,7 +1089,7 @@ async function runLoop(prdPath: string, maxOverride?: number, agentCount: number
       const pct = postCriteria.total > 0 ? Math.round((postCriteria.passing / postCriteria.total) * 100) : 0;
       console.log(`  \x1b[1mIteration ${newIteration} Summary:\x1b[0m \x1b[32m+${gained}\x1b[0m | ${postCriteria.passing}/${postCriteria.total} passing (${pct}%) | ${iterElapsed}s`);
       if (postCriteria.passing >= postCriteria.total) {
-        updateFrontmatter(absPath, { status: "COMPLETE" });
+        updateFrontmatter(absPath, { phase: "complete" });
       }
 
       // Append CHANGELOG entry to PRD
@@ -1100,7 +1098,7 @@ async function runLoop(prdPath: string, maxOverride?: number, agentCount: number
       // Plateau detection: if last 3 iterations had zero progress, exit BLOCKED
       if (state.loopHistory && detectPlateau(state.loopHistory, 3)) {
         console.log(`\x1b[33m  Plateau detected — no progress in last 3 iterations\x1b[0m`);
-        updateFrontmatter(absPath, { status: "BLOCKED", loopStatus: "completed" });
+        updateFrontmatter(absPath, { phase: "blocked", loopStatus: "completed" });
       }
 
       console.log("");
@@ -1194,7 +1192,7 @@ async function runLoop(prdPath: string, maxOverride?: number, agentCount: number
     // Plateau detection: if last 3 iterations had zero progress, exit BLOCKED
     if (state.loopHistory && detectPlateau(state.loopHistory, 3)) {
       console.log(`\x1b[33m  Plateau detected — no progress in last 3 iterations\x1b[0m`);
-      updateFrontmatter(absPath, { status: "BLOCKED", loopStatus: "completed" });
+      updateFrontmatter(absPath, { phase: "blocked", loopStatus: "completed" });
     }
 
     // Brief pause between iterations

--- a/Releases/v4.0.3/.claude/hooks/LoadContext.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/LoadContext.hook.ts
@@ -254,7 +254,7 @@ function getRecentWorkSessions(paiDir: string): WorkSession[] {
         // v4.0: Read from PRD.md frontmatter
         try {
           const prdHead = readFileSync(prdPath, 'utf-8').substring(0, 600);
-          const statusMatch = prdHead.match(/^status:\s*"?(\w+)"?/m);
+          const statusMatch = prdHead.match(/^phase:\s*"?(\w+)"?/m);
           const titleMatch = prdHead.match(/^title:\s*"?(.+?)"?\s*$/m);
           const sessionIdMatch = prdHead.match(/^session_id:\s*"?(.+?)"?\s*$/m);
           if (statusMatch) status = statusMatch[1];
@@ -278,7 +278,7 @@ function getRecentWorkSessions(paiDir: string): WorkSession[] {
 
       try {
 
-        if (status === 'COMPLETED') continue;
+        if (status === 'COMPLETED' || status === 'complete') continue;
         if (rawTitle.toLowerCase().startsWith('tasknotification') || rawTitle.length < 10) continue;
         if (sessionId && seenSessionIds.has(sessionId)) continue;
         if (sessionId) seenSessionIds.add(sessionId);
@@ -300,8 +300,8 @@ function getRecentWorkSessions(paiDir: string): WorkSession[] {
           if (prdFile) {
             const prdContent = readFileSync(prdFile, 'utf-8');
             const prdIdMatch = prdContent.match(/^id:\s*(.+)$/m);
-            const prdStatusMatch = prdContent.match(/^status:\s*(.+)$/m);
-            const prdVerifyMatch = prdContent.match(/^verification_summary:\s*"?(.+?)"?$/m);
+            const prdStatusMatch = prdContent.match(/^phase:\s*(.+)$/m);
+            const prdVerifyMatch = prdContent.match(/^progress:\s*"?(.+?)"?$/m);
             prd = {
               id: prdIdMatch?.[1]?.trim() || 'PRD',
               status: prdStatusMatch?.[1]?.trim() || 'UNKNOWN',

--- a/Releases/v4.0.3/.claude/hooks/SessionCleanup.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/SessionCleanup.hook.ts
@@ -19,7 +19,7 @@
  * - exit(0): Always (non-blocking)
  *
  * SIDE EFFECTS:
- * - Updates: MEMORY/WORK/<dir>/PRD.md or META.yaml (status: COMPLETED)
+ * - Updates: MEMORY/WORK/<dir>/PRD.md (phase: complete) or META.yaml (status: COMPLETED)
  * - Deletes: MEMORY/STATE/current-work.json (clears session state)
  * - Resets: Kitty tab title and color to defaults
  * - Cleans: session-names.json entry (prevents ghost entries)
@@ -96,7 +96,7 @@ function clearSessionWork(sessionId?: string): void {
       // Primary: update PRD.md frontmatter (consolidated format)
       if (existsSync(prdPath)) {
         let prdContent = readFileSync(prdPath, 'utf-8');
-        prdContent = prdContent.replace(/^status: ACTIVE$/m, 'status: COMPLETED');
+        prdContent = prdContent.replace(/^phase: \w+$/m, 'phase: complete');
         prdContent = prdContent.replace(/^completed_at: null$/m, `completed_at: "${getISOTimestamp()}"`);
         writeFileSync(prdPath, prdContent, 'utf-8');
         marked = true;

--- a/Releases/v4.0.3/.claude/hooks/lib/prd-template.ts
+++ b/Releases/v4.0.3/.claude/hooks/lib/prd-template.ts
@@ -137,7 +137,7 @@ prd: true
 id: ${id}
 title: "${curatedTitle.replace(/"/g, '\\"')}"
 session_id: "${opts.sessionId || 'unknown'}"
-status: ACTIVE
+phase: observe
 mode: ${mode}
 effort_level: ${effort}
 created: ${today}
@@ -146,9 +146,8 @@ completed_at: null
 iteration: 0
 maxIterations: 128
 loopStatus: null
-last_phase: null
+progress: "0/0"
 failing_criteria: []
-verification_summary: "0/0"
 parent: null
 children: []
 ---


### PR DESCRIPTION
## Summary

Unifies PRD frontmatter on the canonical schema (`phase:`/`progress:`) defined by `PRDFORMAT.md` and `Algorithm v3.7.0.md`.

**Before:** `LoadContext.hook.ts` and `SessionCleanup.hook.ts` read `status:`/`verification_summary:` — keys that the Algorithm never writes in interactive mode. Result: Active Work summary shows "Status: UNKNOWN" and "PRD (UNKNOWN, 0/0)" for all sessions; SessionCleanup silently fails to mark completed sessions.

**After:** All components use `phase:`/`progress:`, matching the canonical spec and the Algorithm.

### Changes

- **`LoadContext.hook.ts`** — read `phase:` instead of `status:`, `progress:` instead of `verification_summary:`; filter completed sessions by `phase: complete`
- **`prd-template.ts`** — generate `phase: observe` instead of `status: ACTIVE`; replace `verification_summary`/`last_phase` with `progress`
- **`SessionCleanup.hook.ts`** — mark sessions complete via `phase: complete` instead of `status: COMPLETED`
- **`algorithm.ts`** — migrate loop-mode from `status`/`verification_summary`/`last_phase` to `phase`/`progress`

Backward-compatible: `readPRD()` falls back to `fm.status` and `fm.verification_summary` for existing PRDs. Legacy `META.yaml` handling unchanged.

Closes #916

## Test plan

- [ ] Start interactive session → verify PRD.md has `phase: observe` (not `status: ACTIVE`)
- [ ] Complete session → verify SessionCleanup sets `phase: complete`
- [ ] Start new session → verify Active Work summary shows correct phase and progress (not UNKNOWN/0/0)
- [ ] Run loop mode (`algorithm.ts new`) → verify `phase:` and `progress:` updated correctly
- [ ] Open existing PRD with old `status:`/`verification_summary:` keys → verify backward compat fallback works