### PR TITLE
fix: add MEMORY additionalDirectories and write permission to v4.0.3 settings

### DIFF
--- a/Releases/v4.0.3/.claude/settings.json
+++ b/Releases/v4.0.3/.claude/settings.json
@@ -26,7 +26,8 @@
       "ExitPlanMode",
       "Task",
       "Skill",
-      "mcp__*"
+      "mcp__*",
+      "Write(~/.claude/MEMORY/**)"
     ],
     "deny": [],
     "ask": [
@@ -60,7 +61,10 @@
       "Write(~/.ssh/*)",
       "Edit(~/.ssh/*)"
     ],
-    "defaultMode": "default"
+    "defaultMode": "default",
+    "additionalDirectories": [
+      "~/.claude/MEMORY"
+    ]
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [],


### PR DESCRIPTION
## Problem

A regression introduced in Claude Code versions after 2.1.77 broke the MEMORY directory context injection. Users running newer Claude Code versions find that `~/.claude/MEMORY` is no longer accessible across projects, causing PAI's dynamic context (learning signals, session history, Wisdom Frames, etc.) to fail silently.

Reported in discussion #992 — reverting to Claude Code 2.1.77 resolves it, but that's not a sustainable fix.

## Solution

Two surgical additions to `Releases/v4.0.3/.claude/settings.json`:

1. **`additionalDirectories`** — registers `~/.claude/MEMORY` as an additional working directory so Claude Code exposes it across all project sessions
2. **`Write(~/.claude/MEMORY/**)`** in the `allow` permissions — lets PAI hooks write to MEMORY without prompting (required for WorkCompletionLearning, IntegrityCheck, and other session-end hooks)

Tilde paths (`~`) confirmed working — consistent with existing permission patterns already in this file (e.g. `Write(~/.claude/settings.json)`).

## Files Changed

- `Releases/v4.0.3/.claude/settings.json` — 6-line addition

## Test Plan

- [ ] Fresh install of PAI v4.0.3 on Claude Code > 2.1.77
- [ ] Start a new session — verify PAI Dynamic Context block loads (learning signals, recent sessions visible)
- [ ] Confirm hooks can write to MEMORY without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)