### PR TITLE
fix(inference): strip CLAUDE_CODE_* env vars and prevent session pollution

### DIFF
--- a/Releases/v4.0.3/.claude/PAI/Tools/Inference.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/Inference.ts
@@ -75,9 +75,14 @@ export async function inference(options: InferenceOptions): Promise<InferenceRes
     const env = { ...process.env };
     delete env.ANTHROPIC_API_KEY;
     delete env.CLAUDECODE;
+    // Strip all CLAUDE_CODE_* env vars to prevent subprocess hang (CC 2.1.71+)
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('CLAUDE_CODE_')) delete env[key];
+    }
 
     const args = [
       '--print',
+      '--no-session-persistence',
       '--model', config.model,
       '--tools', '',  // Disable tools for faster response
       '--output-format', 'text',


### PR DESCRIPTION
## Fixes #931, #947

Two issues in `Inference.ts` when hooks call `claude --print`:

1. **Hang on CC 2.1.71+** — only `CLAUDECODE` is stripped, but CC now sets `CLAUDE_CODE_SSE_PORT`, `CLAUDE_CODE_ENTRYPOINT`, etc. Subprocess tries to reconnect to parent session and hangs silently.

2. **Session pollution** — every `claude -p` call persists a session. Over normal usage, `claude --resume` fills with 200+ ghost inference sessions.

## Changes

- Strip all `CLAUDE_CODE_*` env vars via prefix loop (future-proof)
- Add `--no-session-persistence` flag

## Tested

Running this pattern in production on Linux (CC 2.1.75) since February with zero issues.

🤖 Generated with [Claude Code](https://claude.ai/code)