### PR TITLE
fix(installer): deduplicate bun shell config entries on retry

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
@@ -14,6 +14,48 @@ import { detectSystem, validateElevenLabsKey } from "./detect";
 import { generateSettingsJson } from "./config-gen";
 
 /**
+ * Remove duplicate bun PATH entries from shell config.
+ * The bun.sh installer appends entries on every run — if install is
+ * interrupted and retried, the config file accumulates duplicates.
+ * Fixes: https://github.com/danielmiessler/Personal_AI_Infrastructure/issues/954
+ */
+function deduplicateBunShellEntries(): void {
+  const home = homedir();
+  const shell = process.env.SHELL || "/bin/zsh";
+
+  let rcFile: string;
+  if (shell.includes("fish")) {
+    rcFile = join(home, ".config", "fish", "config.fish");
+  } else if (shell.includes("bash")) {
+    rcFile = join(home, ".bashrc");
+  } else {
+    rcFile = join(home, ".zshrc");
+  }
+
+  if (!existsSync(rcFile)) return;
+
+  try {
+    const content = readFileSync(rcFile, "utf-8");
+
+    // Match bun config blocks: "# bun" line followed by export/set lines
+    const bunBlockPattern = shell.includes("fish")
+      ? /\n?# bun\nset --export BUN_INSTALL "[^"]*"\nset --export PATH \$BUN_INSTALL\/bin \$PATH\n?/g
+      : /\n?# bun\nexport BUN_INSTALL="[^"]*"\nexport PATH="?\$BUN_INSTALL\/bin:\$PATH"?\n?/g;
+
+    const matches = content.match(bunBlockPattern);
+    if (!matches || matches.length <= 1) return; // No duplicates
+
+    // Remove all bun blocks, then add back exactly one
+    let cleaned = content.replace(bunBlockPattern, "");
+    cleaned = cleaned.trimEnd() + "\n" + matches[0].trim() + "\n";
+
+    writeFileSync(rcFile, cleaned);
+  } catch {
+    // Non-fatal — duplicates are cosmetic, not breaking
+  }
+}
+
+/**
  * Search existing .claude directories and config locations for a given env key.
  * Returns the value if found, or empty string.
  */
@@ -291,6 +333,7 @@ export async function runPrerequisites(
       const bunBin = join(homedir(), ".bun", "bin");
       process.env.PATH = `${bunBin}:${process.env.PATH}`;
       await emit({ event: "message", content: "Bun installed successfully." });
+      deduplicateBunShellEntries(); // Fix #954: clean up duplicate entries from retries
     }
   } else {
     await emit({ event: "progress", step: "prerequisites", percent: 50, detail: `Bun found: v${det.tools.bun.version}` });


### PR DESCRIPTION
## Summary

Fixes #954 — When the PAI installer is interrupted and retried, the bun.sh installer appends `BUN_INSTALL`/`PATH` entries to the shell config file on every run, creating duplicates.

- Adds `deduplicateBunShellEntries()` helper that detects the active shell config (.bashrc/.zshrc/config.fish), finds duplicate `# bun` blocks via regex, and writes back exactly one copy
- Called after every successful bun install in `runPrerequisites()`
- Non-fatal (try/catch) — duplicates are cosmetic, not breaking
- Supports bash, zsh, and fish shell formats

## Test plan

- [ ] Run installer on a system with existing duplicate bun entries → verify deduplication
- [ ] Run installer on clean system → verify single bun entry preserved
- [ ] Test with fish shell config format
- [ ] Verify no-op when no duplicates exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)