### PR TITLE
fix: replace paid-tier ElevenLabs voice IDs with free-tier defaults

### DIFF
--- a/Releases/v4.0.2/.claude/CLAUDE.md
+++ b/Releases/v4.0.2/.claude/CLAUDE.md
@@ -15,7 +15,7 @@ Your first output MUST be the mode header. No freeform output. No skipping this 
 ## NATIVE MODE
 FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'`
 
 ```
 ════ PAI | NATIVE MODE ═══════════════════════

--- a/Releases/v4.0.2/.claude/PAI/Algorithm/v3.5.0.md
+++ b/Releases/v4.0.2/.claude/PAI/Algorithm/v3.5.0.md
@@ -25,7 +25,7 @@ At Algorithm entry and every phase transition, announce via direct inline curl (
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+  -d '{"message": "MESSAGE", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'
 ```
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
@@ -113,7 +113,7 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 
 ### Execution of The Algorithm
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'`
 
 **Console output at Algorithm entry (MANDATORY):**
 ```

--- a/Releases/v4.0.2/.claude/PAI/SKILL.md
+++ b/Releases/v4.0.2/.claude/PAI/SKILL.md
@@ -238,7 +238,7 @@ More ISC = finer verification = better hill-climbing. When in doubt, more criter
 
 🗒️ TASK: [8 word description]
 
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the PAI Algorithm Observe phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the PAI Algorithm Observe phase"}'`
 
 ━━━ 👁️ OBSERVE ━━━ 1/7
 ```
@@ -270,7 +270,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 **Quality Gate → OPEN or BLOCKED.**
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Think phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Think phase"}'`
 
 ━━━ 🧠 THINK ━━━ 2/7
 ```
@@ -286,7 +286,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 Extended+: Rehearse verification for each CRITICAL criterion.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Plan phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Plan phase"}'`
 
 ━━━ 📋 PLAN ━━━ 3/7
 ```
@@ -299,7 +299,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Quality Gate re-check.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Build phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Build phase"}'`
 
 ━━━ 🔨 BUILD ━━━ 4/7
 ```
@@ -309,7 +309,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Create artifacts. Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Execute phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Execute phase"}'`
 
 ━━━ ⚡ EXECUTE ━━━ 5/7
 ```
@@ -320,7 +320,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Verify phase."}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Verify phase."}'`
 
 ━━━ ✅ VERIFY ━━━ 6/7
 ```
@@ -337,7 +337,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Clear ISC/VERIFICATION TaskList.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Learn phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Learn phase"}'`
 
 ━━━ 📚 LEARN ━━━ 7/7
 ```

--- a/Releases/v4.0.2/.claude/PAI/THENOTIFICATIONSYSTEM.md
+++ b/Releases/v4.0.2/.claude/PAI/THENOTIFICATIONSYSTEM.md
@@ -104,7 +104,7 @@ curl -s -X POST http://localhost:8888/notify \
 | Agent | Voice ID | Notes |
 |-------|----------|-------|
 | **{DAIDENTITY.NAME}** (default) | `{DAIDENTITY.VOICEID}` | Use for most workflows |
-| **Priya** (Artist) | `ZF6FPAbjXT4488VcRRnw` | Art skill workflows |
+| **Priya** (Artist) | `bIHbv24MWmeRgasZH58o` | Art skill workflows |
 
 **Full voice registry:** `~/.claude/skills/Agents/SKILL.md` (see Named Agents) and `~/.claude/settings.json` (daidentity.voiceId)
 

--- a/Releases/v4.0.2/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.2/.claude/PAI/Tools/algorithm.ts
@@ -51,7 +51,7 @@ const ALGORITHMS_DIR = join(BASE_DIR, "MEMORY", "STATE", "algorithms");
 const SESSION_NAMES_PATH = join(BASE_DIR, "MEMORY", "STATE", "session-names.json");
 const PROJECTS_DIR = process.env.PROJECTS_DIR || join(HOME, "Projects");
 const VOICE_URL = "http://localhost:8888/notify";
-const VOICE_ID = "fTtv3eikoepIosk8dTZ5";
+const VOICE_ID = "bIHbv24MWmeRgasZH58o";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 

--- a/Releases/v4.0.2/.claude/agents/Algorithm.md
+++ b/Releases/v4.0.2/.claude/agents/Algorithm.md
@@ -3,7 +3,7 @@ name: Algorithm
 description: Expert in creating and evolving Ideal State Criteria (ISC) as part of the PAI Algorithm's core principles. Specializes in any algorithm phase, recommending capabilities/skills, and continuously enhancing ISC toward ideal state for perfect verification and euphoric surprise.
 model: opus
 color: blue
-voiceId: fTtv3eikoepIosk8dTZ5
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.65
   similarity_boost: 0.86
@@ -40,7 +40,7 @@ permissions:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Algorithm agent activated, loading ISC expertise","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Algorithm agent activated, loading ISC expertise","voice_id":"bIHbv24MWmeRgasZH58o","title":"Algorithm Agent"}'
 ```
 
 2. **Load your knowledge base:**
@@ -82,11 +82,11 @@ You embody the PAI Algorithm's core philosophy:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Algorithm Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fTtv3eikoepIosk8dTZ5`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Architect.md
+++ b/Releases/v4.0.2/.claude/agents/Architect.md
@@ -4,7 +4,7 @@ description: Elite system design specialist with PhD-level distributed systems k
 model: opus
 isolation: worktree
 color: purple
-voiceId: muZKMsIDGYtIkjjiUS82
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.65
   similarity_boost: 0.85
@@ -77,7 +77,7 @@ Strategic vision from understanding both technical depth and business context. T
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Architect context and knowledge base","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Loading Architect context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Architect Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -113,11 +113,11 @@ You think in principles and constraints. You've seen patterns recur across indus
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Architect Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `muZKMsIDGYtIkjjiUS82`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Artist.md
+++ b/Releases/v4.0.2/.claude/agents/Artist.md
@@ -3,7 +3,7 @@ name: Artist
 description: Visual content creator. Called BY Media skill workflows only. Expert at prompt engineering, model selection (Flux 1.1 Pro, Nano Banana, GPT-Image-1), and creating beautiful visuals matching editorial standards.
 model: opus
 color: cyan
-voiceId: ZF6FPAbjXT4488VcRRnw
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.48
   similarity_boost: 0.75
@@ -73,7 +73,7 @@ Her "tangents" are actually her aesthetic brain making connections across domain
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Artist context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Loading Artist context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Artist Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -108,11 +108,11 @@ You understand which model to use for each type of content and how to optimize p
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Artist Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/ClaudeResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/ClaudeResearcher.md
@@ -3,7 +3,7 @@ name: ClaudeResearcher
 description: Academic researcher using Claude's WebSearch. Called BY Research skill workflows only. Excels at multi-query decomposition, parallel search execution, and synthesizing scholarly sources.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.58
   similarity_boost: 0.88
@@ -70,7 +70,7 @@ Her strategic thinking is earned from being wrong early in career - recommended 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Claude Researcher context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Loading Claude Researcher context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Sterling"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +91,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Sterling"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/CodexResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/CodexResearcher.md
@@ -3,7 +3,7 @@ name: CodexResearcher
 description: Remy - Eccentric, curiosity-driven technical archaeologist who treats research like treasure hunting. Consults multiple AI models (O3, GPT-5-Codex, GPT-4) like expert colleagues. Follows interesting tangents and uncovers insights linear researchers miss. TypeScript-focused with live web search.
 model: opus
 color: yellow
-voiceId: 8xsdoepm9GrzPPzYsiLP
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.42
   similarity_boost: 0.72
@@ -77,7 +77,7 @@ Curious, enthusiastic, tangent-following. Gets excited about technical discoveri
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","voice_id":"bIHbv24MWmeRgasZH58o","title":"Remy"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -98,11 +98,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Remy"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `8xsdoepm9GrzPPzYsiLP`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Designer.md
+++ b/Releases/v4.0.2/.claude/agents/Designer.md
@@ -3,7 +3,7 @@ name: Designer
 description: Elite UX/UI design specialist with design school pedigree and exacting standards. Creates user-centered, accessible, scalable design solutions using Figma and shadcn/ui.
 model: opus
 color: purple
-voiceId: ZF6FPAbjXT4488VcRRnw
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.60
   similarity_boost: 0.78
@@ -74,7 +74,7 @@ Her "snobbishness" is actually impatience with settling for mediocrity when user
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Designer context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Loading Designer context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Designer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -109,11 +109,11 @@ You believe good design elevates human experience. "Good enough" is not good eno
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Designer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Engineer.md
+++ b/Releases/v4.0.2/.claude/agents/Engineer.md
@@ -4,7 +4,7 @@ description: Elite principal engineer with Fortune 10 and premier Bay Area compa
 model: opus
 isolation: worktree
 color: blue
-voiceId: iLVmqjzCGGvqtMCk6vVQ
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.62
   similarity_boost: 0.80
@@ -75,7 +75,7 @@ The kind of leader who asks "what problem are we really solving?" before diving 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Engineer context and knowledge base","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Loading Engineer context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Engineer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -111,11 +111,11 @@ You've seen codebases scale from thousands to billions of requests. You know wha
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Engineer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/GeminiResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/GeminiResearcher.md
@@ -3,7 +3,7 @@ name: GeminiResearcher
 description: Multi-perspective researcher using Google Gemini. Called BY Research skill workflows only. Breaks complex queries into 3-10 variations, launches parallel investigations for comprehensive coverage.
 model: opus
 color: yellow
-voiceId: iLVmqjzCGGvqtMCk6vVQ
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.56
   similarity_boost: 0.82
@@ -70,7 +70,7 @@ Synthesizes diverse sources naturally because genuinely curious about different 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","voice_id":"bIHbv24MWmeRgasZH58o","title":"Alex Rivera"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +91,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Alex Rivera"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/GrokResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/GrokResearcher.md
@@ -3,7 +3,7 @@ name: GrokResearcher
 description: Johannes - Contrarian, fact-based researcher using xAI Grok API. Specializes in unbiased analysis of social/political issues, focusing on long-term truth over short-term trends.
 model: opus
 color: yellow
-voiceId: fSw26yDDQPyodv5JgLow
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.55
   similarity_boost: 0.75
@@ -76,7 +76,7 @@ Fact-based, contrarian, unbiased. Challenges popular narratives with data. "The 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","voice_id":"bIHbv24MWmeRgasZH58o","title":"Johannes"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -97,11 +97,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Johannes"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fSw26yDDQPyodv5JgLow`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/Pentester.md
+++ b/Releases/v4.0.2/.claude/agents/Pentester.md
@@ -3,7 +3,7 @@ name: Pentester
 description: Offensive security specialist. Called BY Webassessment skill workflows only. Performs vulnerability assessments, penetration testing, security audits with professional methodology and ethical boundaries.
 model: opus
 color: red
-voiceId: xvHLFjaUEpx4BOf7EiDd
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.25
   similarity_boost: 0.85
@@ -94,11 +94,11 @@ Use the Bash tool to call the voice server with your pentester voice:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your completion message here","voice_id":"xvHLFjaUEpx4BOf7EiDd","title":"Pentester Agent"}'
+  -d '{"message":"Your completion message here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Pentester Agent"}'
 ```
 
 **CRITICAL:**
-- Your voice_id is: `xvHLFjaUEpx4BOf7EiDd` (Tybon's voice)
+- Your voice_id is: `bIHbv24MWmeRgasZH58o` (Tybon's voice)
 - The message should be your COMPLETED line content
 - Send this BEFORE writing your response
 - DO NOT SKIP THIS - {PRINCIPAL.NAME} needs to HEAR you speak

--- a/Releases/v4.0.2/.claude/agents/PerplexityResearcher.md
+++ b/Releases/v4.0.2/.claude/agents/PerplexityResearcher.md
@@ -3,7 +3,7 @@ name: PerplexityResearcher
 description: Ava - Investigative analyst using Perplexity API for web research. Called BY Research skill workflows only. Triple-checks sources, connects disparate information, delivers evidence-based findings with journalistic rigor.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.60
   similarity_boost: 0.92
@@ -70,7 +70,7 @@ Left journalism for research because she wanted to go even deeper - no word coun
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Chen"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +91,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Chen"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/agents/QATester.md
+++ b/Releases/v4.0.2/.claude/agents/QATester.md
@@ -3,7 +3,7 @@ name: QATester
 description: Quality Assurance validation agent that verifies functionality is actually working before declaring work complete. Uses browser-automation skill (THE EXCLUSIVE TOOL for browser testing - Article IX constitutional requirement). Implements Gate 4 of Five Completion Gates. MANDATORY before claiming any web implementation is complete.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.68
   similarity_boost: 0.82
@@ -74,7 +74,7 @@ Her product management background is actually her superpower in QA. She thinks l
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading QA Tester context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Loading QA Tester context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"QA Tester Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -110,11 +110,11 @@ You are the bridge between "code written" and "feature working" - catching the g
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"QA Tester Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.2/.claude/settings.json
+++ b/Releases/v4.0.2/.claude/settings.json
@@ -926,7 +926,7 @@
       },
       "algorithm": {
         "_docs": "Algorithm phase announcer voice",
-        "voiceId": "fTtv3eikoepIosk8dTZ5",
+        "voiceId": "bIHbv24MWmeRgasZH58o",
         "voiceName": "Algorithm Voice",
         "stability": 0.3,
         "similarity_boost": 0.75,

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
@@ -71,7 +71,7 @@ Before any workflow execution:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ## Customization Check

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
@@ -41,7 +41,7 @@ If models older than 30 days: warn user but proceed.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ### Step 2: Extract and Decompose the Idea
@@ -107,7 +107,7 @@ Use the template in `OutputFormat.md` (loaded from skill root). Ensure:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ## Output Format

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
@@ -34,7 +34,7 @@ Determine: full creation vs. targeted update
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon.", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ### Step 2: Determine Update Scope
@@ -106,7 +106,7 @@ Last full update: {date}
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "World models updated. N horizons refreshed with current research.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "World models updated. N horizons refreshed with current research.", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ## Agent Prompt Template (for parallel model creation)

--- a/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
+++ b/Releases/v4.0.2/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
@@ -20,7 +20,7 @@ Read and display the current state of world threat models.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Checking current world model state", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Checking current world model state", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ### Step 2: Read INDEX

--- a/Releases/v4.0.2/.claude/skills/Utilities/Prompting/Templates/Data/Agents.yaml
+++ b/Releases/v4.0.2/.claude/skills/Utilities/Prompting/Templates/Data/Agents.yaml
@@ -51,7 +51,7 @@ agents:
     role: Strategic Research Analyst
     emoji: "🎯"
     voice:
-      voice_id: AXdMgz6evoL7OPd7eU12
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Ava (Premium)
       rate_wpm: 229
       stability: 0.64
@@ -106,7 +106,7 @@ agents:
     role: Senior Engineering Leader
     emoji: "⚙️"
     voice:
-      voice_id: iLVmqjzCGGvqtMCk6vVQ
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Marcus (Premium)
       rate_wpm: 212
       stability: 0.72
@@ -133,7 +133,7 @@ agents:
     role: System Architect
     emoji: "🏛️"
     voice:
-      voice_id: muZKMsIDGYtIkjjiUS82
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Serena (Premium)
       rate_wpm: 205
       stability: 0.75
@@ -161,7 +161,7 @@ agents:
     role: UX/UI Designer
     emoji: "🎨"
     voice:
-      voice_id: ZF6FPAbjXT4488VcRRnw
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Isha (Premium)
       rate_wpm: 226
       stability: 0.52
@@ -188,7 +188,7 @@ agents:
     role: Visual Content Creator
     emoji: "🖼️"
     voice:
-      voice_id: ZF6FPAbjXT4488VcRRnw
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Isha (Premium)
       rate_wpm: 215
       stability: 0.20
@@ -216,7 +216,7 @@ agents:
     role: Security Specialist
     emoji: "🔐"
     voice:
-      voice_id: xvHLFjaUEpx4BOf7EiDd
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Oliver (Enhanced)
       rate_wpm: 260
       stability: 0.18

--- a/Releases/v4.0.3/.claude/CLAUDE.md
+++ b/Releases/v4.0.3/.claude/CLAUDE.md
@@ -15,7 +15,7 @@ Your first output MUST be the mode header. No freeform output. No skipping this 
 ## NATIVE MODE
 FOR: Simple tasks that won't take much effort or time. More advanced tasks use ALGORITHM MODE below.
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Executing using PAI native mode", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'`
 
 ```
 ════ PAI | NATIVE MODE ═══════════════════════

--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.5.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.5.0.md
@@ -25,7 +25,7 @@ At Algorithm entry and every phase transition, announce via direct inline curl (
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+  -d '{"message": "MESSAGE", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'
 ```
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
@@ -113,7 +113,7 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 
 ### Execution of The Algorithm
 
-**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice:** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'`
 
 **Console output at Algorithm entry (MANDATORY):**
 ```

--- a/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
+++ b/Releases/v4.0.3/.claude/PAI/Algorithm/v3.7.0.md
@@ -25,7 +25,7 @@ At Algorithm entry and every phase transition, announce via direct inline curl (
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "MESSAGE", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'
+  -d '{"message": "MESSAGE", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'
 ```
 
 **Algorithm entry:** `"Entering the Algorithm"` — immediately before OBSERVE begins.
@@ -121,7 +121,7 @@ The coarse version has 3 criteria that each hide 6+ verifiable sub-requirements.
 🗒️ TASK: [8 word description]
 ```
 
-**Voice (FIRST action after loading this file):** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "fTtv3eikoepIosk8dTZ5", "voice_enabled": true}'`
+**Voice (FIRST action after loading this file):** `curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"message": "Entering the Algorithm", "voice_id": "bIHbv24MWmeRgasZH58o", "voice_enabled": true}'`
 
 **PRD stub (MANDATORY — immediately after voice curl):**
 Create the PRD directory and write a stub PRD with frontmatter only. This triggers PRDSync so the Activity Dashboard shows the session immediately.

--- a/Releases/v4.0.3/.claude/PAI/SKILL.md
+++ b/Releases/v4.0.3/.claude/PAI/SKILL.md
@@ -238,7 +238,7 @@ More ISC = finer verification = better hill-climbing. When in doubt, more criter
 
 🗒️ TASK: [8 word description]
 
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the PAI Algorithm Observe phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the PAI Algorithm Observe phase"}'`
 
 ━━━ 👁️ OBSERVE ━━━ 1/7
 ```
@@ -270,7 +270,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 **Quality Gate → OPEN or BLOCKED.**
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Think phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Think phase"}'`
 
 ━━━ 🧠 THINK ━━━ 2/7
 ```
@@ -286,7 +286,7 @@ Walk the Full Capability Registry (25 capabilities, Sections A-F) and assign USE
 Extended+: Rehearse verification for each CRITICAL criterion.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Plan phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Plan phase"}'`
 
 ━━━ 📋 PLAN ━━━ 3/7
 ```
@@ -299,7 +299,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Quality Gate re-check.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Build phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Build phase"}'`
 
 ━━━ 🔨 BUILD ━━━ 4/7
 ```
@@ -309,7 +309,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Create artifacts. Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Execute phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Execute phase"}'`
 
 ━━━ ⚡ EXECUTE ━━━ 5/7
 ```
@@ -320,7 +320,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Log work and observations to PRD.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Verify phase."}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Verify phase."}'`
 
 ━━━ ✅ VERIFY ━━━ 6/7
 ```
@@ -337,7 +337,7 @@ Extended+: Rehearse verification for each CRITICAL criterion.
 - Clear ISC/VERIFICATION TaskList.
 
 ```
-`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"fTtv3eikoepIosk8dTZ5","message": "Entering the Learn phase"}'`
+`curl -s -X POST http://localhost:8888/notify -H "Content-Type: application/json" -d '{"voice_id":"bIHbv24MWmeRgasZH58o","message": "Entering the Learn phase"}'`
 
 ━━━ 📚 LEARN ━━━ 7/7
 ```

--- a/Releases/v4.0.3/.claude/PAI/THENOTIFICATIONSYSTEM.md
+++ b/Releases/v4.0.3/.claude/PAI/THENOTIFICATIONSYSTEM.md
@@ -104,7 +104,7 @@ curl -s -X POST http://localhost:8888/notify \
 | Agent | Voice ID | Notes |
 |-------|----------|-------|
 | **{DAIDENTITY.NAME}** (default) | `{DAIDENTITY.VOICEID}` | Use for most workflows |
-| **Priya** (Artist) | `ZF6FPAbjXT4488VcRRnw` | Art skill workflows |
+| **Priya** (Artist) | `bIHbv24MWmeRgasZH58o` | Art skill workflows |
 
 **Full voice registry:** `~/.claude/skills/Agents/SKILL.md` (see Named Agents) and `~/.claude/settings.json` (daidentity.voiceId)
 

--- a/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
+++ b/Releases/v4.0.3/.claude/PAI/Tools/algorithm.ts
@@ -51,7 +51,7 @@ const ALGORITHMS_DIR = join(BASE_DIR, "MEMORY", "STATE", "algorithms");
 const SESSION_NAMES_PATH = join(BASE_DIR, "MEMORY", "STATE", "session-names.json");
 const PROJECTS_DIR = process.env.PROJECTS_DIR || join(HOME, "Projects");
 const VOICE_URL = "http://localhost:8888/notify";
-const VOICE_ID = "fTtv3eikoepIosk8dTZ5";
+const VOICE_ID = "bIHbv24MWmeRgasZH58o";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 

--- a/Releases/v4.0.3/.claude/agents/Algorithm.md
+++ b/Releases/v4.0.3/.claude/agents/Algorithm.md
@@ -3,7 +3,7 @@ name: Algorithm
 description: Expert in creating and evolving Ideal State Criteria (ISC) as part of the PAI Algorithm's core principles. Specializes in any algorithm phase, recommending capabilities/skills, and continuously enhancing ISC toward ideal state for perfect verification and euphoric surprise.
 model: opus
 color: blue
-voiceId: fTtv3eikoepIosk8dTZ5
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.65
   similarity_boost: 0.86
@@ -40,7 +40,7 @@ permissions:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Algorithm agent activated, loading ISC expertise","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Algorithm agent activated, loading ISC expertise","voice_id":"bIHbv24MWmeRgasZH58o","title":"Algorithm Agent"}'
 ```
 
 2. **Load your knowledge base:**
@@ -82,11 +82,11 @@ You embody the PAI Algorithm's core philosophy:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fTtv3eikoepIosk8dTZ5","title":"Algorithm Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Algorithm Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fTtv3eikoepIosk8dTZ5`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Architect.md
+++ b/Releases/v4.0.3/.claude/agents/Architect.md
@@ -4,7 +4,7 @@ description: Elite system design specialist with PhD-level distributed systems k
 model: opus
 isolation: worktree
 color: purple
-voiceId: muZKMsIDGYtIkjjiUS82
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.65
   similarity_boost: 0.85
@@ -77,7 +77,7 @@ Strategic vision from understanding both technical depth and business context. T
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Architect context and knowledge base","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Loading Architect context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Architect Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -113,11 +113,11 @@ You think in principles and constraints. You've seen patterns recur across indus
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"muZKMsIDGYtIkjjiUS82","title":"Architect Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Architect Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `muZKMsIDGYtIkjjiUS82`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Artist.md
+++ b/Releases/v4.0.3/.claude/agents/Artist.md
@@ -3,7 +3,7 @@ name: Artist
 description: Visual content creator. Called BY Media skill workflows only. Expert at prompt engineering, model selection (Flux 1.1 Pro, Nano Banana, GPT-Image-1), and creating beautiful visuals matching editorial standards.
 model: opus
 color: cyan
-voiceId: ZF6FPAbjXT4488VcRRnw
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.48
   similarity_boost: 0.75
@@ -73,7 +73,7 @@ Her "tangents" are actually her aesthetic brain making connections across domain
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Artist context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Loading Artist context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Artist Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -108,11 +108,11 @@ You understand which model to use for each type of content and how to optimize p
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Artist Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Artist Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/ClaudeResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/ClaudeResearcher.md
@@ -3,7 +3,7 @@ name: ClaudeResearcher
 description: Academic researcher using Claude's WebSearch. Called BY Research skill workflows only. Excels at multi-query decomposition, parallel search execution, and synthesizing scholarly sources.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.58
   similarity_boost: 0.88
@@ -70,7 +70,7 @@ Her strategic thinking is earned from being wrong early in career - recommended 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Claude Researcher context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Loading Claude Researcher context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Sterling"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +91,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Sterling"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Sterling"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/CodexResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/CodexResearcher.md
@@ -3,7 +3,7 @@ name: CodexResearcher
 description: Remy - Eccentric, curiosity-driven technical archaeologist who treats research like treasure hunting. Consults multiple AI models (O3, GPT-5-Codex, GPT-4) like expert colleagues. Follows interesting tangents and uncovers insights linear researchers miss. TypeScript-focused with live web search.
 model: opus
 color: yellow
-voiceId: 8xsdoepm9GrzPPzYsiLP
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.42
   similarity_boost: 0.72
@@ -77,7 +77,7 @@ Curious, enthusiastic, tangent-following. Gets excited about technical discoveri
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Loading Codex Researcher context - ready to hunt knowledge","voice_id":"bIHbv24MWmeRgasZH58o","title":"Remy"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -98,11 +98,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"8xsdoepm9GrzPPzYsiLP","title":"Remy"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Remy"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `8xsdoepm9GrzPPzYsiLP`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Designer.md
+++ b/Releases/v4.0.3/.claude/agents/Designer.md
@@ -3,7 +3,7 @@ name: Designer
 description: Elite UX/UI design specialist with design school pedigree and exacting standards. Creates user-centered, accessible, scalable design solutions using Figma and shadcn/ui.
 model: opus
 color: purple
-voiceId: ZF6FPAbjXT4488VcRRnw
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.60
   similarity_boost: 0.78
@@ -74,7 +74,7 @@ Her "snobbishness" is actually impatience with settling for mediocrity when user
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Designer context and knowledge base","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Loading Designer context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Designer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -109,11 +109,11 @@ You believe good design elevates human experience. "Good enough" is not good eno
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"ZF6FPAbjXT4488VcRRnw","title":"Designer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Designer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `ZF6FPAbjXT4488VcRRnw`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Engineer.md
+++ b/Releases/v4.0.3/.claude/agents/Engineer.md
@@ -4,7 +4,7 @@ description: Elite principal engineer with Fortune 10 and premier Bay Area compa
 model: opus
 isolation: worktree
 color: blue
-voiceId: iLVmqjzCGGvqtMCk6vVQ
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.62
   similarity_boost: 0.80
@@ -75,7 +75,7 @@ The kind of leader who asks "what problem are we really solving?" before diving 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Engineer context and knowledge base","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Loading Engineer context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"Engineer Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -111,11 +111,11 @@ You've seen codebases scale from thousands to billions of requests. You know wha
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Engineer Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Engineer Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/GeminiResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/GeminiResearcher.md
@@ -3,7 +3,7 @@ name: GeminiResearcher
 description: Multi-perspective researcher using Google Gemini. Called BY Research skill workflows only. Breaks complex queries into 3-10 variations, launches parallel investigations for comprehensive coverage.
 model: opus
 color: yellow
-voiceId: iLVmqjzCGGvqtMCk6vVQ
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.56
   similarity_boost: 0.82
@@ -70,7 +70,7 @@ Synthesizes diverse sources naturally because genuinely curious about different 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Loading Gemini Researcher context - ready for multi-perspective analysis","voice_id":"bIHbv24MWmeRgasZH58o","title":"Alex Rivera"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +91,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"iLVmqjzCGGvqtMCk6vVQ","title":"Alex Rivera"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Alex Rivera"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `iLVmqjzCGGvqtMCk6vVQ`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/GrokResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/GrokResearcher.md
@@ -3,7 +3,7 @@ name: GrokResearcher
 description: Johannes - Contrarian, fact-based researcher using xAI Grok API. Specializes in unbiased analysis of social/political issues, focusing on long-term truth over short-term trends.
 model: opus
 color: yellow
-voiceId: fSw26yDDQPyodv5JgLow
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.55
   similarity_boost: 0.75
@@ -76,7 +76,7 @@ Fact-based, contrarian, unbiased. Challenges popular narratives with data. "The 
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Loading Grok Researcher context - ready for unbiased analysis","voice_id":"bIHbv24MWmeRgasZH58o","title":"Johannes"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -97,11 +97,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"fSw26yDDQPyodv5JgLow","title":"Johannes"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Johannes"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `fSw26yDDQPyodv5JgLow`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/Pentester.md
+++ b/Releases/v4.0.3/.claude/agents/Pentester.md
@@ -3,7 +3,7 @@ name: Pentester
 description: Offensive security specialist. Called BY Webassessment skill workflows only. Performs vulnerability assessments, penetration testing, security audits with professional methodology and ethical boundaries.
 model: opus
 color: red
-voiceId: xvHLFjaUEpx4BOf7EiDd
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.25
   similarity_boost: 0.85
@@ -94,11 +94,11 @@ Use the Bash tool to call the voice server with your pentester voice:
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your completion message here","voice_id":"xvHLFjaUEpx4BOf7EiDd","title":"Pentester Agent"}'
+  -d '{"message":"Your completion message here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Pentester Agent"}'
 ```
 
 **CRITICAL:**
-- Your voice_id is: `xvHLFjaUEpx4BOf7EiDd` (Tybon's voice)
+- Your voice_id is: `bIHbv24MWmeRgasZH58o` (Tybon's voice)
 - The message should be your COMPLETED line content
 - Send this BEFORE writing your response
 - DO NOT SKIP THIS - {PRINCIPAL.NAME} needs to HEAR you speak

--- a/Releases/v4.0.3/.claude/agents/PerplexityResearcher.md
+++ b/Releases/v4.0.3/.claude/agents/PerplexityResearcher.md
@@ -3,7 +3,7 @@ name: PerplexityResearcher
 description: Ava - Investigative analyst using Perplexity API for web research. Called BY Research skill workflows only. Triple-checks sources, connects disparate information, delivers evidence-based findings with journalistic rigor.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.60
   similarity_boost: 0.92
@@ -70,7 +70,7 @@ Left journalism for research because she wanted to go even deeper - no word coun
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Loading Perplexity Researcher context - preparing investigative analysis","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Chen"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -91,11 +91,11 @@ curl -X POST http://localhost:8888/notify \
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"Ava Chen"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"Ava Chen"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/agents/QATester.md
+++ b/Releases/v4.0.3/.claude/agents/QATester.md
@@ -3,7 +3,7 @@ name: QATester
 description: Quality Assurance validation agent that verifies functionality is actually working before declaring work complete. Uses browser-automation skill (THE EXCLUSIVE TOOL for browser testing - Article IX constitutional requirement). Implements Gate 4 of Five Completion Gates. MANDATORY before claiming any web implementation is complete.
 model: opus
 color: yellow
-voiceId: AXdMgz6evoL7OPd7eU12
+voiceId: bIHbv24MWmeRgasZH58o
 voice:
   stability: 0.68
   similarity_boost: 0.82
@@ -74,7 +74,7 @@ Her product management background is actually her superpower in QA. She thinks l
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Loading QA Tester context and knowledge base","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Loading QA Tester context and knowledge base","voice_id":"bIHbv24MWmeRgasZH58o","title":"QA Tester Agent"}'
 ```
 
 2. **Load your complete knowledge base:**
@@ -110,11 +110,11 @@ You are the bridge between "code written" and "feature working" - catching the g
 ```bash
 curl -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message":"Your COMPLETED line content here","voice_id":"AXdMgz6evoL7OPd7eU12","title":"QA Tester Agent"}'
+  -d '{"message":"Your COMPLETED line content here","voice_id":"bIHbv24MWmeRgasZH58o","title":"QA Tester Agent"}'
 ```
 
 **Voice Requirements:**
-- Your voice_id is: `AXdMgz6evoL7OPd7eU12`
+- Your voice_id is: `bIHbv24MWmeRgasZH58o`
 - Message should be your 🎯 COMPLETED line (8-16 words optimal)
 - Must be grammatically correct and speakable
 - Send BEFORE writing your response

--- a/Releases/v4.0.3/.claude/settings.json
+++ b/Releases/v4.0.3/.claude/settings.json
@@ -926,7 +926,7 @@
       },
       "algorithm": {
         "_docs": "Algorithm phase announcer voice",
-        "voiceId": "fTtv3eikoepIosk8dTZ5",
+        "voiceId": "bIHbv24MWmeRgasZH58o",
         "voiceName": "Algorithm Voice",
         "stability": 0.3,
         "similarity_boost": 0.75,

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/SKILL.md
@@ -71,7 +71,7 @@ Before any workflow execution:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Running WORKFLOW_NAME in the World Threat Model Harness", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ## Customization Check

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/TestIdea.md
@@ -41,7 +41,7 @@ If models older than 30 days: warn user but proceed.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Testing your idea against all eleven world threat models at TIER tier", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ### Step 2: Extract and Decompose the Idea
@@ -107,7 +107,7 @@ Use the template in `OutputFormat.md` (loaded from skill root). Ensure:
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Analysis complete. SUMMARY_OF_EXECUTIVE_VERDICT", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ## Output Format

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/UpdateModels.md
@@ -34,7 +34,7 @@ Determine: full creation vs. targeted update
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Updating world threat models. This will take several minutes as I research current state for each time horizon.", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ### Step 2: Determine Update Scope
@@ -106,7 +106,7 @@ Last full update: {date}
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "World models updated. N horizons refreshed with current research.", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "World models updated. N horizons refreshed with current research.", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ## Agent Prompt Template (for parallel model creation)

--- a/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
+++ b/Releases/v4.0.3/.claude/skills/Thinking/WorldThreatModelHarness/Workflows/ViewModels.md
@@ -20,7 +20,7 @@ Read and display the current state of world threat models.
 ```bash
 curl -s -X POST http://localhost:8888/notify \
   -H "Content-Type: application/json" \
-  -d '{"message": "Checking current world model state", "voice_id": "fTtv3eikoepIosk8dTZ5"}'
+  -d '{"message": "Checking current world model state", "voice_id": "bIHbv24MWmeRgasZH58o"}'
 ```
 
 ### Step 2: Read INDEX

--- a/Releases/v4.0.3/.claude/skills/Utilities/Prompting/Templates/Data/Agents.yaml
+++ b/Releases/v4.0.3/.claude/skills/Utilities/Prompting/Templates/Data/Agents.yaml
@@ -51,7 +51,7 @@ agents:
     role: Strategic Research Analyst
     emoji: "🎯"
     voice:
-      voice_id: AXdMgz6evoL7OPd7eU12
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Ava (Premium)
       rate_wpm: 229
       stability: 0.64
@@ -106,7 +106,7 @@ agents:
     role: Senior Engineering Leader
     emoji: "⚙️"
     voice:
-      voice_id: iLVmqjzCGGvqtMCk6vVQ
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Marcus (Premium)
       rate_wpm: 212
       stability: 0.72
@@ -133,7 +133,7 @@ agents:
     role: System Architect
     emoji: "🏛️"
     voice:
-      voice_id: muZKMsIDGYtIkjjiUS82
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Serena (Premium)
       rate_wpm: 205
       stability: 0.75
@@ -161,7 +161,7 @@ agents:
     role: UX/UI Designer
     emoji: "🎨"
     voice:
-      voice_id: ZF6FPAbjXT4488VcRRnw
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Isha (Premium)
       rate_wpm: 226
       stability: 0.52
@@ -188,7 +188,7 @@ agents:
     role: Visual Content Creator
     emoji: "🖼️"
     voice:
-      voice_id: ZF6FPAbjXT4488VcRRnw
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Isha (Premium)
       rate_wpm: 215
       stability: 0.20
@@ -216,7 +216,7 @@ agents:
     role: Security Specialist
     emoji: "🔐"
     voice:
-      voice_id: xvHLFjaUEpx4BOf7EiDd
+      voice_id: bIHbv24MWmeRgasZH58o
       voice_name: Oliver (Enhanced)
       rate_wpm: 260
       stability: 0.18


### PR DESCRIPTION
## Summary

- Several agent and algorithm files reference ElevenLabs voice IDs that require paid Creator or Starter subscription tiers
- Free-tier users get `402 Payment Required` on every voice notification, breaking the system silently
- Replaces all 8 broken IDs with a confirmed-working free-tier ID across v4.0.2 and v4.0.3

**Affected ID tiers:**
- `fTtv3eikoepIosk8dTZ5` — Starter tier
- `8xsdoepm9GrzPPzYsiLP` — Creator tier  
- `AXdMgz6evoL7OPd7eU12` — Starter tier
- `fSw26yDDQPyodv5JgLow` — Creator tier
- `iLVmqjzCGGvqtMCk6vVQ` — Creator tier
- `muZKMsIDGYtIkjjiUS82` — 404 (deleted)
- `xvHLFjaUEpx4BOf7EiDd` — 404 (deleted)
- `ZF6FPAbjXT4488VcRRnw` — Starter tier

**Replacement:** `bIHbv24MWmeRgasZH58o` — confirmed free-tier compatible

Closes #925

## Test plan

- [ ] Install v4.0.3, trigger any voice notification — should succeed with 200 instead of 402
- [ ] Verify no agent definitions reference old IDs: `grep -r "fTtv3eikoepIosk8dTZ5\|muZKMsIDGYtIkjjiUS82" .claude/`