### PR TITLE
docs(Packs): replace broken PAIPackTemplate.md link with structural description

### DIFF
--- a/Packs/README.md
+++ b/Packs/README.md
@@ -56,4 +56,4 @@ Or manually: read `INSTALL.md`, copy files from `src/` to the specified location
 
 ## Creating a Pack
 
-See [PAIPackTemplate.md](../Tools/PAIPackTemplate.md) for the full specification.
+Each pack is a self-contained directory under `Packs/` with its own `README.md` and `INSTALL.md`. See the existing packs above for reference structure.


### PR DESCRIPTION
## Summary

\`Packs/README.md\`'s \"Creating a Pack\" section linked to \`../Tools/PAIPackTemplate.md\`, which no longer exists, so the link 404s (confirmed by grep — the file isn't in the tree and grep finds no other template doc).

Replaced the dead link with a short structural description pointing contributors at the existing packs as reference. If a canonical spec doc is added back, the section can be re-pointed at it; happy to revise this PR if the template file is being restored.

Closes #1094

## Testing

Docs-only. Verified \`Tools/\` has no template file.