### PR TITLE
fix(installer): check for unzip dependency before bun install

### DIFF
--- a/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
+++ b/Releases/v4.0.3/.claude/PAI-Install/engine/actions.ts
@@ -282,6 +282,31 @@ export async function runPrerequisites(
     await emit({ event: "progress", step: "prerequisites", percent: 20, detail: `Git found: v${det.tools.git.version}` });
   }
 
+  // Check for unzip — required by bun installer but missing on minimal Linux installs
+  // Fixes: https://github.com/danielmiessler/Personal_AI_Infrastructure/issues/856
+  if (!det.tools.bun.installed && det.os.platform === "linux") {
+    const hasUnzip = tryExec("which unzip", 5000);
+    if (hasUnzip === null) {
+      await emit({ event: "progress", step: "prerequisites", percent: 35, detail: "Installing unzip (required by Bun)..." });
+
+      // Try common package managers
+      const installed =
+        tryExec("sudo apt-get install -y unzip 2>/dev/null", 30000) !== null ||
+        tryExec("sudo dnf install -y unzip 2>/dev/null", 30000) !== null ||
+        tryExec("sudo yum install -y unzip 2>/dev/null", 30000) !== null ||
+        tryExec("sudo pacman -S --noconfirm unzip 2>/dev/null", 30000) !== null;
+
+      if (installed) {
+        await emit({ event: "message", content: "unzip installed successfully." });
+      } else {
+        await emit({
+          event: "message",
+          content: "⚠️  Could not install 'unzip' automatically. Bun requires it.\n   Please install manually: sudo apt install unzip (Debian/Ubuntu) or sudo dnf install unzip (Fedora/RHEL)",
+        });
+      }
+    }
+  }
+
   // Bun should already be installed by bootstrap script, but verify
   if (!det.tools.bun.installed) {
     await emit({ event: "progress", step: "prerequisites", percent: 40, detail: "Installing Bun..." });


### PR DESCRIPTION
## Summary

Fixes #856 — The bun.sh installer requires `unzip` but fails silently when it's missing. On minimal Linux installs (Ubuntu Server, Debian minimal), `unzip` is not present by default.

- Adds a pre-flight check before bun installation (Linux only)
- Auto-installs `unzip` via apt-get, dnf, yum, or pacman (short-circuits on first success)
- Emits a clear error message with manual install instructions if auto-install fails
- Only triggers when bun is not already installed

## Test plan

- [ ] Run installer on minimal Debian/Ubuntu without `unzip` → verify auto-install
- [ ] Run installer on system with `unzip` present → verify no-op
- [ ] Run installer on macOS → verify Linux-only guard skips check
- [ ] Test with non-sudo environment → verify clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)