### PR TITLE
fix: Respect PAI_DIR environment variable in INSTALL.ts

### DIFF
--- a/Releases/v2.5/.claude/INSTALL.ts
+++ b/Releases/v2.5/.claude/INSTALL.ts
@@ -32,7 +32,7 @@ const c = {
 
 // Paths
 const HOME = homedir();
-const CLAUDE_DIR = join(HOME, '.claude');
+const CLAUDE_DIR = process.env.PAI_DIR || join(HOME, '.claude');
 const ZSHRC = join(HOME, '.zshrc');
 const VOICE_SERVER_DIR = join(CLAUDE_DIR, 'VoiceServer');
 const VOICE_SERVER_PORT = 8888;
@@ -297,7 +297,7 @@ function generateSettingsJson(config: InstallConfig): object {
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
     "paiVersion": "2.5",
     "env": {
-      "PAI_DIR": `${HOME}/.claude`,
+      "PAI_DIR": CLAUDE_DIR,
       "PROJECTS_DIR": config.PROJECTS_DIR || "",
       "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "80000",
       "BASH_DEFAULT_TIMEOUT_MS": "600000"


### PR DESCRIPTION
## Summary

- `Releases/v2.5/.claude/INSTALL.ts` hardcodes `~/.claude` as the installation directory, ignoring the `PAI_DIR` environment variable
- Users who set `PAI_DIR` to a custom path get a mismatch: the env var points to their custom directory but the installer always writes `PAI_DIR` back as `~/.claude` in `settings.json`
- The `Bundles/Official/install.ts` already handles this correctly (line 98), this PR aligns the v2.5 release script

## Changes

Two lines changed in `Releases/v2.5/.claude/INSTALL.ts`:

1. **Line 35:** Read `PAI_DIR` from `process.env` at startup, falling back to `~/.claude`
2. **Line 300:** Use the resolved `CLAUDE_DIR` variable when writing `PAI_DIR` into `settings.json` instead of re-hardcoding the default path

## Test plan

- [ ] Run `INSTALL.ts` without `PAI_DIR` set — should default to `~/.claude` (no behavior change)
- [ ] Run `PAI_DIR=/custom/path bun INSTALL.ts` — should install to `/custom/path` and write that path into `settings.json`