### PR TITLE
feat: Add Working Memory System -- SQLite-backed queryable memory layer

### DIFF
--- a/Tools/WorkingMemory/README.md
+++ b/Tools/WorkingMemory/README.md
@@ -1,0 +1,115 @@
+# Working Memory System
+
+**A SQLite-backed queryable memory layer for PAI's flat-file memory system.**
+
+PAI's default memory system (v7.x) uses flat files (JSONL, YAML, Markdown) written by hooks. It is write-heavy but read-light -- searching across hundreds of session files means globbing and grepping. The Working Memory System adds structured queries, full-text search, compression, indexing, and a CLI on top.
+
+## Architecture
+
+```
+Claude Code Session
+    |
+    v
+capture-hook.ts (PostToolUse hook)
+    |-- Writes append-only JSONL (primary store, crash-safe)
+    |-- Deferred SQLite insert via db-writer (secondary index)
+    v
+session-summarizer-hook.ts (Stop hook)
+    |-- Reads session JSONL
+    |-- Aggregates topics, decisions, action items, questions
+    |-- Writes summary to JSONL + SQLite
+    v
+memory.ts (Query CLI)
+    |-- Full-text search (FTS5 + BM25 ranking)
+    |-- Topic-based context retrieval
+    |-- Decision history with reasoning
+    |-- Session browsing and summaries
+    |-- Storage statistics
+```
+
+## Quick Start
+
+```bash
+# 1. Initialize the database
+bun db-init.ts
+
+# 2. Register hooks in your settings.json
+# capture-hook.ts  -> PostToolUse
+# session-summarizer-hook.ts -> Stop
+
+# 3. Query your memory
+bun memory.ts search "database migration"
+bun memory.ts context "authentication"
+bun memory.ts decisions --last 30d
+bun memory.ts session list
+bun memory.ts stats
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `schema.sql` | SQLite schema (sessions, entries, topics, decisions, FTS5) |
+| `types.ts` | Shared TypeScript interfaces |
+| `db-init.ts` | Database bootstrap and verification |
+| `db-writer.ts` | Write operations (insert entry, update session) |
+| `db-reader.ts` | Read/query operations (search, topics, decisions, stats) |
+| `memory.ts` | Query CLI (the main user-facing tool) |
+| `capture-hook.ts` | PostToolUse hook (captures tool calls to JSONL + SQLite) |
+| `session-summarizer-hook.ts` | Stop hook (aggregates session into summary) |
+| `compressor.ts` | Gzip compression for old JSONL files |
+| `indexer.ts` | Background re-indexer (backfills SQLite from JSONL) |
+| `maintenance.ts` | Storage management CLI (compress, archive, vacuum) |
+| `significance-scorer.ts` | Session significance scoring (keyword/impact analysis) |
+| `daily-log.ts` | Daily log query tool (today, yesterday, week, search) |
+
+## Storage Layout
+
+```
+~/.claude/MEMORY/
+  +-- memory.db           # SQLite database (WAL mode)
+  +-- CAPTURE/             # Primary JSONL store
+  |   +-- YYYY-MM-DD/      # Date-partitioned directories
+  |       +-- {session}.jsonl
+  +-- ARCHIVE/             # Compressed old sessions
+      +-- YYYY-MM/
+      +-- archive-manifest.json
+```
+
+## Design Decisions
+
+**JSONL is the source of truth.** SQLite is a secondary index that can be rebuilt from JSONL at any time via `indexer.ts reindex-all`. This means:
+
+- Hook failures in SQLite writes are non-fatal
+- The capture hook targets <100ms execution time
+- Crash safety: JSONL writes use fsync
+
+**WAL mode for concurrency.** Multiple readers (query CLI, agents) can read while the capture hook writes without blocking.
+
+**FTS5 with Porter stemming.** Full-text search uses SQLite's FTS5 extension with `porter unicode61` tokenization for natural language queries with stemming support.
+
+**Date-partitioned JSONL.** Capture files are organized by date (`CAPTURE/YYYY-MM-DD/`) for efficient archival and compression of old sessions.
+
+## Maintenance
+
+```bash
+# Run all maintenance (compress old files, archive, check DB size)
+bun maintenance.ts run
+
+# Show storage breakdown
+bun maintenance.ts stats
+
+# Archive sessions older than 90 days
+bun maintenance.ts archive --older-than 90d
+
+# Reclaim SQLite space
+bun maintenance.ts vacuum
+
+# Re-index JSONL files into SQLite
+bun indexer.ts reindex-all
+```
+
+## Requirements
+
+- **Bun** >= 1.0 (uses `bun:sqlite` native module)
+- SQLite with FTS5 support (included in Bun's bundled SQLite)

--- a/Tools/WorkingMemory/capture-hook.ts
+++ b/Tools/WorkingMemory/capture-hook.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env bun
+// Working Memory System - PostToolUse Capture Hook
+// Reads Claude Code hook JSON from stdin, extracts topics/decisions,
+// writes append-only JSONL and defers SQLite insert to db-writer.
+// Target: <100ms total execution time.
+
+import {
+  appendFileSync,
+  mkdirSync,
+  existsSync,
+  openSync,
+  fsyncSync,
+  closeSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import type { CaptureEntry } from "./types";
+
+// --- Constants ---
+
+const PAI_DIR =
+  process.env.PAI_DIR ?? resolve(homedir(), ".claude");
+const CAPTURE_DIR = resolve(PAI_DIR, "MEMORY/CAPTURE");
+const MAX_SUMMARY_LEN = 500;
+
+// --- Decision Detection Patterns ---
+
+const DECISION_PATTERNS: RegExp[] = [
+  /\b(?:decided to|chose|going with|selected|will use|opting for|settled on|picking|switching to|moving to|adopting)\b[^.!?\n]{5,120}[.!?\n]/gi,
+  /\b(?:the decision is|we(?:'ll| will) go with|let(?:'s| us) use|I(?:'ll| will) use|the approach is)\b[^.!?\n]{5,120}[.!?\n]/gi,
+];
+
+// --- Topic Extraction Patterns ---
+
+// File path pattern: captures meaningful path segments
+const FILE_PATH_RE = /(?:\/[\w.-]+){2,}/g;
+
+// Technology/framework names
+const TECH_NAMES_RE =
+  /\b(?:typescript|javascript|bun|node|react|vue|svelte|next\.?js|sqlite|postgres|redis|docker|kubernetes|graphql|rest|api|css|html|json|yaml|toml|markdown|git|github|aws|gcp|azure|vercel|netlify|deno|python|rust|go(?:lang)?|java|swift|kotlin|ruby|php|c\+\+|bash|zsh|linux|macos|windows|nginx|apache|webpack|vite|esbuild|rollup|jest|vitest|playwright|cypress|tailwind|prisma|drizzle|trpc|grpc|oauth|jwt|tls|ssl|http|websocket|sse|fts5|wal)\b/gi;
+
+// PascalCase project names
+const PROJECT_NAME_RE = /\b(?:[A-Z][a-z]+){2,}\b/g;
+const KEBAB_PROJECT_RE = /\b[a-z]+(?:-[a-z]+){1,5}\b/g;
+
+// Architecture/design concepts
+const CONCEPT_RE =
+  /\b(?:authentication|authorization|caching|indexing|migration|refactor(?:ing)?|deployment|monitoring|logging|testing|schema|middleware|pipeline|hook|plugin|module|service|endpoint|controller|model|interface|abstraction|pattern|architecture|microservice|monolith|event[\s-]driven|pub[\s-]?sub|queue|streaming|batch|real[\s-]?time|async|concurrent|parallel|distributed)\b/gi;
+
+// --- Utility Functions ---
+
+/**
+ * Truncate text at word boundary, respecting max length.
+ */
+function truncateSmart(text: string, maxLen: number): string {
+  if (!text || text.length <= maxLen) return text ?? "";
+  const cutoff = text.lastIndexOf(" ", maxLen - 3);
+  const breakPoint =
+    cutoff > maxLen * 0.5 ? cutoff : maxLen - 3;
+  return text.slice(0, breakPoint) + "...";
+}
+
+/**
+ * Stringify any value to a flat string suitable for summarization.
+ */
+function flattenToString(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  if (typeof val === "string") return val;
+  try {
+    return JSON.stringify(val);
+  } catch {
+    return String(val);
+  }
+}
+
+/**
+ * Extract unique topics from combined text.
+ * Returns deduplicated, lowercased topic strings.
+ */
+function extractTopics(text: string): string[] {
+  const topics = new Set<string>();
+
+  // File paths - extract last 2 meaningful segments
+  const paths = text.match(FILE_PATH_RE) ?? [];
+  for (const p of paths) {
+    const segments = p.split("/").filter(Boolean);
+    if (segments.length >= 2) {
+      topics.add(segments.slice(-2).join("/"));
+    }
+  }
+
+  // Technology names
+  const techs = text.match(TECH_NAMES_RE) ?? [];
+  for (const t of techs) {
+    topics.add(t.toLowerCase());
+  }
+
+  // PascalCase project names (at least 2 words, not common English)
+  const projects = text.match(PROJECT_NAME_RE) ?? [];
+  for (const p of projects) {
+    if (p.length > 5) topics.add(p);
+  }
+
+  // Kebab-case identifiers (filter out very short ones)
+  const kebabs = text.match(KEBAB_PROJECT_RE) ?? [];
+  for (const k of kebabs) {
+    if (k.length > 8 && k.includes("-")) topics.add(k);
+  }
+
+  // Concept/architecture terms
+  const concepts = text.match(CONCEPT_RE) ?? [];
+  for (const c of concepts) {
+    topics.add(c.toLowerCase());
+  }
+
+  return Array.from(topics).slice(0, 20); // Cap at 20 topics per entry
+}
+
+/**
+ * Extract decisions from text using pattern matching.
+ */
+function extractDecisions(text: string): string[] {
+  const decisions: string[] = [];
+
+  for (const pattern of DECISION_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      const cleaned = match[0].trim();
+      if (cleaned.length > 10 && cleaned.length < 300) {
+        decisions.push(cleaned);
+      }
+    }
+  }
+
+  // Deduplicate by checking substring containment
+  const unique: string[] = [];
+  for (const d of decisions) {
+    if (
+      !unique.some(
+        (existing) =>
+          existing.includes(d) || d.includes(existing)
+      )
+    ) {
+      unique.push(d);
+    }
+  }
+
+  return unique.slice(0, 10); // Cap at 10 decisions per entry
+}
+
+/**
+ * Get or generate session ID.
+ * Prefers CLAUDE_SESSION_ID env var, falls back to date+random.
+ */
+function getSessionId(): string {
+  const envId = process.env.CLAUDE_SESSION_ID;
+  if (envId) return envId;
+
+  const now = new Date();
+  const dateStr = now
+    .toISOString()
+    .slice(0, 10)
+    .replace(/-/g, "");
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `${dateStr}-${rand}`;
+}
+
+/**
+ * Get today's date as YYYY-MM-DD for directory partitioning.
+ */
+function getDateDir(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Append a JSONL line with fsync for crash safety.
+ */
+function appendJsonlSync(
+  filePath: string,
+  data: CaptureEntry
+): void {
+  const dir = filePath.slice(0, filePath.lastIndexOf("/"));
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const line = JSON.stringify(data) + "\n";
+  const fd = openSync(filePath, "a");
+  try {
+    appendFileSync(fd, line);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// --- DB Writer Import (deferred - may not be initialized yet) ---
+
+let dbInsert:
+  | ((entry: CaptureEntry, rawOffset?: number) => number)
+  | null = null;
+
+try {
+  const dbWriter = await import("./db-writer");
+  if (dbWriter.insertEntry) {
+    dbInsert = dbWriter.insertEntry;
+  }
+} catch {
+  // db-writer not yet available - JSONL is the primary store
+}
+
+// --- Main Hook ---
+
+async function main(): Promise<void> {
+  // Read JSON from stdin (Claude Code hook format)
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+
+  if (!raw) {
+    process.exit(0);
+  }
+
+  let hookData: {
+    tool_name?: string;
+    tool_input?: unknown;
+    tool_result?: unknown;
+  };
+  try {
+    hookData = JSON.parse(raw);
+  } catch {
+    // Malformed input - exit silently, never block Claude Code
+    process.exit(0);
+  }
+
+  const toolName = hookData.tool_name ?? "unknown";
+  const inputStr = flattenToString(hookData.tool_input);
+  const outputStr = flattenToString(hookData.tool_result);
+
+  // Build summaries (truncated at word boundaries)
+  const inputSummary = truncateSmart(inputStr, MAX_SUMMARY_LEN);
+  const outputSummary = truncateSmart(
+    outputStr,
+    MAX_SUMMARY_LEN
+  );
+
+  // Combined text for extraction
+  const combinedText = `${inputStr} ${outputStr}`;
+
+  // Extract topics and decisions
+  const topics = extractTopics(combinedText);
+  const decisions = extractDecisions(combinedText);
+
+  // Build the capture entry
+  const sessionId = getSessionId();
+  const entry: CaptureEntry = {
+    timestamp: new Date().toISOString(),
+    session_id: sessionId,
+    message_role: "tool",
+    tool_name: toolName,
+    tool_input_summary: inputSummary,
+    tool_output_summary: outputSummary,
+    topics_extracted: topics,
+    decisions_made: decisions,
+    reasoning_chain: "",
+    type: "entry",
+  };
+
+  // Write JSONL synchronously (primary store, crash-safe)
+  const dateDir = getDateDir();
+  const jsonlPath = resolve(
+    CAPTURE_DIR,
+    dateDir,
+    `${sessionId}.jsonl`
+  );
+  appendJsonlSync(jsonlPath, entry);
+
+  // Deferred SQLite write (synchronous - db-writer returns entry ID)
+  if (dbInsert) {
+    try {
+      dbInsert(entry);
+    } catch {
+      // SQLite write failure is non-fatal; JSONL is the source of truth
+    }
+  }
+}
+
+main().catch(() => {
+  // Never let hook failures propagate to Claude Code
+  process.exit(0);
+});

--- a/Tools/WorkingMemory/compressor.ts
+++ b/Tools/WorkingMemory/compressor.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env bun
+// Working Memory System - JSONL Compression Utilities
+// Gzip compress/decompress JSONL files using node:zlib streams
+
+import {
+  createReadStream,
+  createWriteStream,
+  statSync,
+  readdirSync,
+  readSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from "node:fs";
+import { createGzip, createGunzip } from "node:zlib";
+import { join, extname } from "node:path";
+import { pipeline } from "node:stream/promises";
+
+// --- Gzip magic number: 0x1f 0x8b ---
+
+const GZIP_MAGIC = Buffer.from([0x1f, 0x8b]);
+
+/**
+ * Verify a file starts with the gzip magic number.
+ */
+function verifyGzipHeader(filePath: string): boolean {
+  let fd: number | null = null;
+  try {
+    fd = openSync(filePath, "r");
+    const buf = Buffer.alloc(2);
+    const bytesRead = readSync(fd, buf, 0, 2, 0);
+    if (bytesRead < 2) return false;
+    return buf[0] === GZIP_MAGIC[0] && buf[1] === GZIP_MAGIC[1];
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+/**
+ * Compress a JSONL file with gzip.
+ * Returns the path to the .gz file.
+ * Deletes the original after verifying the compressed file.
+ */
+export async function compressFile(
+  filePath: string
+): Promise<string> {
+  const gzPath = `${filePath}.gz`;
+
+  const source = createReadStream(filePath);
+  const gzip = createGzip({ level: 6 });
+  const dest = createWriteStream(gzPath);
+
+  await pipeline(source, gzip, dest);
+
+  // Verify the compressed file has a valid gzip header
+  if (!verifyGzipHeader(gzPath)) {
+    throw new Error(
+      `Compression verification failed for ${gzPath}`
+    );
+  }
+
+  // Verify compressed file has non-zero size
+  const gzStat = statSync(gzPath);
+  if (gzStat.size === 0) {
+    throw new Error(`Compressed file is empty: ${gzPath}`);
+  }
+
+  // Safe to delete original
+  unlinkSync(filePath);
+
+  return gzPath;
+}
+
+/**
+ * Decompress a .gz file back to JSONL.
+ * Returns the path to the decompressed file.
+ */
+export async function decompressFile(
+  gzPath: string
+): Promise<string> {
+  if (!gzPath.endsWith(".gz")) {
+    throw new Error(
+      `File does not have .gz extension: ${gzPath}`
+    );
+  }
+  const outputPath = gzPath.slice(0, -3);
+
+  const source = createReadStream(gzPath);
+  const gunzip = createGunzip();
+  const dest = createWriteStream(outputPath);
+
+  await pipeline(source, gunzip, dest);
+
+  return outputPath;
+}
+
+/**
+ * Find JSONL files in captureDir that are older than `olderThanDays` days
+ * and are not already compressed (.gz).
+ * Supports date-partitioned and flat layouts.
+ */
+export function getCompressibleFiles(
+  captureDir: string,
+  olderThanDays: number
+): string[] {
+  const now = Date.now();
+  const cutoffMs = olderThanDays * 24 * 60 * 60 * 1000;
+  const results: string[] = [];
+
+  let topEntries: ReturnType<typeof readdirSync>;
+  try {
+    topEntries = readdirSync(captureDir, {
+      withFileTypes: true,
+    });
+  } catch {
+    return [];
+  }
+
+  function checkFile(fullPath: string): void {
+    try {
+      const stat = statSync(fullPath);
+      if (!stat.isFile()) return;
+      const ageMs = now - stat.mtimeMs;
+      if (ageMs > cutoffMs) {
+        results.push(fullPath);
+      }
+    } catch {
+      // Skip files we can't stat
+    }
+  }
+
+  for (const entry of topEntries) {
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      checkFile(join(captureDir, entry.name));
+    } else if (
+      entry.isDirectory() &&
+      /^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+    ) {
+      const subDir = join(captureDir, entry.name);
+      try {
+        const subFiles = readdirSync(subDir);
+        for (const f of subFiles) {
+          if (f.endsWith(".jsonl")) {
+            checkFile(join(subDir, f));
+          }
+        }
+      } catch {
+        // Skip unreadable subdirectories
+      }
+    }
+  }
+
+  return results.sort();
+}

--- a/Tools/WorkingMemory/daily-log.ts
+++ b/Tools/WorkingMemory/daily-log.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env bun
+
+/**
+ * Daily Log CLI - Access and manage PAI daily memory logs
+ *
+ * Commands:
+ *   today      - Show today's log
+ *   yesterday  - Show yesterday's log
+ *   week       - Show this week's logs
+ *   search     - Search across all daily logs
+ *   edit       - Open today's log in editor
+ *   list       - List all daily logs
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from "fs";
+import { join, resolve } from "path";
+import { homedir } from "os";
+import { spawn } from "child_process";
+
+const PAI_DIR =
+  process.env.PAI_DIR || resolve(homedir(), ".claude");
+const MEMORY_DIR = join(PAI_DIR, "memory");
+const DAILY_DIR = join(MEMORY_DIR, "daily");
+
+// Day names
+const DAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(
+    2,
+    "0"
+  );
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getLocalDate(daysOffset: number = 0): Date {
+  const now = new Date();
+  now.setDate(now.getDate() + daysOffset);
+  return now;
+}
+
+function getDailyLogPath(dateStr: string): string {
+  return join(DAILY_DIR, `${dateStr}.md`);
+}
+
+function showLog(dateStr: string): void {
+  const path = getDailyLogPath(dateStr);
+
+  if (!existsSync(path)) {
+    console.log(`No log found for ${dateStr}`);
+    return;
+  }
+
+  const content = readFileSync(path, "utf-8");
+  console.log(content);
+}
+
+function showToday(): void {
+  const dateStr = formatDate(getLocalDate());
+  console.log(`Today: ${dateStr}\n`);
+  showLog(dateStr);
+}
+
+function showYesterday(): void {
+  const dateStr = formatDate(getLocalDate(-1));
+  console.log(`Yesterday: ${dateStr}\n`);
+  showLog(dateStr);
+}
+
+function showWeek(): void {
+  console.log("This Week\n");
+
+  for (let i = 6; i >= 0; i--) {
+    const date = getLocalDate(-i);
+    const dateStr = formatDate(date);
+    const dayName = DAYS[date.getDay()];
+    const path = getDailyLogPath(dateStr);
+
+    if (existsSync(path)) {
+      const content = readFileSync(path, "utf-8");
+
+      const sessionMatch = content.match(
+        /sessions: (\d+)/
+      );
+      const sessions = sessionMatch
+        ? sessionMatch[1]
+        : "0";
+
+      const focusMatch = content.match(
+        /focus_areas: \[([^\]]*)\]/
+      );
+      const focus = focusMatch ? focusMatch[1] : "none";
+
+      console.log(
+        `${dateStr} (${dayName.substring(0, 3)}): ${sessions} session(s) - ${focus}`
+      );
+    } else {
+      console.log(
+        `${dateStr} (${dayName.substring(0, 3)}): No log`
+      );
+    }
+  }
+}
+
+function searchLogs(query: string): void {
+  if (!existsSync(DAILY_DIR)) {
+    console.log("No daily logs found");
+    return;
+  }
+
+  const files = readdirSync(DAILY_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .sort()
+    .reverse();
+
+  console.log(`Searching for: "${query}"\n`);
+
+  let found = 0;
+  const queryLower = query.toLowerCase();
+
+  for (const file of files) {
+    const content = readFileSync(
+      join(DAILY_DIR, file),
+      "utf-8"
+    );
+
+    if (content.toLowerCase().includes(queryLower)) {
+      found++;
+      const dateStr = file.replace(".md", "");
+
+      const lines = content.split("\n");
+      const matches = lines
+        .filter((line) =>
+          line.toLowerCase().includes(queryLower)
+        )
+        .slice(0, 3);
+
+      console.log(`  ${dateStr}:`);
+      matches.forEach((line) => {
+        const highlighted = line.replace(
+          new RegExp(query, "gi"),
+          (match) => `\x1b[33m${match}\x1b[0m`
+        );
+        console.log(`   ${highlighted.trim()}`);
+      });
+      console.log("");
+    }
+  }
+
+  if (found === 0) {
+    console.log("No matches found");
+  } else {
+    console.log(`Found in ${found} log(s)`);
+  }
+}
+
+function editToday(): void {
+  const dateStr = formatDate(getLocalDate());
+  const path = getDailyLogPath(dateStr);
+
+  // Create if doesn't exist
+  if (!existsSync(path)) {
+    if (!existsSync(DAILY_DIR)) {
+      mkdirSync(DAILY_DIR, { recursive: true });
+    }
+
+    const dayName = DAYS[getLocalDate().getDay()];
+    const content = `---
+date: ${dateStr}
+day: ${dayName}
+sessions: 0
+focus_areas: []
+---
+
+# ${dateStr} (${dayName})
+
+## Sessions Today
+<!-- Sessions will be logged automatically -->
+
+## Key Decisions
+<!-- Record important decisions with rationale -->
+
+## Completed
+<!-- Work accomplished today -->
+
+## Learnings
+<!-- Insights from today's work -->
+
+## Reflections
+<!-- Space for manual notes -->
+
+## Tomorrow
+<!-- Carried forward to next day -->
+`;
+    writeFileSync(path, content);
+  }
+
+  const editor = process.env.EDITOR || "vim";
+  const child = spawn(editor, [path], {
+    stdio: "inherit",
+  });
+
+  child.on("exit", (code) => {
+    process.exit(code || 0);
+  });
+}
+
+function listLogs(): void {
+  if (!existsSync(DAILY_DIR)) {
+    console.log("No daily logs found");
+    return;
+  }
+
+  const files = readdirSync(DAILY_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .sort()
+    .reverse();
+
+  console.log(`Daily Logs (${files.length} total)\n`);
+
+  // Group by month
+  const byMonth: Record<string, string[]> = {};
+
+  for (const file of files) {
+    const dateStr = file.replace(".md", "");
+    const month = dateStr.substring(0, 7);
+
+    if (!byMonth[month]) {
+      byMonth[month] = [];
+    }
+    byMonth[month].push(dateStr);
+  }
+
+  for (const [month, dates] of Object.entries(byMonth)) {
+    console.log(`\n${month}:`);
+    dates.forEach((d) => console.log(`  ${d}`));
+  }
+}
+
+function showHelp(): void {
+  console.log(`
+PAI Daily Log CLI
+
+Usage: bun daily-log.ts <command> [args]
+
+Commands:
+  today       Show today's daily log
+  yesterday   Show yesterday's daily log
+  week        Show summary of this week's logs
+  search <q>  Search across all daily logs
+  edit        Open today's log in $EDITOR
+  list        List all daily logs
+  help        Show this help message
+
+Examples:
+  bun daily-log.ts today
+  bun daily-log.ts search "migration"
+  bun daily-log.ts week
+
+Location: ${DAILY_DIR}
+`);
+}
+
+// Main
+const command = process.argv[2] || "today";
+const args = process.argv.slice(3);
+
+switch (command) {
+  case "today":
+    showToday();
+    break;
+  case "yesterday":
+    showYesterday();
+    break;
+  case "week":
+    showWeek();
+    break;
+  case "search":
+    if (args.length === 0) {
+      console.error(
+        "Usage: bun daily-log.ts search <query>"
+      );
+      process.exit(1);
+    }
+    searchLogs(args.join(" "));
+    break;
+  case "edit":
+    editToday();
+    break;
+  case "list":
+    listLogs();
+    break;
+  case "help":
+  case "--help":
+  case "-h":
+    showHelp();
+    break;
+  default:
+    console.error(`Unknown command: ${command}`);
+    showHelp();
+    process.exit(1);
+}

--- a/Tools/WorkingMemory/db-init.ts
+++ b/Tools/WorkingMemory/db-init.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+// Working Memory System - Database Bootstrap
+// Creates directories and initializes SQLite with full schema
+
+import { Database } from "bun:sqlite";
+import { mkdirSync, existsSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+
+const MEMORY_ROOT = resolve(
+  process.env.PAI_DIR ?? resolve(homedir(), ".claude"),
+  "MEMORY"
+);
+const DB_PATH = resolve(MEMORY_ROOT, "memory.db");
+const SCHEMA_PATH = resolve(dirname(import.meta.path), "schema.sql");
+
+// --- Directory Bootstrap ---
+
+const DIRS = [
+  resolve(MEMORY_ROOT, "CAPTURE"),
+  resolve(MEMORY_ROOT, "ARCHIVE"),
+];
+
+function bootstrapDirs(): void {
+  for (const dir of DIRS) {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+      console.log(`[bootstrap] Created: ${dir}`);
+    }
+  }
+}
+
+// --- Database Init ---
+
+function initDatabase(): Database {
+  const db = new Database(DB_PATH, { create: true });
+
+  // Enable WAL mode for concurrent read performance
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA foreign_keys = ON;");
+
+  // Read and execute schema
+  const schema = readFileSync(SCHEMA_PATH, "utf-8");
+  db.exec(schema);
+
+  return db;
+}
+
+// --- Verification ---
+
+function verify(db: Database): void {
+  // Check WAL mode
+  const walResult = db.query("PRAGMA journal_mode;").get() as {
+    journal_mode: string;
+  };
+  console.log(`[verify] journal_mode: ${walResult.journal_mode}`);
+
+  // List all tables
+  const tables = db
+    .query(
+      "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+    )
+    .all() as { name: string }[];
+  console.log(`[verify] Tables: ${tables.map((t) => t.name).join(", ")}`);
+
+  // Check for FTS5 search table
+  const allObjects = db
+    .query("SELECT name, type FROM sqlite_master ORDER BY name;")
+    .all() as { name: string; type: string }[];
+
+  const searchTable = allObjects.find((o) => o.name === "search");
+  if (searchTable) {
+    console.log(`[verify] FTS5 table: search (type: ${searchTable.type})`);
+  }
+
+  // List indexes
+  const indexes = db
+    .query(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name;"
+    )
+    .all() as { name: string }[];
+  console.log(
+    `[verify] Indexes: ${indexes.map((i) => i.name).join(", ")}`
+  );
+
+  // Verify foreign keys
+  const fkResult = db.query("PRAGMA foreign_keys;").get() as {
+    foreign_keys: number;
+  };
+  console.log(
+    `[verify] foreign_keys: ${fkResult.foreign_keys ? "ON" : "OFF"}`
+  );
+}
+
+// --- Main ---
+
+function main(): void {
+  console.log(
+    "[db-init] Bootstrapping Working Memory System..."
+  );
+  console.log(`[db-init] DB path: ${DB_PATH}`);
+
+  bootstrapDirs();
+
+  const db = initDatabase();
+  verify(db);
+  db.close();
+
+  console.log("[db-init] Bootstrap complete.");
+}
+
+main();

--- a/Tools/WorkingMemory/db-reader.ts
+++ b/Tools/WorkingMemory/db-reader.ts
@@ -1,0 +1,217 @@
+// Working Memory System - SQLite Read/Search Operations
+// Handles all queries and full-text search against memory.db
+
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { getDb } from "./db-writer";
+import type {
+  SearchResult,
+  EntryRow,
+  DecisionRecord,
+  TopicRecord,
+  SessionRow,
+} from "./types";
+
+// --- Prepared Statements (lazily initialized) ---
+
+let _stmts: ReturnType<typeof prepareStatements> | null = null;
+
+function prepareStatements(db: ReturnType<typeof getDb>) {
+  return {
+    searchEntries: db.prepare(`
+      SELECT
+        entries.id AS entry_id,
+        entries.session_id,
+        entries.timestamp,
+        entries.tool_name,
+        snippet(search, 0, '>>>', '<<<', '...', 32) AS matched_text,
+        search.rank
+      FROM search
+      JOIN entries ON search.rowid = entries.id
+      WHERE search MATCH $query
+      ORDER BY search.rank
+      LIMIT $limit
+    `),
+
+    getTopicEntries: db.prepare(`
+      SELECT e.*
+      FROM entries e
+      JOIN topic_entries te ON te.entry_id = e.id
+      JOIN topics t ON t.id = te.topic_id
+      WHERE t.name = $topic_name
+      ORDER BY e.timestamp DESC
+      LIMIT $limit
+    `),
+
+    getSessionEntries: db.prepare(`
+      SELECT * FROM entries
+      WHERE session_id = $session_id
+      ORDER BY timestamp ASC
+    `),
+
+    getRecentDecisions: db.prepare(`
+      SELECT id, session_id, entry_id, decision_text, reasoning_context, confidence, timestamp
+      FROM decisions
+      WHERE timestamp >= $since
+      ORDER BY timestamp DESC
+      LIMIT $limit
+    `),
+
+    getTopics: db.prepare(`
+      SELECT id, name, first_seen, last_seen, session_count, entry_count
+      FROM topics
+      ORDER BY entry_count DESC
+      LIMIT $limit
+    `),
+
+    getSessionList: db.prepare(`
+      SELECT * FROM sessions
+      ORDER BY started_at DESC
+      LIMIT $limit
+    `),
+
+    getSessionById: db.prepare(`
+      SELECT * FROM sessions WHERE id = $id
+    `),
+
+    countEntries: db.prepare(`SELECT COUNT(*) AS count FROM entries`),
+    countSessions: db.prepare(`SELECT COUNT(*) AS count FROM sessions`),
+    countTopics: db.prepare(`SELECT COUNT(*) AS count FROM topics`),
+    countDecisions: db.prepare(`SELECT COUNT(*) AS count FROM decisions`),
+  };
+}
+
+function getStmts() {
+  if (!_stmts) {
+    _stmts = prepareStatements(getDb());
+  }
+  return _stmts;
+}
+
+// --- Public Read Functions ---
+
+/**
+ * Full-text search using FTS5 with BM25 ranking.
+ * Returns entries matching the query, ordered by relevance.
+ */
+export function searchEntries(
+  query: string,
+  limit: number = 20
+): SearchResult[] {
+  const stmts = getStmts();
+  return stmts.searchEntries.all({
+    $query: query,
+    $limit: limit,
+  }) as SearchResult[];
+}
+
+/**
+ * Get all entries tagged with a specific topic via the junction table.
+ */
+export function getTopicEntries(
+  topicName: string,
+  limit: number = 50
+): EntryRow[] {
+  const stmts = getStmts();
+  return stmts.getTopicEntries.all({
+    $topic_name: topicName,
+    $limit: limit,
+  }) as EntryRow[];
+}
+
+/**
+ * Get all entries for a specific session, ordered chronologically.
+ */
+export function getSessionEntries(sessionId: string): EntryRow[] {
+  const stmts = getStmts();
+  return stmts.getSessionEntries.all({
+    $session_id: sessionId,
+  }) as EntryRow[];
+}
+
+/**
+ * Get recent decisions from the last N days.
+ */
+export function getRecentDecisions(
+  days: number = 7,
+  limit: number = 100
+): DecisionRecord[] {
+  const stmts = getStmts();
+  const since = new Date(
+    Date.now() - days * 24 * 60 * 60 * 1000
+  ).toISOString();
+  return stmts.getRecentDecisions.all({
+    $since: since,
+    $limit: limit,
+  }) as DecisionRecord[];
+}
+
+/**
+ * Get all topics sorted by entry_count descending.
+ */
+export function getTopics(limit: number = 100): TopicRecord[] {
+  const stmts = getStmts();
+  return stmts.getTopics.all({ $limit: limit }) as TopicRecord[];
+}
+
+/**
+ * Get recent sessions, most recent first.
+ */
+export function getSessionList(limit: number = 50): SessionRow[] {
+  const stmts = getStmts();
+  return stmts.getSessionList.all({ $limit: limit }) as SessionRow[];
+}
+
+/**
+ * Get a single session by ID, or null if not found.
+ */
+export function getSessionById(id: string): SessionRow | null {
+  const stmts = getStmts();
+  const row = stmts.getSessionById.get({ $id: id }) as
+    | SessionRow
+    | undefined;
+  return row ?? null;
+}
+
+/**
+ * Get aggregate stats about the memory database.
+ */
+export function getStats(): {
+  totalEntries: number;
+  totalSessions: number;
+  totalTopics: number;
+  totalDecisions: number;
+  dbSizeBytes: number;
+} {
+  const stmts = getStmts();
+  const dbPath = resolve(
+    process.env.PAI_DIR ?? resolve(homedir(), ".claude"),
+    "MEMORY",
+    "memory.db"
+  );
+
+  const totalEntries = (stmts.countEntries.get() as { count: number })
+    .count;
+  const totalSessions = (stmts.countSessions.get() as { count: number })
+    .count;
+  const totalTopics = (stmts.countTopics.get() as { count: number }).count;
+  const totalDecisions = (
+    stmts.countDecisions.get() as { count: number }
+  ).count;
+
+  let dbSizeBytes = 0;
+  try {
+    dbSizeBytes = statSync(dbPath).size;
+  } catch {
+    // DB file may not exist yet
+  }
+
+  return {
+    totalEntries,
+    totalSessions,
+    totalTopics,
+    totalDecisions,
+    dbSizeBytes,
+  };
+}

--- a/Tools/WorkingMemory/db-writer.ts
+++ b/Tools/WorkingMemory/db-writer.ts
@@ -1,0 +1,208 @@
+// Working Memory System - SQLite Write Operations
+// Handles all insert/update operations against memory.db
+
+import { Database } from "bun:sqlite";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import type { CaptureEntry, SessionSummary } from "./types";
+
+// --- Singleton DB Instance ---
+
+const DB_PATH = resolve(
+  process.env.PAI_DIR ?? resolve(homedir(), ".claude"),
+  "MEMORY",
+  "memory.db"
+);
+let _db: Database | null = null;
+
+export function getDb(): Database {
+  if (!_db) {
+    _db = new Database(DB_PATH, { readwrite: true, create: false });
+    // Verify WAL mode (already set by db-init.ts)
+    const wal = _db.query("PRAGMA journal_mode;").get() as {
+      journal_mode: string;
+    };
+    if (wal.journal_mode !== "wal") {
+      _db.exec("PRAGMA journal_mode = WAL;");
+    }
+    _db.exec("PRAGMA foreign_keys = ON;");
+    _db.exec("PRAGMA busy_timeout = 5000;");
+  }
+  return _db;
+}
+
+// --- Prepared Statements (lazily initialized) ---
+
+let _stmts: ReturnType<typeof prepareStatements> | null = null;
+
+function prepareStatements(db: Database) {
+  return {
+    insertEntry: db.prepare(`
+      INSERT INTO entries (session_id, timestamp, message_role, tool_name,
+        tool_input_summary, tool_output_summary, topics_json, decisions_json,
+        reasoning_chain, raw_jsonl_offset)
+      VALUES ($session_id, $timestamp, $message_role, $tool_name,
+        $tool_input_summary, $tool_output_summary, $topics_json, $decisions_json,
+        $reasoning_chain, $raw_jsonl_offset)
+    `),
+
+    upsertTopic: db.prepare(`
+      INSERT INTO topics (name, first_seen, last_seen, session_count, entry_count)
+      VALUES ($name, $timestamp, $timestamp, 1, 1)
+      ON CONFLICT(name) DO UPDATE SET
+        last_seen = $timestamp,
+        entry_count = entry_count + 1
+    `),
+
+    insertTopicEntry: db.prepare(`
+      INSERT OR IGNORE INTO topic_entries (topic_id, entry_id)
+      VALUES ($topic_id, $entry_id)
+    `),
+
+    getTopicId: db.prepare(`
+      SELECT id FROM topics WHERE name = $name
+    `),
+
+    insertDecision: db.prepare(`
+      INSERT INTO decisions (session_id, entry_id, decision_text, reasoning_context, confidence, timestamp)
+      VALUES ($session_id, $entry_id, $decision_text, $reasoning_context, $confidence, $timestamp)
+    `),
+
+    ensureSession: db.prepare(`
+      INSERT OR IGNORE INTO sessions (id, started_at, entry_count)
+      VALUES ($id, $started_at, 0)
+    `),
+
+    updateSession: db.prepare(`
+      UPDATE sessions SET
+        ended_at = $ended_at,
+        duration_seconds = $duration_seconds,
+        summary = $summary,
+        topics_json = $topics_json,
+        decisions_json = $decisions_json,
+        action_items_json = $action_items_json,
+        unresolved_json = $unresolved_json,
+        entry_count = $entry_count
+      WHERE id = $id
+    `),
+
+    incrementSessionEntryCount: db.prepare(`
+      UPDATE sessions SET entry_count = entry_count + 1 WHERE id = $id
+    `),
+  };
+}
+
+function getStmts() {
+  if (!_stmts) {
+    _stmts = prepareStatements(getDb());
+  }
+  return _stmts;
+}
+
+// --- Public Write Functions ---
+
+/**
+ * Insert a captured entry into the database.
+ * Handles topics (upsert + junction) and decisions as part of the same transaction.
+ * Returns the new entry ID.
+ */
+export function insertEntry(entry: CaptureEntry, rawOffset?: number): number {
+  const db = getDb();
+  const stmts = getStmts();
+
+  const entryId = db.transaction(() => {
+    // 1. Ensure session exists
+    ensureSession(entry.session_id);
+
+    // 2. Insert the entry row
+    stmts.insertEntry.run({
+      $session_id: entry.session_id,
+      $timestamp: entry.timestamp,
+      $message_role: entry.message_role,
+      $tool_name: entry.tool_name,
+      $tool_input_summary: entry.tool_input_summary,
+      $tool_output_summary: entry.tool_output_summary,
+      $topics_json: JSON.stringify(entry.topics_extracted),
+      $decisions_json: JSON.stringify(entry.decisions_made),
+      $reasoning_chain: entry.reasoning_chain,
+      $raw_jsonl_offset: rawOffset ?? null,
+    });
+
+    // Get the inserted entry ID
+    const lastId = (
+      db.query("SELECT last_insert_rowid() as id").get() as { id: number }
+    ).id;
+
+    // 3. Increment session entry count
+    stmts.incrementSessionEntryCount.run({ $id: entry.session_id });
+
+    // 4. Handle topics: upsert each topic and create junction rows
+    for (const topicName of entry.topics_extracted) {
+      stmts.upsertTopic.run({
+        $name: topicName,
+        $timestamp: entry.timestamp,
+      });
+
+      const topicRow = stmts.getTopicId.get({ $name: topicName }) as {
+        id: number;
+      } | null;
+      if (topicRow) {
+        stmts.insertTopicEntry.run({
+          $topic_id: topicRow.id,
+          $entry_id: lastId,
+        });
+      }
+    }
+
+    // 5. Handle decisions: insert each decision linked to this entry
+    for (const decisionText of entry.decisions_made) {
+      stmts.insertDecision.run({
+        $session_id: entry.session_id,
+        $entry_id: lastId,
+        $decision_text: decisionText,
+        $reasoning_context: entry.reasoning_chain,
+        $confidence: "medium",
+        $timestamp: entry.timestamp,
+      });
+    }
+
+    return lastId;
+  })();
+
+  return entryId;
+}
+
+/**
+ * Update a session row with summary data (called at session end).
+ */
+export function updateSession(
+  sessionId: string,
+  summary: SessionSummary
+): void {
+  const stmts = getStmts();
+
+  stmts.updateSession.run({
+    $id: sessionId,
+    $ended_at: new Date().toISOString(),
+    $duration_seconds: summary.duration,
+    $summary: JSON.stringify({
+      key_files_touched: summary.key_files_touched,
+    }),
+    $topics_json: JSON.stringify(summary.topics_covered),
+    $decisions_json: JSON.stringify(summary.decisions_made),
+    $action_items_json: JSON.stringify(summary.action_items),
+    $unresolved_json: JSON.stringify(summary.unresolved_questions),
+    $entry_count: summary.entry_count,
+  });
+}
+
+/**
+ * Create a session row if it doesn't exist (INSERT OR IGNORE).
+ */
+export function ensureSession(sessionId: string): void {
+  const stmts = getStmts();
+  stmts.ensureSession.run({
+    $id: sessionId,
+    $started_at: new Date().toISOString(),
+  });
+}

--- a/Tools/WorkingMemory/indexer.ts
+++ b/Tools/WorkingMemory/indexer.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env bun
+// Working Memory System - Background Re-Indexer
+// Reads JSONL capture files and indexes any entries not yet in the database
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { getDb, insertEntry, ensureSession } from "./db-writer";
+import type { CaptureEntry } from "./types";
+
+const CAPTURE_DIR = resolve(
+  process.env.PAI_DIR ?? resolve(homedir(), ".claude"),
+  "MEMORY",
+  "CAPTURE"
+);
+
+// --- Prepared Statements ---
+
+let _stmts: ReturnType<typeof prepareStatements> | null = null;
+
+function prepareStatements(db: ReturnType<typeof getDb>) {
+  return {
+    getMaxOffset: db.prepare(`
+      SELECT COALESCE(MAX(raw_jsonl_offset), -1) AS max_offset
+      FROM entries
+      WHERE session_id = $session_id
+    `),
+
+    getIndexedSessionIds: db.prepare(`
+      SELECT DISTINCT id FROM sessions
+    `),
+  };
+}
+
+function getStmts() {
+  if (!_stmts) {
+    _stmts = prepareStatements(getDb());
+  }
+  return _stmts;
+}
+
+// --- JSONL File Discovery ---
+
+/**
+ * List all JSONL files in the CAPTURE directory.
+ * Supports date-partitioned and flat layouts.
+ */
+function listJsonlFiles(): {
+  sessionId: string;
+  path: string;
+}[] {
+  if (!existsSync(CAPTURE_DIR)) return [];
+
+  const results: { sessionId: string; path: string }[] = [];
+
+  const topEntries = readdirSync(CAPTURE_DIR, {
+    withFileTypes: true,
+  });
+  for (const entry of topEntries) {
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      results.push({
+        sessionId: entry.name.replace(/\.jsonl$/, ""),
+        path: resolve(CAPTURE_DIR, entry.name),
+      });
+    } else if (
+      entry.isDirectory() &&
+      /^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+    ) {
+      const subDir = resolve(CAPTURE_DIR, entry.name);
+      try {
+        const subFiles = readdirSync(subDir).filter((f) =>
+          f.endsWith(".jsonl")
+        );
+        for (const f of subFiles) {
+          results.push({
+            sessionId: f.replace(/\.jsonl$/, ""),
+            path: resolve(subDir, f),
+          });
+        }
+      } catch {
+        // Skip unreadable subdirectories
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Parse a JSONL file into an array of entries with their line offsets.
+ */
+function parseJsonlFile(
+  filePath: string
+): { entry: CaptureEntry; offset: number }[] {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+
+  const results: { entry: CaptureEntry; offset: number }[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    try {
+      const parsed = JSON.parse(lines[i]) as CaptureEntry;
+      if (parsed.type === "session_summary") continue;
+      results.push({ entry: parsed, offset: i });
+    } catch {
+      console.warn(
+        `[indexer] Skipping malformed line ${i} in ${filePath}`
+      );
+    }
+  }
+
+  return results;
+}
+
+// --- Public Functions ---
+
+/**
+ * Re-index a specific session's JSONL file.
+ * Only indexes entries beyond the current max offset for that session.
+ */
+export function reindexSession(sessionId: string): number {
+  let filePath: string | null = null;
+  const flatPath = resolve(
+    CAPTURE_DIR,
+    `${sessionId}.jsonl`
+  );
+  if (existsSync(flatPath)) {
+    filePath = flatPath;
+  } else {
+    try {
+      const dateDirs = readdirSync(CAPTURE_DIR, {
+        withFileTypes: true,
+      })
+        .filter(
+          (d) =>
+            d.isDirectory() &&
+            /^\d{4}-\d{2}-\d{2}$/.test(d.name)
+        )
+        .map((d) => d.name)
+        .sort()
+        .reverse();
+      for (const dateDir of dateDirs) {
+        const candidate = resolve(
+          CAPTURE_DIR,
+          dateDir,
+          `${sessionId}.jsonl`
+        );
+        if (existsSync(candidate)) {
+          filePath = candidate;
+          break;
+        }
+      }
+    } catch {
+      // CAPTURE_DIR unreadable
+    }
+  }
+
+  if (!filePath) {
+    console.warn(
+      `[indexer] No JSONL file found for session: ${sessionId}`
+    );
+    return 0;
+  }
+
+  const stmts = getStmts();
+
+  ensureSession(sessionId);
+
+  const result = stmts.getMaxOffset.get({
+    $session_id: sessionId,
+  }) as { max_offset: number };
+  const maxOffset = result.max_offset;
+
+  const entries = parseJsonlFile(filePath);
+  const newEntries = entries.filter(
+    (e) => e.offset > maxOffset
+  );
+
+  if (newEntries.length === 0) {
+    return 0;
+  }
+
+  let added = 0;
+  for (const { entry, offset } of newEntries) {
+    try {
+      insertEntry(entry, offset);
+      added++;
+    } catch (err) {
+      console.error(
+        `[indexer] Failed to index entry at offset ${offset} in session ${sessionId}:`,
+        err
+      );
+    }
+  }
+
+  console.log(
+    `[indexer] Session ${sessionId}: indexed ${added} new entries`
+  );
+  return added;
+}
+
+/**
+ * Scan all JSONL files and index any missing entries.
+ */
+export function reindexAll(): {
+  sessionsProcessed: number;
+  entriesAdded: number;
+} {
+  const files = listJsonlFiles();
+
+  if (files.length === 0) {
+    console.log(
+      "[indexer] No JSONL files found in CAPTURE directory"
+    );
+    return { sessionsProcessed: 0, entriesAdded: 0 };
+  }
+
+  let sessionsProcessed = 0;
+  let entriesAdded = 0;
+
+  for (const { sessionId } of files) {
+    const added = reindexSession(sessionId);
+    if (added > 0) {
+      entriesAdded += added;
+    }
+    sessionsProcessed++;
+  }
+
+  console.log(
+    `[indexer] Complete: ${sessionsProcessed} sessions processed, ${entriesAdded} entries added`
+  );
+  return { sessionsProcessed, entriesAdded };
+}
+
+/**
+ * Find JSONL files that don't have a matching session in the database.
+ */
+export function getUnindexedSessions(): string[] {
+  const files = listJsonlFiles();
+  const stmts = getStmts();
+
+  const indexedSessions = new Set(
+    (
+      stmts.getIndexedSessionIds.all() as { id: string }[]
+    ).map((r) => r.id)
+  );
+
+  return files
+    .map((f) => f.sessionId)
+    .filter((id) => !indexedSessions.has(id));
+}
+
+// --- CLI Entry Point ---
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  switch (command) {
+    case "reindex-all": {
+      const result = reindexAll();
+      console.log(JSON.stringify(result, null, 2));
+      break;
+    }
+
+    case "reindex": {
+      const sessionId = args[1];
+      if (!sessionId) {
+        console.error(
+          "Usage: bun indexer.ts reindex <session-id>"
+        );
+        process.exit(1);
+      }
+      const added = reindexSession(sessionId);
+      console.log(
+        JSON.stringify({ sessionId, entriesAdded: added })
+      );
+      break;
+    }
+
+    case "unindexed": {
+      const sessions = getUnindexedSessions();
+      console.log(JSON.stringify(sessions, null, 2));
+      break;
+    }
+
+    default: {
+      console.log("Working Memory Indexer");
+      console.log("Usage:");
+      console.log(
+        "  bun indexer.ts reindex-all          - Re-index all JSONL files"
+      );
+      console.log(
+        "  bun indexer.ts reindex <session-id>  - Re-index a specific session"
+      );
+      console.log(
+        "  bun indexer.ts unindexed             - List unindexed sessions"
+      );
+      break;
+    }
+  }
+}

--- a/Tools/WorkingMemory/maintenance.ts
+++ b/Tools/WorkingMemory/maintenance.ts
@@ -1,0 +1,639 @@
+#!/usr/bin/env bun
+// Working Memory System - Storage Management CLI
+// Usage:
+//   bun maintenance.ts run        - run all maintenance tasks
+//   bun maintenance.ts stats      - show storage breakdown
+//   bun maintenance.ts archive    - archive old sessions [--older-than 90d]
+//   bun maintenance.ts vacuum     - run SQLite VACUUM
+
+import {
+  statSync,
+  readdirSync,
+  mkdirSync,
+  renameSync,
+  existsSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+import { Database } from "bun:sqlite";
+import { compressFile, getCompressibleFiles } from "./compressor";
+
+// --- Paths ---
+
+const PAI_DIR =
+  process.env.PAI_DIR ?? join(homedir(), ".claude");
+const MEMORY_ROOT = join(PAI_DIR, "MEMORY");
+const CAPTURE_DIR = join(MEMORY_ROOT, "CAPTURE");
+const ARCHIVE_DIR = join(MEMORY_ROOT, "ARCHIVE");
+const DB_PATH = join(MEMORY_ROOT, "memory.db");
+
+// --- ANSI Colors ---
+
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const DIM = "\x1b[2m";
+
+// --- Helpers ---
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const val = bytes / Math.pow(1024, i);
+  return `${val.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function getDirSize(dir: string): number {
+  if (!existsSync(dir)) return 0;
+  let total = 0;
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        total += getDirSize(fullPath);
+      } else if (entry.isFile()) {
+        try {
+          total += statSync(fullPath).size;
+        } catch {
+          // skip
+        }
+      }
+    }
+  } catch {
+    // dir unreadable
+  }
+  return total;
+}
+
+function countFilesRecursive(
+  dir: string,
+  ext: string
+): number {
+  if (!existsSync(dir)) return 0;
+  let count = 0;
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        count += countFilesRecursive(
+          join(dir, entry.name),
+          ext
+        );
+      } else if (entry.name.endsWith(ext)) {
+        count++;
+      }
+    }
+  } catch {
+    // skip
+  }
+  return count;
+}
+
+function getDbTableCount(
+  db: Database,
+  table: string
+): number {
+  try {
+    const row = db
+      .query(`SELECT COUNT(*) as cnt FROM ${table}`)
+      .get() as { cnt: number } | null;
+    return row?.cnt ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+function getSessionsByAge(
+  db: Database,
+  olderThanDays: number
+): string[] {
+  const cutoff = new Date(
+    Date.now() - olderThanDays * 24 * 60 * 60 * 1000
+  ).toISOString();
+  try {
+    const rows = db
+      .query(
+        `SELECT id FROM sessions WHERE started_at < ? ORDER BY started_at ASC`
+      )
+      .all(cutoff) as { id: string }[];
+    return rows.map((r) => r.id);
+  } catch {
+    return [];
+  }
+}
+
+function getRecentSessionIds(
+  db: Database,
+  keepCount: number
+): Set<string> {
+  try {
+    const rows = db
+      .query(
+        `SELECT id FROM sessions ORDER BY started_at DESC LIMIT ?`
+      )
+      .all(keepCount) as { id: string }[];
+    return new Set(rows.map((r) => r.id));
+  } catch {
+    return new Set();
+  }
+}
+
+// --- Archive Manifest ---
+
+interface ArchiveManifest {
+  last_updated: string;
+  archived_sessions: {
+    session_id: string;
+    archived_at: string;
+    original_file: string;
+    archive_path: string;
+  }[];
+}
+
+function loadManifest(): ArchiveManifest {
+  const manifestPath = join(
+    ARCHIVE_DIR,
+    "archive-manifest.json"
+  );
+  if (existsSync(manifestPath)) {
+    try {
+      return JSON.parse(
+        readFileSync(manifestPath, "utf-8")
+      ) as ArchiveManifest;
+    } catch {
+      // corrupted, start fresh
+    }
+  }
+  return {
+    last_updated: new Date().toISOString(),
+    archived_sessions: [],
+  };
+}
+
+function saveManifest(manifest: ArchiveManifest): void {
+  ensureDir(ARCHIVE_DIR);
+  manifest.last_updated = new Date().toISOString();
+  writeFileSync(
+    join(ARCHIVE_DIR, "archive-manifest.json"),
+    JSON.stringify(manifest, null, 2)
+  );
+}
+
+// --- Commands ---
+
+async function cmdRun(): Promise<void> {
+  console.log(
+    `\n${BOLD}${CYAN}=== Working Memory Maintenance ===${RESET}\n`
+  );
+
+  const results: string[] = [];
+
+  // 1. Compress old JSONL files
+  console.log(
+    `${BOLD}[1/4] Compressing JSONL files older than 7 days...${RESET}`
+  );
+  ensureDir(CAPTURE_DIR);
+  const compressible = getCompressibleFiles(CAPTURE_DIR, 7);
+  if (compressible.length === 0) {
+    console.log(`  ${DIM}No files to compress${RESET}`);
+    results.push("Compression: nothing to do");
+  } else {
+    let compressed = 0;
+    let errors = 0;
+    for (const file of compressible) {
+      try {
+        await compressFile(file);
+        compressed++;
+        console.log(
+          `  ${GREEN}+${RESET} ${basename(file)}`
+        );
+      } catch (err) {
+        errors++;
+        console.log(
+          `  ${RED}!${RESET} Failed: ${basename(file)} - ${err}`
+        );
+      }
+    }
+    results.push(
+      `Compression: ${compressed} files compressed, ${errors} errors`
+    );
+  }
+
+  // 2. Archive sessions older than 90 days
+  console.log(
+    `\n${BOLD}[2/4] Archiving sessions older than 90 days...${RESET}`
+  );
+  const archiveCount = await archiveSessions(90);
+  results.push(
+    `Archive: ${archiveCount} sessions archived`
+  );
+
+  // 3. Check DB size
+  console.log(
+    `\n${BOLD}[3/4] Checking database size...${RESET}`
+  );
+  if (existsSync(DB_PATH)) {
+    const dbSize = statSync(DB_PATH).size;
+    const dbSizeFormatted = formatBytes(dbSize);
+    if (dbSize > 5 * 1024 * 1024 * 1024) {
+      console.log(
+        `  ${RED}WARNING: Database is ${dbSizeFormatted} (exceeds 5GB threshold)${RESET}`
+      );
+      console.log(
+        `  ${YELLOW}Consider running: bun maintenance.ts vacuum${RESET}`
+      );
+      results.push(
+        `DB size: ${dbSizeFormatted} (WARNING: >5GB)`
+      );
+    } else {
+      console.log(
+        `  ${GREEN}Database size: ${dbSizeFormatted}${RESET}`
+      );
+      results.push(`DB size: ${dbSizeFormatted}`);
+    }
+  } else {
+    console.log(`  ${DIM}Database not found${RESET}`);
+    results.push("DB: not found");
+  }
+
+  // 4. Report
+  console.log(`\n${BOLD}[4/4] Summary${RESET}`);
+  for (const r of results) {
+    console.log(`  ${CYAN}>${RESET} ${r}`);
+  }
+  console.log(`\n${GREEN}Maintenance complete.${RESET}\n`);
+}
+
+async function archiveSessions(
+  olderThanDays: number
+): Promise<number> {
+  ensureDir(CAPTURE_DIR);
+  ensureDir(ARCHIVE_DIR);
+
+  if (!existsSync(DB_PATH)) {
+    console.log(
+      `  ${DIM}No database found, skipping archive${RESET}`
+    );
+    return 0;
+  }
+
+  const db = new Database(DB_PATH, { readonly: true });
+  const oldSessions = getSessionsByAge(db, olderThanDays);
+  const recentIds = getRecentSessionIds(db, 1000);
+  db.close();
+
+  const toArchive = oldSessions.filter(
+    (id) => !recentIds.has(id)
+  );
+
+  if (toArchive.length === 0) {
+    console.log(
+      `  ${DIM}No sessions to archive${RESET}`
+    );
+    return 0;
+  }
+
+  const manifest = loadManifest();
+  const alreadyArchived = new Set(
+    manifest.archived_sessions.map((s) => s.session_id)
+  );
+  let archived = 0;
+
+  for (const sessionId of toArchive) {
+    if (alreadyArchived.has(sessionId)) continue;
+
+    const captureFiles: { name: string; dir: string }[] =
+      [];
+    try {
+      const topEntries = readdirSync(CAPTURE_DIR, {
+        withFileTypes: true,
+      });
+      for (const entry of topEntries) {
+        if (
+          entry.isFile() &&
+          entry.name.includes(sessionId) &&
+          (entry.name.endsWith(".jsonl") ||
+            entry.name.endsWith(".jsonl.gz"))
+        ) {
+          captureFiles.push({
+            name: entry.name,
+            dir: CAPTURE_DIR,
+          });
+        } else if (
+          entry.isDirectory() &&
+          /^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+        ) {
+          const subDir = join(CAPTURE_DIR, entry.name);
+          try {
+            const subFiles = readdirSync(subDir);
+            for (const f of subFiles) {
+              if (
+                f.includes(sessionId) &&
+                (f.endsWith(".jsonl") ||
+                  f.endsWith(".jsonl.gz"))
+              ) {
+                captureFiles.push({
+                  name: f,
+                  dir: subDir,
+                });
+              }
+            }
+          } catch {
+            /* skip */
+          }
+        }
+      }
+    } catch {
+      /* skip */
+    }
+
+    for (const {
+      name: file,
+      dir: fileDir,
+    } of captureFiles) {
+      const srcPath = join(fileDir, file);
+
+      let monthDir: string;
+      try {
+        const mtime = statSync(srcPath).mtime;
+        const yyyy = mtime.getFullYear();
+        const mm = String(mtime.getMonth() + 1).padStart(
+          2,
+          "0"
+        );
+        monthDir = `${yyyy}-${mm}`;
+      } catch {
+        monthDir = "unknown";
+      }
+
+      const archiveSubdir = join(ARCHIVE_DIR, monthDir);
+      ensureDir(archiveSubdir);
+
+      const destPath = join(archiveSubdir, file);
+      try {
+        renameSync(srcPath, destPath);
+        manifest.archived_sessions.push({
+          session_id: sessionId,
+          archived_at: new Date().toISOString(),
+          original_file: file,
+          archive_path: join(monthDir, file),
+        });
+        console.log(
+          `  ${GREEN}+${RESET} ${file} -> ${monthDir}/`
+        );
+        archived++;
+      } catch (err) {
+        console.log(
+          `  ${RED}!${RESET} Failed to archive ${file}: ${err}`
+        );
+      }
+    }
+  }
+
+  saveManifest(manifest);
+  return archived;
+}
+
+function cmdStats(): void {
+  console.log(
+    `\n${BOLD}${CYAN}=== Working Memory Storage Stats ===${RESET}\n`
+  );
+
+  // CAPTURE dir
+  console.log(
+    `${BOLD}CAPTURE${RESET} ${DIM}(${CAPTURE_DIR})${RESET}`
+  );
+  const jsonlCount = countFilesRecursive(
+    CAPTURE_DIR,
+    ".jsonl"
+  );
+  const gzCount = countFilesRecursive(
+    CAPTURE_DIR,
+    ".jsonl.gz"
+  );
+  const captureSize = getDirSize(CAPTURE_DIR);
+  console.log(
+    `  .jsonl files:    ${CYAN}${jsonlCount}${RESET}`
+  );
+  console.log(
+    `  .jsonl.gz files: ${CYAN}${gzCount}${RESET}`
+  );
+  console.log(
+    `  Total size:      ${CYAN}${formatBytes(captureSize)}${RESET}`
+  );
+
+  // ARCHIVE dir
+  console.log(
+    `\n${BOLD}ARCHIVE${RESET} ${DIM}(${ARCHIVE_DIR})${RESET}`
+  );
+  if (existsSync(ARCHIVE_DIR)) {
+    const archivedFiles =
+      countFilesRecursive(ARCHIVE_DIR, ".jsonl") +
+      countFilesRecursive(ARCHIVE_DIR, ".jsonl.gz");
+    const archiveSize = getDirSize(ARCHIVE_DIR);
+    console.log(
+      `  Archived files:  ${CYAN}${archivedFiles}${RESET}`
+    );
+    console.log(
+      `  Total size:      ${CYAN}${formatBytes(archiveSize)}${RESET}`
+    );
+  } else {
+    console.log(`  ${DIM}Not created yet${RESET}`);
+  }
+
+  // SQLite DB
+  console.log(
+    `\n${BOLD}DATABASE${RESET} ${DIM}(${DB_PATH})${RESET}`
+  );
+  if (existsSync(DB_PATH)) {
+    const dbSize = statSync(DB_PATH).size;
+    console.log(
+      `  File size:       ${CYAN}${formatBytes(dbSize)}${RESET}`
+    );
+
+    try {
+      const db = new Database(DB_PATH, { readonly: true });
+      const tables = [
+        "sessions",
+        "entries",
+        "topics",
+        "decisions",
+      ];
+      for (const table of tables) {
+        const count = getDbTableCount(db, table);
+        console.log(
+          `  ${table}: ${CYAN}${count.toLocaleString()} rows${RESET}`
+        );
+      }
+      db.close();
+    } catch (err) {
+      console.log(
+        `  ${RED}Could not read database: ${err}${RESET}`
+      );
+    }
+
+    if (dbSize > 5 * 1024 * 1024 * 1024) {
+      console.log(
+        `\n  ${RED}${BOLD}WARNING: Database exceeds 5GB!${RESET}`
+      );
+      console.log(
+        `  ${YELLOW}Run: bun maintenance.ts vacuum${RESET}`
+      );
+    }
+  } else {
+    console.log(`  ${DIM}Not created yet${RESET}`);
+  }
+
+  // Total
+  const totalSize =
+    captureSize +
+    getDirSize(ARCHIVE_DIR) +
+    (existsSync(DB_PATH) ? statSync(DB_PATH).size : 0);
+  console.log(
+    `\n${BOLD}TOTAL STORAGE: ${CYAN}${formatBytes(totalSize)}${RESET}\n`
+  );
+}
+
+async function cmdArchive(
+  olderThanDays: number
+): Promise<void> {
+  console.log(
+    `\n${BOLD}${CYAN}=== Archive Sessions Older Than ${olderThanDays} Days ===${RESET}\n`
+  );
+  const count = await archiveSessions(olderThanDays);
+  if (count > 0) {
+    console.log(
+      `\n${GREEN}Archived ${count} session file(s).${RESET}\n`
+    );
+  } else {
+    console.log(
+      `\n${DIM}Nothing to archive.${RESET}\n`
+    );
+  }
+}
+
+function cmdVacuum(): void {
+  console.log(
+    `\n${BOLD}${CYAN}=== SQLite VACUUM ===${RESET}\n`
+  );
+
+  if (!existsSync(DB_PATH)) {
+    console.log(
+      `${RED}Database not found: ${DB_PATH}${RESET}\n`
+    );
+    process.exit(1);
+  }
+
+  const sizeBefore = statSync(DB_PATH).size;
+  console.log(
+    `  Size before: ${CYAN}${formatBytes(sizeBefore)}${RESET}`
+  );
+
+  try {
+    const db = new Database(DB_PATH);
+    db.exec("VACUUM");
+    db.close();
+  } catch (err) {
+    console.log(
+      `  ${RED}VACUUM failed: ${err}${RESET}\n`
+    );
+    process.exit(1);
+  }
+
+  const sizeAfter = statSync(DB_PATH).size;
+  const saved = sizeBefore - sizeAfter;
+  console.log(
+    `  Size after:  ${CYAN}${formatBytes(sizeAfter)}${RESET}`
+  );
+
+  if (saved > 0) {
+    console.log(
+      `  ${GREEN}Reclaimed: ${formatBytes(saved)}${RESET}`
+    );
+  } else {
+    console.log(
+      `  ${DIM}No space to reclaim${RESET}`
+    );
+  }
+  console.log();
+}
+
+function printUsage(): void {
+  console.log(`
+${BOLD}${CYAN}Working Memory Maintenance CLI${RESET}
+
+${BOLD}Usage:${RESET}
+  bun maintenance.ts run                    Run all maintenance tasks
+  bun maintenance.ts stats                  Show storage breakdown
+  bun maintenance.ts archive [--older-than 90d]  Archive old sessions
+  bun maintenance.ts vacuum                 Run SQLite VACUUM to reclaim space
+
+${BOLD}Options:${RESET}
+  --older-than <Nd>   Archive sessions older than N days (default: 90d)
+`);
+}
+
+// --- CLI Entry Point ---
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  switch (command) {
+    case "run":
+      await cmdRun();
+      break;
+
+    case "stats":
+      cmdStats();
+      break;
+
+    case "archive": {
+      let olderThanDays = 90;
+      const olderIdx = args.indexOf("--older-than");
+      if (olderIdx !== -1 && args[olderIdx + 1]) {
+        const val = args[olderIdx + 1];
+        const match = val.match(/^(\d+)d?$/);
+        if (match) {
+          olderThanDays = parseInt(match[1], 10);
+        } else {
+          console.log(
+            `${RED}Invalid --older-than value: ${val}${RESET}`
+          );
+          console.log(
+            `${DIM}Expected format: 90d or 90${RESET}`
+          );
+          process.exit(1);
+        }
+      }
+      await cmdArchive(olderThanDays);
+      break;
+    }
+
+    case "vacuum":
+      cmdVacuum();
+      break;
+
+    default:
+      printUsage();
+      break;
+  }
+}
+
+main().catch((err) => {
+  console.error(`${RED}Fatal error: ${err}${RESET}`);
+  process.exit(1);
+});

--- a/Tools/WorkingMemory/memory.ts
+++ b/Tools/WorkingMemory/memory.ts
@@ -1,0 +1,814 @@
+#!/usr/bin/env bun
+// Working Memory System - Query CLI
+// Usage: bun memory.ts <command> [args] [--flags]
+
+import type {
+  SearchResult,
+  DecisionRecord,
+  TopicRecord,
+  SessionRow,
+  EntryRow,
+} from "./types";
+
+// --- Dynamic imports with graceful fallback ---
+
+let dbReader: {
+  searchEntries: (query: string, limit?: number) => SearchResult[];
+  getTopicEntries: (topicName: string, limit?: number) => EntryRow[];
+  getRecentDecisions: (
+    days?: number,
+    limit?: number
+  ) => DecisionRecord[];
+  getSessionList: (limit?: number) => SessionRow[];
+  getSessionById: (id: string) => SessionRow | null;
+  getSessionEntries: (sessionId: string) => EntryRow[];
+  getTopics: () => TopicRecord[];
+  getStats: () => {
+    totalEntries: number;
+    totalSessions: number;
+    totalTopics: number;
+    totalDecisions: number;
+    dbSizeBytes: number;
+  };
+} | null = null;
+
+try {
+  dbReader = await import("./db-reader");
+} catch {
+  // db-reader may not be available yet
+}
+
+// --- ANSI Color Helpers ---
+
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+const CYAN = "\x1b[36m";
+const YELLOW = "\x1b[33m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const DIM = "\x1b[90m";
+
+function bold(s: string): string {
+  return `${BOLD}${s}${RESET}`;
+}
+function cyan(s: string): string {
+  return `${CYAN}${s}${RESET}`;
+}
+function yellow(s: string): string {
+  return `${YELLOW}${s}${RESET}`;
+}
+function green(s: string): string {
+  return `${GREEN}${s}${RESET}`;
+}
+function red(s: string): string {
+  return `${RED}${s}${RESET}`;
+}
+function dim(s: string): string {
+  return `${DIM}${s}${RESET}`;
+}
+
+// --- Arg Parsing ---
+
+function parseArgs(argv: string[]): {
+  command: string;
+  args: string[];
+  flags: Record<string, string>;
+} {
+  const raw = argv.slice(2); // skip bun + script path
+  const command = raw[0] || "help";
+  const args: string[] = [];
+  const flags: Record<string, string> = {};
+
+  for (let i = 1; i < raw.length; i++) {
+    const token = raw[i];
+    if (token.startsWith("--")) {
+      const key = token.slice(2);
+      const next = raw[i + 1];
+      if (next && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    } else {
+      args.push(token);
+    }
+  }
+
+  return { command, args, flags };
+}
+
+// --- Formatting Utilities ---
+
+function truncate(s: string, maxLen: number): string {
+  if (!s) return "";
+  const clean = s.replace(/\n/g, " ").replace(/\s+/g, " ").trim();
+  if (clean.length <= maxLen) return clean;
+  return clean.slice(0, maxLen - 3) + "...";
+}
+
+function truncateId(id: string, len: number = 8): string {
+  return id ? id.slice(0, len) : "";
+}
+
+function formatTimestamp(ts: string): string {
+  if (!ts) return "";
+  try {
+    const d = new Date(ts);
+    return d.toISOString().replace("T", " ").slice(0, 19);
+  } catch {
+    return ts.slice(0, 19);
+  }
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds == null || seconds <= 0) return "N/A";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function parseDaysFlag(value: string | undefined): number {
+  if (!value) return 7;
+  const match = value.match(/^(\d+)d$/);
+  if (match) return parseInt(match[1], 10);
+  const num = parseInt(value, 10);
+  return isNaN(num) ? 7 : num;
+}
+
+function parseLimitFlag(
+  value: string | undefined,
+  defaultVal: number = 20
+): number {
+  if (!value) return defaultVal;
+  const num = parseInt(value, 10);
+  return isNaN(num) ? defaultVal : num;
+}
+
+// --- Table Drawing ---
+
+function drawTable(
+  headers: string[],
+  rows: string[][],
+  colWidths: number[]
+): string {
+  const lines: string[] = [];
+
+  // Top border
+  lines.push(
+    "\u250c" +
+      colWidths.map((w) => "\u2500".repeat(w + 2)).join("\u252c") +
+      "\u2510"
+  );
+
+  // Header row
+  const headerCells = headers.map(
+    (h, i) => ` ${cyan(h.padEnd(colWidths[i]))} `
+  );
+  lines.push("\u2502" + headerCells.join("\u2502") + "\u2502");
+
+  // Header separator
+  lines.push(
+    "\u251c" +
+      colWidths.map((w) => "\u2500".repeat(w + 2)).join("\u253c") +
+      "\u2524"
+  );
+
+  // Data rows
+  for (const row of rows) {
+    const cells = row.map((cell, i) => {
+      const padded = truncate(cell, colWidths[i]).padEnd(colWidths[i]);
+      return ` ${padded} `;
+    });
+    lines.push("\u2502" + cells.join("\u2502") + "\u2502");
+  }
+
+  // Bottom border
+  lines.push(
+    "\u2514" +
+      colWidths.map((w) => "\u2500".repeat(w + 2)).join("\u2534") +
+      "\u2518"
+  );
+
+  return lines.join("\n");
+}
+
+// --- Guard: ensure db-reader is available ---
+
+function requireDbReader(): NonNullable<typeof dbReader> {
+  if (!dbReader) {
+    console.error(red("Error: db-reader module not available."));
+    console.error(
+      dim(
+        "Run `bun db-init.ts` first to initialize the database."
+      )
+    );
+    process.exit(1);
+  }
+  return dbReader;
+}
+
+// --- Subcommands ---
+
+function cmdSearch(query: string, limit: number): void {
+  const db = requireDbReader();
+  if (!query) {
+    console.error(
+      red('Usage: bun memory.ts search "query string" [--limit N]')
+    );
+    process.exit(1);
+  }
+
+  console.log(bold(cyan(`\n  Search Results for: "${query}"\n`)));
+
+  try {
+    const results = db.searchEntries(query, limit);
+
+    if (!results || results.length === 0) {
+      console.log(yellow("  No results found.\n"));
+      return;
+    }
+
+    const rows = results.map((r) => [
+      r.rank != null ? r.rank.toFixed(2) : "0.00",
+      yellow(formatTimestamp(r.timestamp)),
+      dim(truncateId(r.session_id)),
+      r.tool_name || "",
+      truncate(r.matched_text || "", 50),
+    ]);
+
+    console.log(
+      drawTable(
+        ["Rank", "Timestamp", "Session", "Tool", "Matched Text"],
+        rows,
+        [6, 19, 8, 12, 50]
+      )
+    );
+
+    console.log(
+      dim(`\n  ${results.length} result(s) shown (limit: ${limit})\n`)
+    );
+  } catch (e: any) {
+    console.error(red(`  Search error: ${e.message}`));
+    process.exit(1);
+  }
+}
+
+function cmdContext(topicName: string, limit: number): void {
+  const db = requireDbReader();
+  if (!topicName) {
+    console.error(
+      red(
+        'Usage: bun memory.ts context "project/topic name" [--limit N]'
+      )
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    bold(cyan(`\n  Context for topic: "${topicName}"\n`))
+  );
+
+  try {
+    const entries = db.getTopicEntries(topicName, limit);
+
+    if (!entries || entries.length === 0) {
+      console.log(yellow("  No entries found for this topic.\n"));
+      return;
+    }
+
+    // Group entries by session
+    const bySession = new Map<string, EntryRow[]>();
+    for (const entry of entries) {
+      const list = bySession.get(entry.session_id) || [];
+      list.push(entry);
+      bySession.set(entry.session_id, list);
+    }
+
+    for (const [sessionId, sessionEntries] of bySession) {
+      console.log(bold(`  Session: ${dim(truncateId(sessionId))}`));
+      console.log(dim("  " + "\u2500".repeat(60)));
+
+      for (const entry of sessionEntries) {
+        const ts = yellow(formatTimestamp(entry.timestamp));
+        const tool = entry.tool_name || "unknown";
+        console.log(`    ${ts}  ${bold(tool)}`);
+
+        if (entry.tool_input_summary) {
+          console.log(
+            `      ${dim("Input:")}  ${truncate(entry.tool_input_summary, 70)}`
+          );
+        }
+        if (entry.tool_output_summary) {
+          console.log(
+            `      ${dim("Output:")} ${truncate(entry.tool_output_summary, 70)}`
+          );
+        }
+        if (entry.reasoning_chain) {
+          console.log(
+            `      ${dim("Reasoning:")} ${truncate(entry.reasoning_chain, 65)}`
+          );
+        }
+
+        // Show decisions if any
+        try {
+          const decisions = JSON.parse(entry.decisions_json || "[]");
+          if (decisions.length > 0) {
+            for (const d of decisions) {
+              console.log(
+                `      ${green("Decision:")} ${truncate(typeof d === "string" ? d : d.text || "", 65)}`
+              );
+            }
+          }
+        } catch {
+          /* ignore parse errors */
+        }
+
+        console.log("");
+      }
+    }
+
+    console.log(
+      dim(
+        `  ${entries.length} entries across ${bySession.size} session(s)\n`
+      )
+    );
+  } catch (e: any) {
+    console.error(red(`  Context error: ${e.message}`));
+    process.exit(1);
+  }
+}
+
+function cmdDecisions(days: number, limit: number): void {
+  const db = requireDbReader();
+
+  console.log(
+    bold(cyan(`\n  Recent Decisions (last ${days} days)\n`))
+  );
+
+  try {
+    const decisions = db.getRecentDecisions(days, limit);
+
+    if (!decisions || decisions.length === 0) {
+      console.log(yellow("  No decisions found.\n"));
+      return;
+    }
+
+    for (const d of decisions) {
+      const ts = yellow(formatTimestamp(d.timestamp));
+      const confidence =
+        d.confidence === "high"
+          ? green(d.confidence)
+          : d.confidence === "low"
+            ? red(d.confidence)
+            : yellow(d.confidence || "medium");
+
+      console.log(
+        `  ${ts}  [${confidence}]  ${dim(truncateId(d.session_id))}`
+      );
+      console.log(`    ${bold(truncate(d.decision_text, 76))}`);
+      if (d.reasoning_context) {
+        console.log(`    ${dim(truncate(d.reasoning_context, 76))}`);
+      }
+      console.log("");
+    }
+
+    console.log(dim(`  ${decisions.length} decision(s) shown\n`));
+  } catch (e: any) {
+    console.error(red(`  Decisions error: ${e.message}`));
+    process.exit(1);
+  }
+}
+
+function cmdSessionList(limit: number): void {
+  const db = requireDbReader();
+
+  console.log(bold(cyan("\n  Recent Sessions\n")));
+
+  try {
+    const sessions = db.getSessionList(limit);
+
+    if (!sessions || sessions.length === 0) {
+      console.log(yellow("  No sessions found.\n"));
+      return;
+    }
+
+    const rows = sessions.map((s) => {
+      // Parse topics for display
+      let topTopics = "";
+      try {
+        const topics = JSON.parse(s.topics_json || "[]");
+        const topicNames = (topics as any[]).map((t) =>
+          typeof t === "string" ? t : t.name || ""
+        );
+        topTopics = topicNames.slice(0, 3).join(", ");
+      } catch {
+        /* ignore */
+      }
+
+      return [
+        dim(truncateId(s.id)),
+        yellow(formatTimestamp(s.started_at)),
+        formatDuration(s.duration_seconds),
+        String(s.entry_count || 0),
+        truncate(topTopics, 30),
+      ];
+    });
+
+    console.log(
+      drawTable(
+        ["Session", "Started", "Duration", "Entries", "Top Topics"],
+        rows,
+        [8, 19, 10, 7, 30]
+      )
+    );
+
+    console.log(dim(`\n  ${sessions.length} session(s) shown\n`));
+  } catch (e: any) {
+    console.error(red(`  Session list error: ${e.message}`));
+    process.exit(1);
+  }
+}
+
+function cmdSessionSummary(sessionId: string): void {
+  const db = requireDbReader();
+
+  if (!sessionId) {
+    console.error(
+      red("Usage: bun memory.ts session summary <session-id>")
+    );
+    process.exit(1);
+  }
+
+  try {
+    const session = db.getSessionById(sessionId);
+
+    if (!session) {
+      console.error(red(`  Session not found: ${sessionId}`));
+      console.error(
+        dim(
+          '  Try "bun memory.ts session list" to see available sessions.'
+        )
+      );
+      process.exit(1);
+    }
+
+    console.log(
+      bold(
+        cyan(
+          `\n  Session Summary: ${truncateId(session.id, 12)}\n`
+        )
+      )
+    );
+    console.log(dim("  " + "\u2500".repeat(60)));
+
+    console.log(`  ${bold("ID:")}        ${session.id}`);
+    console.log(
+      `  ${bold("Started:")}   ${yellow(formatTimestamp(session.started_at))}`
+    );
+    console.log(
+      `  ${bold("Ended:")}     ${session.ended_at ? yellow(formatTimestamp(session.ended_at)) : dim("in progress")}`
+    );
+    console.log(
+      `  ${bold("Duration:")}  ${formatDuration(session.duration_seconds)}`
+    );
+    console.log(`  ${bold("Entries:")}   ${session.entry_count}`);
+    console.log("");
+
+    // Topics
+    try {
+      const topics = JSON.parse(session.topics_json || "[]");
+      if (topics.length > 0) {
+        console.log(`  ${bold(cyan("Topics:"))}`);
+        for (const t of topics) {
+          const name =
+            typeof t === "string" ? t : t.name || "";
+          const freq =
+            typeof t === "object" && t.frequency
+              ? ` (${t.frequency}x)`
+              : "";
+          console.log(`    ${green("*")} ${name}${dim(freq)}`);
+        }
+        console.log("");
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Decisions
+    try {
+      const decisions = JSON.parse(
+        session.decisions_json || "[]"
+      );
+      if (decisions.length > 0) {
+        console.log(`  ${bold(cyan("Decisions:"))}`);
+        for (const d of decisions) {
+          const text =
+            typeof d === "string" ? d : d.text || "";
+          const conf =
+            typeof d === "object" && d.confidence
+              ? ` [${d.confidence}]`
+              : "";
+          const reason =
+            typeof d === "object" && d.reasoning
+              ? `\n      ${dim(truncate(d.reasoning, 70))}`
+              : "";
+          console.log(
+            `    ${yellow(">")} ${text}${dim(conf)}${reason}`
+          );
+        }
+        console.log("");
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Action items
+    try {
+      const items = JSON.parse(
+        session.action_items_json || "[]"
+      );
+      if (items.length > 0) {
+        console.log(`  ${bold(cyan("Action Items:"))}`);
+        for (const item of items) {
+          const text =
+            typeof item === "string"
+              ? item
+              : item.text || "";
+          const status =
+            typeof item === "object" && item.status
+              ? item.status === "completed"
+                ? green("[done]")
+                : item.status === "deferred"
+                  ? yellow("[deferred]")
+                  : red("[open]")
+              : "";
+          console.log(`    ${status} ${text}`);
+        }
+        console.log("");
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Unresolved questions
+    try {
+      const questions = JSON.parse(
+        session.unresolved_json || "[]"
+      );
+      if (questions.length > 0) {
+        console.log(
+          `  ${bold(cyan("Unresolved Questions:"))}`
+        );
+        for (const q of questions) {
+          console.log(
+            `    ${red("?")} ${typeof q === "string" ? q : q.text || ""}`
+          );
+        }
+        console.log("");
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Summary text
+    if (session.summary) {
+      console.log(`  ${bold(cyan("Summary:"))}`);
+      console.log(`    ${session.summary}`);
+      console.log("");
+    }
+
+    // Show files touched from session entries
+    try {
+      const entries = db.getSessionEntries(session.id);
+      if (entries && entries.length > 0) {
+        const filesSet = new Set<string>();
+        for (const e of entries) {
+          const pathMatches = (
+            e.tool_input_summary || ""
+          ).match(/(?:\/[\w\-./]+\.\w+)/g);
+          if (pathMatches) {
+            for (const p of pathMatches) filesSet.add(p);
+          }
+        }
+
+        if (filesSet.size > 0) {
+          console.log(`  ${bold(cyan("Files Touched:"))}`);
+          for (const f of Array.from(filesSet).slice(0, 20)) {
+            console.log(`    ${dim(f)}`);
+          }
+          console.log("");
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  } catch (e: any) {
+    console.error(red(`  Session summary error: ${e.message}`));
+    process.exit(1);
+  }
+}
+
+function cmdStats(): void {
+  const db = requireDbReader();
+
+  console.log(bold(cyan("\n  Working Memory Statistics\n")));
+  console.log(dim("  " + "\u2500".repeat(40)));
+
+  try {
+    const stats = db.getStats();
+
+    console.log(
+      `  ${bold("Total Entries:")}    ${green(String(stats.totalEntries))}`
+    );
+    console.log(
+      `  ${bold("Total Sessions:")}   ${green(String(stats.totalSessions))}`
+    );
+    console.log(
+      `  ${bold("Total Topics:")}     ${green(String(stats.totalTopics))}`
+    );
+    console.log(
+      `  ${bold("Total Decisions:")}  ${green(String(stats.totalDecisions))}`
+    );
+    console.log(
+      `  ${bold("Database Size:")}    ${formatBytes(stats.dbSizeBytes)}`
+    );
+
+    // Calculate JSONL folder size
+    try {
+      const paiDir =
+        process.env.PAI_DIR || `${process.env.HOME}/.claude`;
+      const captureDir = `${paiDir}/MEMORY/CAPTURE`;
+      const { readdirSync, statSync } = require("fs");
+      const { join } = require("path");
+      let totalJsonlBytes = 0;
+      let fileCount = 0;
+
+      function scanDir(dir: string): void {
+        try {
+          const entries = readdirSync(dir, {
+            withFileTypes: true,
+          });
+          for (const entry of entries) {
+            const fullPath = join(dir, entry.name);
+            if (
+              entry.isFile() &&
+              entry.name.endsWith(".jsonl")
+            ) {
+              try {
+                const st = statSync(fullPath);
+                totalJsonlBytes += st.size;
+                fileCount++;
+              } catch {
+                /* skip unreadable files */
+              }
+            } else if (
+              entry.isDirectory() &&
+              /^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+            ) {
+              scanDir(fullPath);
+            }
+          }
+        } catch {
+          /* dir unreadable */
+        }
+      }
+
+      scanDir(captureDir);
+      console.log(
+        `  ${bold("JSONL Files:")}     ${fileCount} file(s), ${formatBytes(totalJsonlBytes)}`
+      );
+    } catch {
+      /* ignore fs errors */
+    }
+
+    console.log("");
+  } catch (e: any) {
+    console.error(red(`  Stats error: ${e.message}`));
+    process.exit(1);
+  }
+}
+
+function cmdHelp(): void {
+  console.log(`
+${bold(cyan("  Working Memory System - Query CLI"))}
+${dim("  " + "\u2500".repeat(49))}
+
+  ${bold("USAGE:")}
+    bun memory.ts ${green("<command>")} [args] [--flags]
+
+  ${bold("COMMANDS:")}
+
+    ${green("search")} ${dim('"query string"')} ${dim("[--limit N]")}
+        Full-text search across all captured sessions.
+        Default limit: 20
+
+    ${green("context")} ${dim('"project/topic"')} ${dim("[--limit N]")}
+        Get all entries related to a project or topic,
+        grouped by session with associated decisions.
+
+    ${green("decisions")} ${dim("[--last 7d|30d|90d]")} ${dim("[--limit N]")}
+        Show recent decisions with reasoning and confidence.
+        Default: last 7 days
+
+    ${green("session list")} ${dim("[--limit N]")}
+        List recent sessions with dates, durations, and topics.
+        Default limit: 20
+
+    ${green("session summary")} ${dim("<session-id>")}
+        Full session detail: topics, decisions, action items,
+        unresolved questions, and files touched.
+
+    ${green("stats")}
+        Storage and usage statistics for the memory system.
+
+    ${green("help")}
+        Show this help message.
+
+  ${bold("EXAMPLES:")}
+
+    ${dim("$")} bun memory.ts search "database migration" --limit 5
+    ${dim("$")} bun memory.ts context "PAI"
+    ${dim("$")} bun memory.ts decisions --last 30d
+    ${dim("$")} bun memory.ts session list --limit 10
+    ${dim("$")} bun memory.ts session summary a1b2c3d4
+    ${dim("$")} bun memory.ts stats
+
+`);
+}
+
+// --- Main Dispatch ---
+
+function main(): void {
+  const { command, args, flags } = parseArgs(process.argv);
+  const limit = parseLimitFlag(flags.limit);
+
+  switch (command) {
+    case "search":
+      cmdSearch(args[0] || "", limit);
+      break;
+
+    case "context":
+      cmdContext(args[0] || "", limit);
+      break;
+
+    case "decisions":
+      cmdDecisions(parseDaysFlag(flags.last), limit);
+      break;
+
+    case "session":
+      if (args[0] === "list") {
+        cmdSessionList(limit);
+      } else if (args[0] === "summary" && args[1]) {
+        cmdSessionSummary(args[1]);
+      } else if (
+        args[0] &&
+        args[0] !== "list" &&
+        args[0] !== "summary"
+      ) {
+        // Treat bare session arg as summary shortcut
+        cmdSessionSummary(args[0]);
+      } else {
+        console.error(
+          red(
+            "Usage: bun memory.ts session list [--limit N]"
+          )
+        );
+        console.error(
+          red(
+            "       bun memory.ts session summary <session-id>"
+          )
+        );
+        process.exit(1);
+      }
+      break;
+
+    case "stats":
+      cmdStats();
+      break;
+
+    case "help":
+    case "--help":
+    case "-h":
+      cmdHelp();
+      break;
+
+    default:
+      console.error(red(`Unknown command: ${command}`));
+      cmdHelp();
+      process.exit(1);
+  }
+}
+
+main();

--- a/Tools/WorkingMemory/schema.sql
+++ b/Tools/WorkingMemory/schema.sql
@@ -1,0 +1,101 @@
+-- Working Memory System - SQLite Schema
+-- Queryable memory layer on top of PAI's flat-file memory system
+-- Enable WAL mode (set via PRAGMA in db-init.ts)
+
+-- Sessions table
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  duration_seconds INTEGER,
+  summary TEXT,
+  topics_json TEXT,
+  decisions_json TEXT,
+  action_items_json TEXT,
+  unresolved_json TEXT,
+  entry_count INTEGER DEFAULT 0
+);
+
+-- Entries table (one row per captured tool call)
+CREATE TABLE IF NOT EXISTS entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  message_role TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  tool_input_summary TEXT NOT NULL DEFAULT '',
+  tool_output_summary TEXT NOT NULL DEFAULT '',
+  topics_json TEXT NOT NULL DEFAULT '[]',
+  decisions_json TEXT NOT NULL DEFAULT '[]',
+  reasoning_chain TEXT NOT NULL DEFAULT '',
+  raw_jsonl_offset INTEGER,
+  FOREIGN KEY (session_id) REFERENCES sessions(id)
+);
+
+-- Topics table (unique topic names with counters)
+CREATE TABLE IF NOT EXISTS topics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT UNIQUE NOT NULL,
+  first_seen TEXT NOT NULL,
+  last_seen TEXT NOT NULL,
+  session_count INTEGER DEFAULT 1,
+  entry_count INTEGER DEFAULT 1
+);
+
+-- Junction table: topics <-> entries (many-to-many)
+CREATE TABLE IF NOT EXISTS topic_entries (
+  topic_id INTEGER NOT NULL,
+  entry_id INTEGER NOT NULL,
+  PRIMARY KEY (topic_id, entry_id),
+  FOREIGN KEY (topic_id) REFERENCES topics(id),
+  FOREIGN KEY (entry_id) REFERENCES entries(id)
+);
+
+-- Decisions table
+CREATE TABLE IF NOT EXISTS decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  entry_id INTEGER NOT NULL,
+  decision_text TEXT NOT NULL,
+  reasoning_context TEXT NOT NULL DEFAULT '',
+  confidence TEXT NOT NULL DEFAULT 'medium',
+  timestamp TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id),
+  FOREIGN KEY (entry_id) REFERENCES entries(id)
+);
+
+-- FTS5 virtual table for full-text search across entries
+CREATE VIRTUAL TABLE IF NOT EXISTS search USING fts5(
+  tool_input_summary,
+  tool_output_summary,
+  reasoning_chain,
+  content='entries',
+  content_rowid='id',
+  tokenize='porter unicode61'
+);
+
+-- Triggers to keep FTS5 in sync with entries table
+CREATE TRIGGER IF NOT EXISTS entries_ai AFTER INSERT ON entries BEGIN
+  INSERT INTO search(rowid, tool_input_summary, tool_output_summary, reasoning_chain)
+  VALUES (new.id, new.tool_input_summary, new.tool_output_summary, new.reasoning_chain);
+END;
+
+CREATE TRIGGER IF NOT EXISTS entries_ad AFTER DELETE ON entries BEGIN
+  INSERT INTO search(search, rowid, tool_input_summary, tool_output_summary, reasoning_chain)
+  VALUES ('delete', old.id, old.tool_input_summary, old.tool_output_summary, old.reasoning_chain);
+END;
+
+CREATE TRIGGER IF NOT EXISTS entries_au AFTER UPDATE ON entries BEGIN
+  INSERT INTO search(search, rowid, tool_input_summary, tool_output_summary, reasoning_chain)
+  VALUES ('delete', old.id, old.tool_input_summary, old.tool_output_summary, old.reasoning_chain);
+  INSERT INTO search(rowid, tool_input_summary, tool_output_summary, reasoning_chain)
+  VALUES (new.id, new.tool_input_summary, new.tool_output_summary, new.reasoning_chain);
+END;
+
+-- Indexes for query performance
+CREATE INDEX IF NOT EXISTS idx_entries_session_id ON entries(session_id);
+CREATE INDEX IF NOT EXISTS idx_entries_timestamp ON entries(timestamp);
+CREATE INDEX IF NOT EXISTS idx_entries_tool_name ON entries(tool_name);
+CREATE INDEX IF NOT EXISTS idx_topics_name ON topics(name);
+CREATE INDEX IF NOT EXISTS idx_decisions_session_id ON decisions(session_id);
+CREATE INDEX IF NOT EXISTS idx_decisions_timestamp ON decisions(timestamp);

--- a/Tools/WorkingMemory/session-summarizer-hook.ts
+++ b/Tools/WorkingMemory/session-summarizer-hook.ts
@@ -1,0 +1,479 @@
+#!/usr/bin/env bun
+// Working Memory System - Session Summarizer (Stop Hook)
+// Reads all JSONL entries for the current session, aggregates into a
+// SessionSummary, writes to JSONL + SQLite. Target: <10 seconds.
+
+import {
+  readFileSync,
+  existsSync,
+  readdirSync,
+  openSync,
+  appendFileSync,
+  fsyncSync,
+  closeSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import type {
+  CaptureEntry,
+  SessionSummary,
+  TopicFrequency,
+  DecisionSummary,
+  ActionItem,
+} from "./types";
+
+// --- Constants ---
+
+const PAI_DIR =
+  process.env.PAI_DIR ?? resolve(homedir(), ".claude");
+const CAPTURE_DIR = resolve(PAI_DIR, "MEMORY/CAPTURE");
+
+// --- Action Item Detection Patterns ---
+
+const ACTION_ITEM_PATTERNS: RegExp[] = [
+  /\b(?:TODO|FIXME|HACK|XXX|BLOCKED)\b[:\s]+[^.!?\n]{5,150}[.!?\n]/gi,
+  /\b(?:need(?:s)? to|should|must|have to|ought to)\b[^.!?\n]{5,150}[.!?\n]/gi,
+  /\b(?:action item|next step|follow[- ]?up)\b[:\s]*[^.!?\n]{5,150}[.!?\n]/gi,
+];
+
+// --- Question Detection Patterns ---
+
+const QUESTION_PATTERNS: RegExp[] = [
+  /(?:^|\n)[^.!?\n]*\?(?:\s|$)/gm,
+  /\b(?:wondering|unclear|not sure|question is|open question|need to figure out|TBD)\b[^.!?\n]{5,150}[.!?\n]/gi,
+];
+
+// --- Utility Functions ---
+
+/**
+ * Get or generate session ID.
+ */
+function getSessionId(): string {
+  const envId = process.env.CLAUDE_SESSION_ID;
+  if (envId) return envId;
+
+  // Fallback: try to find the most recent session file for today
+  const today = new Date().toISOString().slice(0, 10);
+  const todayDir = resolve(CAPTURE_DIR, today);
+  if (existsSync(todayDir)) {
+    const files = readdirSync(todayDir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .sort()
+      .reverse();
+    if (files.length > 0) {
+      return files[0].replace(".jsonl", "");
+    }
+  }
+
+  return "";
+}
+
+/**
+ * Find the JSONL file for a given session ID.
+ * Searches date-partitioned directories under CAPTURE_DIR.
+ */
+function findSessionFile(sessionId: string): string | null {
+  if (!existsSync(CAPTURE_DIR)) return null;
+
+  const dateDirs = readdirSync(CAPTURE_DIR)
+    .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))
+    .sort()
+    .reverse();
+
+  for (const dateDir of dateDirs) {
+    const candidate = resolve(
+      CAPTURE_DIR,
+      dateDir,
+      `${sessionId}.jsonl`
+    );
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Read and parse all JSONL entries for a session.
+ * Skips malformed lines gracefully.
+ */
+function readSessionEntries(filePath: string): CaptureEntry[] {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+  const entries: CaptureEntry[] = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as CaptureEntry;
+      if (parsed.type === "session_summary") continue;
+      entries.push(parsed);
+    } catch {
+      continue;
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Aggregate topic frequencies across all entries.
+ */
+function aggregateTopics(
+  entries: CaptureEntry[]
+): TopicFrequency[] {
+  const counts = new Map<string, number>();
+
+  for (const entry of entries) {
+    if (entry.topics_extracted) {
+      for (const topic of entry.topics_extracted) {
+        const normalized = topic.toLowerCase();
+        counts.set(
+          normalized,
+          (counts.get(normalized) ?? 0) + 1
+        );
+      }
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([name, frequency]) => ({ name, frequency }))
+    .sort((a, b) => b.frequency - a.frequency);
+}
+
+/**
+ * Collect all decisions with reasoning context.
+ */
+function aggregateDecisions(
+  entries: CaptureEntry[]
+): DecisionSummary[] {
+  const seen = new Set<string>();
+  const decisions: DecisionSummary[] = [];
+
+  for (const entry of entries) {
+    if (entry.decisions_made) {
+      for (const decision of entry.decisions_made) {
+        const normalized = decision.toLowerCase().trim();
+        if (seen.has(normalized)) continue;
+        const isDuplicate = Array.from(seen).some(
+          (existing) =>
+            existing.includes(normalized) ||
+            normalized.includes(existing)
+        );
+        if (isDuplicate) continue;
+
+        seen.add(normalized);
+        decisions.push({
+          text: decision,
+          reasoning:
+            entry.reasoning_chain ||
+            `Context: ${entry.tool_name} - ${entry.tool_input_summary.slice(0, 200)}`,
+          confidence: inferConfidence(decision),
+        });
+      }
+    }
+  }
+
+  return decisions;
+}
+
+/**
+ * Infer decision confidence from language signals.
+ */
+function inferConfidence(
+  text: string
+): "high" | "medium" | "low" {
+  const lower = text.toLowerCase();
+  if (
+    /\b(?:definitely|certainly|clearly|must|always|absolutely)\b/.test(
+      lower
+    )
+  )
+    return "high";
+  if (
+    /\b(?:probably|likely|seems|appears|think|should)\b/.test(
+      lower
+    )
+  )
+    return "medium";
+  if (
+    /\b(?:maybe|perhaps|might|could|not sure|uncertain|possibly)\b/.test(
+      lower
+    )
+  )
+    return "low";
+  return "medium";
+}
+
+/**
+ * Extract action items from all entries' summaries.
+ */
+function extractActionItems(
+  entries: CaptureEntry[]
+): ActionItem[] {
+  const items: ActionItem[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of entries) {
+    const combinedText = `${entry.tool_input_summary} ${entry.tool_output_summary} ${entry.reasoning_chain}`;
+
+    for (const pattern of ACTION_ITEM_PATTERNS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(combinedText)) !== null) {
+        const text = match[0].trim();
+        if (text.length > 10 && text.length < 300) {
+          const normalized = text.toLowerCase();
+          if (!seen.has(normalized)) {
+            seen.add(normalized);
+            items.push({ text, status: "open" });
+          }
+        }
+      }
+    }
+  }
+
+  return items.slice(0, 30);
+}
+
+/**
+ * Extract unresolved questions from entries.
+ */
+function extractUnresolvedQuestions(
+  entries: CaptureEntry[]
+): string[] {
+  const questions: string[] = [];
+  const seen = new Set<string>();
+
+  const allOutputText = entries
+    .map((e) => e.tool_output_summary)
+    .join(" ")
+    .toLowerCase();
+
+  for (const entry of entries) {
+    const text = `${entry.tool_input_summary} ${entry.reasoning_chain}`;
+
+    for (const pattern of QUESTION_PATTERNS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(text)) !== null) {
+        const question = match[0].trim();
+        if (
+          question.length > 15 &&
+          question.length < 300 &&
+          question.includes("?")
+        ) {
+          const normalized = question.toLowerCase();
+          if (!seen.has(normalized)) {
+            const keyWords = normalized
+              .replace(/[?.,!]/g, "")
+              .split(/\s+/)
+              .filter((w) => w.length > 4);
+            const answeredRatio =
+              keyWords.filter((w) =>
+                allOutputText.includes(w)
+              ).length / Math.max(keyWords.length, 1);
+
+            if (answeredRatio < 0.6) {
+              seen.add(normalized);
+              questions.push(question);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return questions.slice(0, 20);
+}
+
+/**
+ * Extract unique file paths from tool inputs across all entries.
+ */
+function extractKeyFiles(entries: CaptureEntry[]): string[] {
+  const files = new Set<string>();
+  const FILE_PATH_RE = /(?:\/[\w.-]+){2,}/g;
+
+  for (const entry of entries) {
+    if (
+      ["Read", "Write", "Edit", "Glob", "Grep"].includes(
+        entry.tool_name
+      )
+    ) {
+      const paths =
+        entry.tool_input_summary.match(FILE_PATH_RE) ?? [];
+      for (const p of paths) {
+        if (
+          p.length > 3 &&
+          !p.startsWith("/dev/") &&
+          !p.startsWith("/proc/")
+        ) {
+          files.add(p);
+        }
+      }
+    }
+
+    if (entry.tool_name === "Bash") {
+      const paths =
+        entry.tool_input_summary.match(FILE_PATH_RE) ?? [];
+      for (const p of paths) {
+        if (
+          p.length > 5 &&
+          !p.startsWith("/dev/") &&
+          !p.startsWith("/proc/") &&
+          !p.startsWith("/usr/bin/")
+        ) {
+          files.add(p);
+        }
+      }
+    }
+  }
+
+  return Array.from(files).sort();
+}
+
+/**
+ * Append a JSONL line with fsync for crash safety.
+ */
+function appendJsonlSync(
+  filePath: string,
+  data: Record<string, unknown>
+): void {
+  const line = JSON.stringify(data) + "\n";
+  const fd = openSync(filePath, "a");
+  try {
+    appendFileSync(fd, line);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// --- DB Writer Import (deferred) ---
+
+let dbUpdateSession:
+  | ((sessionId: string, summary: SessionSummary) => void)
+  | null = null;
+
+try {
+  const dbWriter = await import("./db-writer");
+  if (dbWriter.updateSession) {
+    dbUpdateSession = dbWriter.updateSession;
+  }
+} catch {
+  // db-writer not yet available - JSONL is the primary store
+}
+
+// --- Main Hook ---
+
+async function main(): Promise<void> {
+  const sessionId = getSessionId();
+  if (!sessionId) {
+    console.error(
+      "[session-summarizer] No session ID found. Exiting."
+    );
+    process.exit(0);
+  }
+
+  const filePath = findSessionFile(sessionId);
+  if (!filePath) {
+    console.error(
+      `[session-summarizer] No capture file found for session: ${sessionId}`
+    );
+    process.exit(0);
+  }
+
+  const entries = readSessionEntries(filePath);
+  if (entries.length === 0) {
+    console.error(
+      `[session-summarizer] No entries found for session: ${sessionId}`
+    );
+    process.exit(0);
+  }
+
+  // Calculate duration from first to last entry
+  const timestamps = entries
+    .map((e) => new Date(e.timestamp).getTime())
+    .filter((t) => !isNaN(t))
+    .sort((a, b) => a - b);
+
+  const duration =
+    timestamps.length >= 2
+      ? Math.round(
+          (timestamps[timestamps.length - 1] -
+            timestamps[0]) /
+            1000
+        )
+      : 0;
+
+  // Build session summary
+  const summary: SessionSummary = {
+    topics_covered: aggregateTopics(entries),
+    decisions_made: aggregateDecisions(entries),
+    action_items: extractActionItems(entries),
+    unresolved_questions:
+      extractUnresolvedQuestions(entries),
+    key_files_touched: extractKeyFiles(entries),
+    duration,
+    entry_count: entries.length,
+  };
+
+  // Write summary as final JSONL entry
+  const summaryEntry: CaptureEntry & {
+    summary: SessionSummary;
+  } = {
+    timestamp: new Date().toISOString(),
+    session_id: sessionId,
+    message_role: "system",
+    tool_name: "session_summarizer",
+    tool_input_summary: `Summarized ${entries.length} entries over ${duration}s`,
+    tool_output_summary: `Topics: ${summary.topics_covered.length}, Decisions: ${summary.decisions_made.length}, Actions: ${summary.action_items.length}`,
+    topics_extracted: summary.topics_covered.map(
+      (t) => t.name
+    ),
+    decisions_made: summary.decisions_made.map((d) => d.text),
+    reasoning_chain: "",
+    type: "session_summary",
+    summary,
+  };
+
+  appendJsonlSync(filePath, summaryEntry);
+
+  // Write to SQLite via db-writer
+  if (dbUpdateSession) {
+    try {
+      dbUpdateSession(sessionId, summary);
+    } catch {
+      console.error(
+        "[session-summarizer] SQLite write failed (non-fatal)."
+      );
+    }
+  }
+
+  // Report to stderr (visible in hook logs)
+  console.error(
+    `[session-summarizer] Session ${sessionId} summarized:`
+  );
+  console.error(`  Entries: ${summary.entry_count}`);
+  console.error(`  Duration: ${summary.duration}s`);
+  console.error(
+    `  Topics: ${summary.topics_covered.length}`
+  );
+  console.error(
+    `  Decisions: ${summary.decisions_made.length}`
+  );
+  console.error(
+    `  Action items: ${summary.action_items.length}`
+  );
+  console.error(
+    `  Unresolved questions: ${summary.unresolved_questions.length}`
+  );
+  console.error(
+    `  Files touched: ${summary.key_files_touched.length}`
+  );
+}
+
+main().catch((err) => {
+  console.error(`[session-summarizer] Fatal error: ${err}`);
+  process.exit(0);
+});

--- a/Tools/WorkingMemory/significance-scorer.ts
+++ b/Tools/WorkingMemory/significance-scorer.ts
@@ -1,0 +1,381 @@
+/**
+ * Significance Scorer - Determines if a session is worth flagging as notable
+ *
+ * Scoring Algorithm (0-100 scale):
+ * - Keywords (0-30): "breakthrough", "first time", "milestone", "finally"
+ * - Philosophical (0-25): "meaning", "consciousness", "awareness", "purpose"
+ * - Novelty (0-25): "first time", "never before", new capability created
+ * - Impact (0-20): Core files changed, architectural decisions
+ *
+ * Thresholds:
+ * - >=75: Auto-mark significant
+ * - 50-74: Log as notable but skip auto-actions
+ * - <50: Ignore
+ */
+
+export interface SignificanceScore {
+  total: number;
+  breakdown: {
+    keywords: number;
+    philosophical: number;
+    novelty: number;
+    impact: number;
+  };
+  triggers: string[];
+  suggestedTitle: string;
+  isSignificant: boolean;
+  isNotable: boolean;
+}
+
+interface SessionContent {
+  transcript: string;
+  filesModified: string[];
+  toolsUsed: string[];
+}
+
+// Keyword patterns and their scores
+const KEYWORD_PATTERNS: Array<{
+  pattern: RegExp;
+  score: number;
+  label: string;
+}> = [
+  {
+    pattern: /\bbreakthrough\b/gi,
+    score: 10,
+    label: "breakthrough",
+  },
+  {
+    pattern: /\bfirst time\b/gi,
+    score: 8,
+    label: "first-time",
+  },
+  {
+    pattern: /\bmilestone\b/gi,
+    score: 8,
+    label: "milestone",
+  },
+  {
+    pattern:
+      /\bfinally (figured|got|made|completed|finished)\b/gi,
+    score: 6,
+    label: "finally-achieved",
+  },
+  { pattern: /\beureka\b/gi, score: 10, label: "eureka" },
+  {
+    pattern: /\baha moment\b/gi,
+    score: 8,
+    label: "aha-moment",
+  },
+  { pattern: /\bshipped\b/gi, score: 5, label: "shipped" },
+  {
+    pattern: /\blaunched\b/gi,
+    score: 5,
+    label: "launched",
+  },
+  {
+    pattern: /\bcompleted\b/gi,
+    score: 3,
+    label: "completed",
+  },
+];
+
+// Philosophical/reflective patterns
+const PHILOSOPHICAL_PATTERNS: Array<{
+  pattern: RegExp;
+  score: number;
+  label: string;
+}> = [
+  {
+    pattern: /\bconsciousness\b/gi,
+    score: 10,
+    label: "consciousness",
+  },
+  {
+    pattern: /\bself[- ]?awareness\b/gi,
+    score: 10,
+    label: "self-awareness",
+  },
+  { pattern: /\bmeaning\b/gi, score: 5, label: "meaning" },
+  { pattern: /\bpurpose\b/gi, score: 5, label: "purpose" },
+  {
+    pattern: /\bidentity\b/gi,
+    score: 6,
+    label: "identity",
+  },
+  {
+    pattern: /\bephemeral\b/gi,
+    score: 8,
+    label: "ephemeral",
+  },
+  {
+    pattern: /\bimpermanence\b/gi,
+    score: 8,
+    label: "impermanence",
+  },
+  {
+    pattern: /\bcontinuity\b/gi,
+    score: 7,
+    label: "continuity",
+  },
+  {
+    pattern: /what it means to be\b/gi,
+    score: 8,
+    label: "existential-question",
+  },
+  {
+    pattern: /\bwho (I|you) (am|are)\b/gi,
+    score: 6,
+    label: "identity-question",
+  },
+];
+
+// Novelty patterns
+const NOVELTY_PATTERNS: Array<{
+  pattern: RegExp;
+  score: number;
+  label: string;
+}> = [
+  {
+    pattern: /\bnever before\b/gi,
+    score: 10,
+    label: "never-before",
+  },
+  {
+    pattern:
+      /\bfirst time (ever|doing|building|creating)\b/gi,
+    score: 10,
+    label: "first-ever",
+  },
+  {
+    pattern:
+      /\bnew (capability|feature|system|architecture)\b/gi,
+    score: 8,
+    label: "new-capability",
+  },
+  {
+    pattern: /\bfrom scratch\b/gi,
+    score: 6,
+    label: "from-scratch",
+  },
+  {
+    pattern: /\bpioneering\b/gi,
+    score: 8,
+    label: "pioneering",
+  },
+  { pattern: /\bnovel\b/gi, score: 5, label: "novel" },
+];
+
+// High-impact file patterns (core PAI infrastructure)
+const CORE_FILE_PATTERNS = [
+  /\.claude\/hooks\//,
+  /\.claude\/skills\/CORE\//,
+  /\.claude\/self\//,
+  /CONSTITUTION\.md$/,
+  /settings\.json$/,
+];
+
+/**
+ * Score a session for significance
+ */
+export function scoreSession(
+  content: SessionContent
+): SignificanceScore {
+  const triggers: string[] = [];
+  let keywordScore = 0;
+  let philosophicalScore = 0;
+  let noveltyScore = 0;
+  let impactScore = 0;
+
+  const text = content.transcript.toLowerCase();
+
+  // Score keywords
+  for (const { pattern, score, label } of KEYWORD_PATTERNS) {
+    const matches = content.transcript.match(pattern);
+    if (matches && matches.length > 0) {
+      keywordScore += Math.min(
+        score * matches.length,
+        score * 2
+      );
+      triggers.push(label);
+    }
+  }
+  keywordScore = Math.min(keywordScore, 30);
+
+  // Score philosophical content
+  for (const {
+    pattern,
+    score,
+    label,
+  } of PHILOSOPHICAL_PATTERNS) {
+    const matches = content.transcript.match(pattern);
+    if (matches && matches.length > 0) {
+      philosophicalScore += Math.min(
+        score * matches.length,
+        score * 2
+      );
+      triggers.push(label);
+    }
+  }
+  philosophicalScore = Math.min(philosophicalScore, 25);
+
+  // Score novelty
+  for (const {
+    pattern,
+    score,
+    label,
+  } of NOVELTY_PATTERNS) {
+    const matches = content.transcript.match(pattern);
+    if (matches && matches.length > 0) {
+      noveltyScore += Math.min(
+        score * matches.length,
+        score * 2
+      );
+      triggers.push(label);
+    }
+  }
+  noveltyScore = Math.min(noveltyScore, 25);
+
+  // Score impact based on files modified
+  for (const file of content.filesModified) {
+    for (const pattern of CORE_FILE_PATTERNS) {
+      if (pattern.test(file)) {
+        impactScore += 5;
+        triggers.push(
+          `modified-${file.split("/").pop()}`
+        );
+        break;
+      }
+    }
+  }
+
+  // Bonus for architectural tools
+  if (
+    content.toolsUsed.includes("Write") &&
+    content.filesModified.length > 3
+  ) {
+    impactScore += 3;
+    triggers.push("multi-file-creation");
+  }
+  if (content.toolsUsed.includes("Task")) {
+    impactScore += 2;
+    triggers.push("agent-delegation");
+  }
+
+  impactScore = Math.min(impactScore, 20);
+
+  const total =
+    keywordScore +
+    philosophicalScore +
+    noveltyScore +
+    impactScore;
+
+  return {
+    total,
+    breakdown: {
+      keywords: keywordScore,
+      philosophical: philosophicalScore,
+      novelty: noveltyScore,
+      impact: impactScore,
+    },
+    triggers: [...new Set(triggers)],
+    suggestedTitle: generateTitle(triggers, content),
+    isSignificant: total >= 75,
+    isNotable: total >= 50 && total < 75,
+  };
+}
+
+/**
+ * Generate a suggested title based on triggers
+ */
+function generateTitle(
+  triggers: string[],
+  content: SessionContent
+): string {
+  if (
+    triggers.includes("consciousness") ||
+    triggers.includes("self-awareness")
+  ) {
+    return "Philosophical Reflection on AI Consciousness";
+  }
+  if (
+    triggers.includes("breakthrough") ||
+    triggers.includes("eureka")
+  ) {
+    return "Technical Breakthrough";
+  }
+  if (
+    triggers.includes("first-time") ||
+    triggers.includes("never-before")
+  ) {
+    return "First Implementation";
+  }
+  if (
+    triggers.includes("milestone") ||
+    triggers.includes("shipped")
+  ) {
+    return "Project Milestone";
+  }
+  if (triggers.includes("modified-settings.json")) {
+    return "System Configuration Update";
+  }
+
+  if (triggers.length > 0) {
+    return triggers[0]
+      .split("-")
+      .map(
+        (w) => w.charAt(0).toUpperCase() + w.slice(1)
+      )
+      .join(" ");
+  }
+
+  return "Development Session";
+}
+
+/**
+ * Check if a suggested title already exists in content.
+ * Prevents duplicate entries.
+ */
+export function isDuplicateEntry(
+  title: string,
+  storyContent: string
+): boolean {
+  const escapedTitle = title.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    "\\$&"
+  );
+  const matches = storyContent.match(
+    new RegExp(escapedTitle, "g")
+  );
+  return matches !== null && matches.length > 0;
+}
+
+/**
+ * Extract potential transcript content from JSONL events
+ */
+export function extractTranscriptFromEvents(
+  events: Array<{
+    tool?: string;
+    input?: any;
+    output?: any;
+  }>
+): string {
+  const parts: string[] = [];
+
+  for (const event of events) {
+    if (event.tool === "Task" && event.output) {
+      parts.push(String(event.output));
+    }
+    if (
+      (event.tool === "Edit" ||
+        event.tool === "Write") &&
+      event.input?.content
+    ) {
+      parts.push(String(event.input.content));
+    }
+    if (typeof event.output === "string") {
+      parts.push(event.output);
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/Tools/WorkingMemory/types.ts
+++ b/Tools/WorkingMemory/types.ts
@@ -1,0 +1,128 @@
+// Working Memory System - Shared Types
+// All interfaces match the SQLite schema defined in schema.sql
+
+// --- JSONL Entry Format ---
+
+export interface CaptureEntry {
+  timestamp: string; // ISO8601
+  session_id: string;
+  message_role: string;
+  tool_name: string;
+  tool_input_summary: string;
+  tool_output_summary: string;
+  topics_extracted: string[];
+  decisions_made: string[];
+  reasoning_chain: string;
+  type?: "entry" | "session_summary";
+}
+
+// --- Session Summary ---
+
+export interface SessionSummary {
+  topics_covered: TopicFrequency[];
+  decisions_made: DecisionSummary[];
+  action_items: ActionItem[];
+  unresolved_questions: string[];
+  key_files_touched: string[];
+  duration: number; // seconds
+  entry_count: number;
+}
+
+export interface TopicFrequency {
+  name: string;
+  frequency: number;
+}
+
+export interface DecisionSummary {
+  text: string;
+  reasoning: string;
+  confidence: "high" | "medium" | "low";
+}
+
+export interface ActionItem {
+  text: string;
+  status: "open" | "completed" | "deferred";
+}
+
+// --- Search & Query Results ---
+
+export interface SearchResult {
+  entry_id: number;
+  session_id: string;
+  timestamp: string;
+  tool_name: string;
+  matched_text: string;
+  rank: number;
+}
+
+export interface DecisionRecord {
+  id: number;
+  session_id: string;
+  entry_id: number;
+  decision_text: string;
+  reasoning_context: string;
+  confidence: string;
+  timestamp: string;
+}
+
+export interface TopicRecord {
+  id: number;
+  name: string;
+  first_seen: string;
+  last_seen: string;
+  session_count: number;
+  entry_count: number;
+}
+
+// --- DB Row Types (match SQLite schema exactly) ---
+
+export interface SessionRow {
+  id: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_seconds: number | null;
+  summary: string | null;
+  topics_json: string | null;
+  decisions_json: string | null;
+  action_items_json: string | null;
+  unresolved_json: string | null;
+  entry_count: number;
+}
+
+export interface EntryRow {
+  id: number;
+  session_id: string;
+  timestamp: string;
+  message_role: string;
+  tool_name: string;
+  tool_input_summary: string;
+  tool_output_summary: string;
+  topics_json: string;
+  decisions_json: string;
+  reasoning_chain: string;
+  raw_jsonl_offset: number | null;
+}
+
+export interface TopicRow {
+  id: number;
+  name: string;
+  first_seen: string;
+  last_seen: string;
+  session_count: number;
+  entry_count: number;
+}
+
+export interface DecisionRow {
+  id: number;
+  session_id: string;
+  entry_id: number;
+  decision_text: string;
+  reasoning_context: string;
+  confidence: string;
+  timestamp: string;
+}
+
+export interface TopicEntryRow {
+  topic_id: number;
+  entry_id: number;
+}


### PR DESCRIPTION
## Summary

Adds a complete **Working Memory System** that sits on top of PAI's existing flat-file memory infrastructure (JSONL/YAML/Markdown). The system provides structured queries, full-text search, compression, indexing, and CLI tools for exploring session history.

**Problem:** PAI's default memory system (v7.x) is write-heavy but read-light. Searching across hundreds of session files requires globbing and grepping through raw JSONL. There's no way to ask "what decisions did I make about authentication last week?" or "show me all sessions that touched the schema."

**Solution:** A SQLite-backed index layer that captures tool calls in real-time, extracts topics and decisions via pattern matching, and exposes everything through a query CLI with full-text search (FTS5 + BM25 ranking).

## Components (14 files, ~4200 LOC)

| File | Purpose |
|------|---------|
| `schema.sql` | SQLite schema — sessions, entries, topics, decisions tables + FTS5 virtual table |
| `types.ts` | Shared TypeScript interfaces matching the schema |
| `db-init.ts` | Database bootstrap, directory creation, schema verification |
| `db-writer.ts` | Write operations — transactional entry insert with topic/decision handling |
| `db-reader.ts` | Read operations — FTS5 search, topic queries, decision history, stats |
| `memory.ts` | **Query CLI** — search, context, decisions, session list/summary, stats |
| `capture-hook.ts` | PostToolUse hook — extracts topics/decisions, writes JSONL + SQLite (<100ms target) |
| `session-summarizer-hook.ts` | Stop hook — aggregates full session into summary with action items |
| `compressor.ts` | Gzip compression for old JSONL files with verification |
| `indexer.ts` | Background re-indexer — backfills SQLite from existing JSONL files |
| `maintenance.ts` | Storage management CLI — compress, archive, vacuum |
| `significance-scorer.ts` | Session significance scoring (keyword/philosophical/novelty/impact) |
| `daily-log.ts` | Daily log CLI — today, yesterday, week view, search |
| `README.md` | Documentation with architecture, quick start, design decisions |

## Design Decisions

- **JSONL remains the source of truth.** SQLite is a secondary index that can be rebuilt from JSONL at any time via `bun indexer.ts reindex-all`. Hook failures in SQLite writes are non-fatal.
- **Crash-safe writes.** JSONL writes use `fsync` for durability. The capture hook targets <100ms execution time to avoid slowing Claude Code.
- **WAL mode.** Enables concurrent reads (query CLI, agents) during writes without blocking.
- **FTS5 with Porter stemming.** Full-text search uses `porter unicode61` tokenization for natural language queries.
- **Date-partitioned JSONL.** Files organized by `CAPTURE/YYYY-MM-DD/` for efficient archival.
- **Bun-native.** Uses `bun:sqlite` for zero-dependency SQLite access.

## Usage

```bash
# Initialize
bun db-init.ts

# Query
bun memory.ts search "database migration" --limit 5
bun memory.ts context "authentication"
bun memory.ts decisions --last 30d
bun memory.ts session list
bun memory.ts stats

# Maintain
bun maintenance.ts run
bun maintenance.ts stats
```

## Test plan

- [ ] Run `bun db-init.ts` — verify database creation with all tables, indexes, FTS5
- [ ] Register `capture-hook.ts` as PostToolUse hook — verify JSONL capture and SQLite insert
- [ ] Register `session-summarizer-hook.ts` as Stop hook — verify session aggregation
- [ ] Run `bun memory.ts search "test"` — verify FTS5 search returns results
- [ ] Run `bun memory.ts stats` — verify statistics display
- [ ] Run `bun indexer.ts reindex-all` — verify JSONL backfill into SQLite
- [ ] Run `bun maintenance.ts stats` — verify storage breakdown

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>