### PR TITLE
fix: replace "Task" with "Agent" in settings allow list and hook matcher

### DIFF
--- a/Releases/v4.0.2/.claude/PAI/Algorithm/v3.5.0.md
+++ b/Releases/v4.0.2/.claude/PAI/Algorithm/v3.5.0.md
@@ -33,7 +33,7 @@ curl -s -X POST http://localhost:8888/notify \
 
 These are direct, synchronous calls. Do not send to background. The voice notification is part of the phase transition ritual.
 
-**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Task tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
+**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Agent tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
 
 ### PRD as System of Record
 

--- a/Releases/v4.0.2/.claude/PAI/THEHOOKSYSTEM.md
+++ b/Releases/v4.0.2/.claude/PAI/THEHOOKSYSTEM.md
@@ -267,7 +267,7 @@ Each Stop hook is a self-contained `.hook.ts` file that reads stdin via shared `
       ]
     },
     {
-      "matcher": "Task",
+      "matcher": "Agent",
       "hooks": [
         { "type": "command", "command": "${PAI_DIR}/hooks/AgentExecutionGuard.hook.ts" }
       ]

--- a/Releases/v4.0.2/.claude/hooks/AgentExecutionGuard.hook.ts
+++ b/Releases/v4.0.2/.claude/hooks/AgentExecutionGuard.hook.ts
@@ -4,7 +4,7 @@
  *
  * PURPOSE:
  * Structural enforcement for the Algorithm's background execution rule.
- * When the Task tool is called without run_in_background: true and the
+ * When the Agent tool is called without run_in_background: true and the
  * timing context is not "fast", injects a warning system-reminder.
  *
  * TRIGGER: PreToolUse (matcher: Agent)
@@ -88,7 +88,7 @@ async function main() {
 WARNING: FOREGROUND AGENT DETECTED — "${desc}" (${agentType})
 run_in_background is NOT set to true. This will BLOCK the user interface.
 
-FIX: Add run_in_background: true to this Task call.
+FIX: Add run_in_background: true to this Agent call.
 
 The Algorithm requires ALL non-fast agents to run in background:
 - Spawn with run_in_background: true

--- a/Releases/v4.0.2/.claude/hooks/AgentExecutionGuard.hook.ts
+++ b/Releases/v4.0.2/.claude/hooks/AgentExecutionGuard.hook.ts
@@ -7,7 +7,7 @@
  * When the Task tool is called without run_in_background: true and the
  * timing context is not "fast", injects a warning system-reminder.
  *
- * TRIGGER: PreToolUse (matcher: Task)
+ * TRIGGER: PreToolUse (matcher: Agent)
  *
  * DECISION LOGIC:
  * - run_in_background: true → PASS (correct usage)

--- a/Releases/v4.0.2/.claude/settings.json
+++ b/Releases/v4.0.2/.claude/settings.json
@@ -24,7 +24,7 @@
       "NotebookEdit",
       "TodoWrite",
       "ExitPlanMode",
-      "Task",
+      "Agent",
       "Skill",
       "mcp__*"
     ],

--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.5.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.5.0.md
@@ -33,7 +33,7 @@ curl -s -X POST http://localhost:8888/notify \
 
 These are direct, synchronous calls. Do not send to background. The voice notification is part of the phase transition ritual.
 
-**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Task tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
+**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Agent tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
 
 ### PRD as System of Record
 

--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
@@ -33,7 +33,7 @@ curl -s -X POST http://localhost:8888/notify \
 
 These are direct, synchronous calls. Do not send to background. The voice notification is part of the phase transition ritual.
 
-**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Task tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
+**CRITICAL: Only the primary agent may execute voice curls.** Background agents, subagents, and teammates spawned via the Agent tool must NEVER make voice curl calls. Voice is exclusively for the main conversation agent. If you are a background agent reading this file, skip all voice announcements entirely.
 
 ### PRD as System of Record
 

--- a/Releases/v4.0.3/.claude/PAI/THEHOOKSYSTEM.md
+++ b/Releases/v4.0.3/.claude/PAI/THEHOOKSYSTEM.md
@@ -267,7 +267,7 @@ Each Stop hook is a self-contained `.hook.ts` file that reads stdin via shared `
       ]
     },
     {
-      "matcher": "Task",
+      "matcher": "Agent",
       "hooks": [
         { "type": "command", "command": "${PAI_DIR}/hooks/AgentExecutionGuard.hook.ts" }
       ]

--- a/Releases/v4.0.3/.claude/hooks/AgentExecutionGuard.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/AgentExecutionGuard.hook.ts
@@ -4,7 +4,7 @@
  *
  * PURPOSE:
  * Structural enforcement for the Algorithm's background execution rule.
- * When the Task tool is called without run_in_background: true and the
+ * When the Agent tool is called without run_in_background: true and the
  * timing context is not "fast", injects a warning system-reminder.
  *
  * TRIGGER: PreToolUse (matcher: Agent)
@@ -88,7 +88,7 @@ async function main() {
 WARNING: FOREGROUND AGENT DETECTED — "${desc}" (${agentType})
 run_in_background is NOT set to true. This will BLOCK the user interface.
 
-FIX: Add run_in_background: true to this Task call.
+FIX: Add run_in_background: true to this Agent call.
 
 The Algorithm requires ALL non-fast agents to run in background:
 - Spawn with run_in_background: true

--- a/Releases/v4.0.3/.claude/hooks/AgentExecutionGuard.hook.ts
+++ b/Releases/v4.0.3/.claude/hooks/AgentExecutionGuard.hook.ts
@@ -7,7 +7,7 @@
  * When the Task tool is called without run_in_background: true and the
  * timing context is not "fast", injects a warning system-reminder.
  *
- * TRIGGER: PreToolUse (matcher: Task)
+ * TRIGGER: PreToolUse (matcher: Agent)
  *
  * DECISION LOGIC:
  * - run_in_background: true → PASS (correct usage)

--- a/Releases/v4.0.3/.claude/settings.json
+++ b/Releases/v4.0.3/.claude/settings.json
@@ -24,7 +24,7 @@
       "NotebookEdit",
       "TodoWrite",
       "ExitPlanMode",
-      "Task",
+      "Agent",
       "Skill",
       "mcp__*"
     ],


### PR DESCRIPTION
## Summary

- The Claude Code tool for spawning subagents is named `Agent`, not `Task`
- `settings.json` allows `"Task"` in the permissions allow list — should be `"Agent"`
- `settings.json` hooks matcher is `"Task"` — should be `"Agent"`
- `AgentExecutionGuard.hook.ts` comment says `matcher: Task` — updated to match
- `PAI/THEHOOKSYSTEM.md` example config shows `"matcher": "Task"` — updated

Applied to both v4.0.2 and v4.0.3.

Closes #969

## Test plan

- [ ] After installing v4.0.3, spawn a subagent — should pass through without manual approval prompt
- [ ] AgentExecutionGuard fires correctly when `run_in_background` is missing